### PR TITLE
fix: pool types filter selection

### DIFF
--- a/apps/web/src/ui/pool/TableFiltersPoolType.tsx
+++ b/apps/web/src/ui/pool/TableFiltersPoolType.tsx
@@ -57,20 +57,15 @@ export const TableFiltersPoolType: FC = () => {
     (item: SushiSwapProtocol) => {
       let _newValues: SushiSwapProtocol[]
       if (values?.includes(item)) {
-        _newValues = values.filter((el) => el !== item)
+        _newValues = isAllThenNone(values.filter((el) => el !== item))
       } else {
-        _newValues = [...(values ?? []), item]
+        _newValues = isAllThenNone([...(values ?? []), item])
       }
       setValues(_newValues)
 
       startTransition(() => {
         setFilters((prev) => {
-          if (prev.protocols?.includes(item)) {
-            const protocols = prev.protocols.filter((el) => el !== item)
-            return { ...prev, protocols }
-          } else {
-            return { ...prev, protocols: [...(prev.protocols ?? []), item] }
-          }
+          return { ...prev, protocols: _newValues }
         })
       })
     },


### PR DESCRIPTION
**Changes:**
- The correct pool type is always selected.
- When you select both pool types, the filter is removed from the URL, as it's the default state. This is optional, and can be reverted if we prefer to keep them.

**Demo:**
Before:
https://github.com/user-attachments/assets/268088c0-fc71-4adc-8b8a-0309b79298e9
After:
https://github.com/user-attachments/assets/4ae3e208-1292-4d95-87f0-0c2554ed7ce7

