### PR TITLE
feat (apps/web): Change the position of the "Hide closed" toggle in V3 positions table

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/positions/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/positions/page.tsx
@@ -2,10 +2,10 @@ import { V3Pool, getV3Pool } from '@sushiswap/graph-client/data-api'
 import { unstable_cache } from 'next/cache'
 import { notFound } from 'next/navigation'
 import { PoolsFiltersProvider } from 'src/ui/pool'
-import { ConcentratedPositionsTable } from 'src/ui/pool/ConcentratedPositionsTable'
 import { ChainId } from 'sushi/chain'
 import { isSushiSwapV3ChainId } from 'sushi/config'
 import { isAddress } from 'viem'
+import { ManageV3PoolPositionsTable } from './table'
 
 export default async function ManageV3PoolPage({
   params,
@@ -32,11 +32,7 @@ export default async function ManageV3PoolPage({
 
   return (
     <PoolsFiltersProvider>
-      <ConcentratedPositionsTable
-        chainId={pool.chainId}
-        poolAddress={pool.address}
-        hideNewSmartPositionButton={!pool.hasEnabledSteerVault}
-      />
+      <ManageV3PoolPositionsTable pool={pool} />
     </PoolsFiltersProvider>
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/positions/table.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/positions/table.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { V3Pool } from '@sushiswap/graph-client/data-api'
+import { Switch } from '@sushiswap/ui'
+import { useState } from 'react'
+import { ConcentratedPositionsTable } from 'src/ui/pool/ConcentratedPositionsTable'
+
+export function ManageV3PoolPositionsTable({
+  pool,
+}: {
+  pool: V3Pool
+}) {
+  const [hideClosed, setHideClosed] = useState(true)
+  return (
+    <ConcentratedPositionsTable
+      chainId={pool.chainId}
+      poolAddress={pool.address}
+      hideNewSmartPositionButton={!pool.hasEnabledSteerVault}
+      hideClosedPositions={hideClosed}
+      actions={
+        <div className="flex gap-3 items-center whitespace-nowrap">
+          <span className="text-sm font-medium text-gray-600 dark:text-slate-400">
+            Hide closed
+          </span>
+          <Switch
+            checked={hideClosed}
+            onCheckedChange={() => setHideClosed((prev) => !prev)}
+          />
+        </div>
+      }
+    />
+  )
+}

--- a/apps/web/src/ui/pool/ConcentratedPositionsTable/ConcentratedPositionsTable.tsx
+++ b/apps/web/src/ui/pool/ConcentratedPositionsTable/ConcentratedPositionsTable.tsx
@@ -8,7 +8,6 @@ import {
   CardTitle,
   DataTable,
   LinkInternal,
-  Switch,
 } from '@sushiswap/ui'
 import { Slot } from '@sushiswap/ui'
 import { ColumnDef, PaginationState, Row } from '@tanstack/react-table'
@@ -41,6 +40,8 @@ interface ConcentratedPositionsTableProps {
   onRowClick?(row: ConcentratedLiquidityPositionWithV3Pool): void
   hideNewSmartPositionButton?: boolean
   hideNewPositionButton?: boolean
+  hideClosedPositions?: boolean
+  actions?: ReactNode
 }
 
 export const ConcentratedPositionsTable: FC<ConcentratedPositionsTableProps> =
@@ -50,10 +51,11 @@ export const ConcentratedPositionsTable: FC<ConcentratedPositionsTableProps> =
     poolAddress,
     hideNewSmartPositionButton = true,
     hideNewPositionButton = false,
+    hideClosedPositions = true,
+    actions,
   }) => {
     const { address } = useAccount()
     const { tokenSymbols } = usePoolFilters()
-    const [hide, setHide] = useState(true)
 
     const chainIds = useMemo(() => {
       return isSushiSwapV3ChainId(chainId) ? [chainId] : []
@@ -85,13 +87,13 @@ export const ConcentratedPositionsTable: FC<ConcentratedPositionsTableProps> =
         )
         .filter((el) => {
           return (
-            (hide ? el.liquidity !== 0n : true) &&
+            (hideClosedPositions ? el.liquidity !== 0n : true) &&
             (poolAddress
               ? el.address.toLowerCase() === poolAddress.toLowerCase()
               : true)
           )
         })
-    }, [tokenSymbols, positions, hide, poolAddress])
+    }, [tokenSymbols, positions, hideClosedPositions, poolAddress])
 
     const rowRenderer = useCallback(
       (
@@ -123,15 +125,7 @@ export const ConcentratedPositionsTable: FC<ConcentratedPositionsTableProps> =
                   ({_positions.length})
                 </span>
               </span>
-              <div className="flex gap-3 items-center whitespace-nowrap">
-                <span className="text-sm font-medium text-gray-600 dark:text-slate-400">
-                  Hide closed
-                </span>
-                <Switch
-                  checked={hide}
-                  onCheckedChange={() => setHide((prev) => !prev)}
-                />
-              </div>
+              {actions}
               {!hideNewSmartPositionButton ? (
                 <LinkInternal
                   shallow={true}

--- a/apps/web/src/ui/pool/PositionsTab.tsx
+++ b/apps/web/src/ui/pool/PositionsTab.tsx
@@ -4,6 +4,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Switch,
   Tabs,
   TabsContent,
   TabsList,
@@ -59,7 +60,7 @@ export const PositionsTab: FC<{ chainId: SushiSwapChainId }> = ({
   chainId,
 }) => {
   const [tab, setTab] = useState('v3')
-
+  const [hideClosedPositions, setHideClosedPositions] = useState(true)
   return (
     <div className="flex flex-col gap-4">
       <Tabs value={tab} onValueChange={setTab} defaultValue="v3">
@@ -89,11 +90,23 @@ export const PositionsTab: FC<{ chainId: SushiSwapChainId }> = ({
               </TabsTrigger>
             ))}
           </TabsList>
+          {tab === 'v3' ? (
+            <div className="flex gap-3 items-center whitespace-nowrap">
+              <span className="text-sm font-medium text-gray-600 dark:text-slate-400">
+                Hide closed
+              </span>
+              <Switch
+                checked={hideClosedPositions}
+                onCheckedChange={() => setHideClosedPositions((prev) => !prev)}
+              />
+            </div>
+          ) : null}
         </div>
         <TabsContent value="v3">
           <ConcentratedPositionsTable
             chainId={chainId}
             hideNewPositionButton={true}
+            hideClosedPositions={hideClosedPositions}
           />
         </TabsContent>
         <TabsContent value="v2">


### PR DESCRIPTION
### Requested Change:
Move the "Hide closed" toggle to the same container as the pool position selector (as shown in the attached image).

![image](https://github.com/user-attachments/assets/30837e30-fc44-4e59-bf9a-920286f61541)

### Changes Implemented:

The "Hide closed" toggle was initially placed within the `ConcentratedPositionsTable` component, which is used across two pages:
1. **Pool Positions Page**:  
   `(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/positions`
2. **Chain Pools Page**:  
   `(networks)/(evm)/[chainId]/(positions)/pool`

The requested change applies only to the **Chain Pools Page**, not the **Pool Positions Page**.

#### What Was Done:
- The "Hide closed" toggle has been moved to the same container as the pool position selector on the Chain Pools Page, as requested.
  <img width="1358" alt="image" src="https://github.com/user-attachments/assets/6e2015ff-8ca1-40ff-b1b4-f32049c89132" />
- The "Hide closed" toggle is hidden when the tab is not v3 pools. This is because it's not used in the other pool version tables. This behavior is up for discussion.
  <img width="1292" alt="image" src="https://github.com/user-attachments/assets/647a7097-7e16-417e-a7dc-3eb936b30b64" />

- To preserve the existing functionality on the **Pool Positions Page**, an `actions` slot prop was added to the `ConcentratedPositionsTable`. This allows the toggle to remain in its original position on that page, while also enabling the new layout for the Chain Pools Page.
  <img width="1086" alt="image" src="https://github.com/user-attachments/assets/ebb01562-f290-4988-8774-09504977172c" />

