### PR TITLE
feat: add custom 404 page similar to default Next.js one

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+export default function NotFound() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center font-sans">
+      <div className="flex leading-[48px]">
+        <h1 className="mr-5 inline-block border-r border-current pr-6 text-2xl font-medium text-opacity-30 align-top">
+          404
+        </h1>
+        <div className="inline-block">
+          <h2 className="text-sm font-normal leading-7">
+            This page could not be found.
+          </h2>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Partially recreated the default [Next 404 page](https://github.com/vercel/next.js/blob/canary/packages/next/src/pages/_error.tsx) just using Tailwind. This way the text color is white.

![CleanShot 2025-01-28 at 19 03 04@2x](https://github.com/user-attachments/assets/73ac1bb9-9c99-4d8a-aade-83820fcb20be)
