### PR TITLE
refactor: use readcontracts for xsushi bar data

### DIFF
--- a/apps/web/src/ui/stake/SushiBarProvider.tsx
+++ b/apps/web/src/ui/stake/SushiBarProvider.tsx
@@ -38,7 +38,6 @@ export const SushiBarProvider: FC<{
     data: balanceAndSupplyData,
     isLoading: isLoadingSushiBalanceData,
     isError: isErrorSushiBalanceData,
-    queryKey: balanceAndSupplyQueryKey,
   } = useReadContracts({
     allowFailure: false,
     contracts: [

--- a/apps/web/src/ui/stake/SushiBarProvider.tsx
+++ b/apps/web/src/ui/stake/SushiBarProvider.tsx
@@ -2,7 +2,6 @@
 
 import { FC, ReactNode, createContext, useContext, useMemo } from 'react'
 import { useBarData } from 'src/lib/stake'
-import { useWatchByInterval } from 'src/lib/wagmi/hooks/watch/useWatchByInterval'
 import { ChainId } from 'sushi/chain'
 import {
   Amount,
@@ -64,11 +63,9 @@ export const SushiBarProvider: FC<{
           Amount.fromRawAmount(XSUSHI[ChainId.ETHEREUM], data[1]),
         ] as const
       },
-      staleTime: 30000,
+      refetchInterval: 30000,
     },
   })
-
-  useWatchByInterval({ key: balanceAndSupplyQueryKey, interval: 30000 })
 
   return (
     <Context.Provider


### PR DESCRIPTION
**Notes:**

- The `staleTime` of the graphql query is 30 seconds. I used the same time for the contract data, and refresh it every 30 seconds.