### PR TITLE
fix: tvl and volume charts when datasets have different dates

### DIFF
--- a/apps/web/src/ui/explore/global-stats-charts.tsx
+++ b/apps/web/src/ui/explore/global-stats-charts.tsx
@@ -8,6 +8,13 @@ import { GlobalStatsLoading } from './global-stats-loading'
 import { TVLChart } from './tvl-chart'
 import { VolumeChart } from './volume-chart'
 
+const getChartStartDate = (daysAgo: number): Date => {
+  const date = new Date()
+  date.setUTCHours(0, 0, 0, 0)
+  date.setUTCDate(date.getUTCDate() - daysAgo)
+  return date
+}
+
 export const GlobalStatsCharts: FC<{ chainId: PoolChainId }> = ({
   chainId,
 }) => {
@@ -32,12 +39,19 @@ const _GlobalStatsCharts: FC<{ chainId: PoolChainId }> = async ({
     },
   )()
 
+  const tvlStartDate = getChartStartDate(500)
+  const volumeStartDate = getChartStartDate(30)
+
   return !dayBuckets.v2.length && !dayBuckets.v3.length ? (
     <GlobalStatsLoading chainId={chainId} />
   ) : (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-20 gap-y-10">
-      <TVLChart chainId={chainId} data={dayBuckets} />
-      <VolumeChart chainId={chainId} data={dayBuckets} />
+      <TVLChart chainId={chainId} data={dayBuckets} startDate={tvlStartDate} />
+      <VolumeChart
+        chainId={chainId}
+        data={dayBuckets}
+        startDate={volumeStartDate}
+      />
     </div>
   )
 }

--- a/apps/web/src/ui/explore/tvl-chart.tsx
+++ b/apps/web/src/ui/explore/tvl-chart.tsx
@@ -209,7 +209,7 @@ export const TVLChart: FC<TVLChart> = ({ data, chainId, startDate }) => {
                 className="text-sm text-gray-500 dark:text-slate-500"
               >
                 {isMounted
-                  ? format(new Date(currentDate), 'MMM dd yyyy HH:mm aa')
+                  ? format(new Date(currentDate), 'dd MMM yyyy HH:mm aa')
                   : ''}
               </div>
             </div>

--- a/apps/web/src/ui/explore/tvl-chart.tsx
+++ b/apps/web/src/ui/explore/tvl-chart.tsx
@@ -14,9 +14,10 @@ import { formatUSD } from 'sushi/format'
 interface TVLChart {
   data: AnalyticsDayBuckets
   chainId: ChainId
+  startDate?: Date
 }
 
-export const TVLChart: FC<TVLChart> = ({ data, chainId }) => {
+export const TVLChart: FC<TVLChart> = ({ data, chainId, startDate }) => {
   const isMounted = useIsMounted()
 
   const { resolvedTheme } = useTheme()
@@ -33,7 +34,12 @@ export const TVLChart: FC<TVLChart> = ({ data, chainId }) => {
     data.v2.forEach((item) => uniqueDates.add(item.date * 1000))
     data.v3.forEach((item) => uniqueDates.add(item.date * 1000))
 
-    const sortedDates = Array.from(uniqueDates).sort((a, b) => a - b)
+    const startTimestamp = startDate ? startDate.getTime() : 0
+    const filteredDates = startTimestamp
+      ? Array.from(uniqueDates).filter((date) => date >= startTimestamp)
+      : Array.from(uniqueDates)
+
+    const sortedDates = filteredDates.sort((a, b) => a - b)
     const v2 = sortedDates.map((date) => [date, v2Map.get(date) ?? 0])
     const v3 = sortedDates.map((date) => [date, v3Map.get(date) ?? 0])
 
@@ -41,7 +47,7 @@ export const TVLChart: FC<TVLChart> = ({ data, chainId }) => {
     const currentDate = sortedDates[sortedDates.length - 1]
 
     return [v2, v3, combinedTVL, currentDate]
-  }, [data])
+  }, [data, startDate])
 
   const zIndex = useMemo(() => {
     const v2Sum = v2.reduce((sum, [_, value]) => sum + value, 0)

--- a/apps/web/src/ui/explore/tvl-chart.tsx
+++ b/apps/web/src/ui/explore/tvl-chart.tsx
@@ -22,19 +22,23 @@ export const TVLChart: FC<TVLChart> = ({ data, chainId }) => {
   const { resolvedTheme } = useTheme()
 
   const [v2, v3, combinedTVL, currentDate] = useMemo(() => {
-    const xData = (data.v2.length > data.v3.length ? data.v2 : data.v3).map(
-      (data) => data.date * 1000,
+    const v2Map = new Map(
+      data.v2.map((item) => [item.date * 1000, item.liquidityUSD]),
+    )
+    const v3Map = new Map(
+      data.v3.map((item) => [item.date * 1000, item.liquidityUSD]),
     )
 
-    const v2 = xData
-      .map((xData, i) => [xData, data.v2[i]?.liquidityUSD ?? 0])
-      .reverse()
-    const v3 = xData
-      .map((xData, i) => [xData, data.v3[i]?.liquidityUSD ?? 0])
-      .reverse()
-    const combinedTVL = v2[v2.length - 1][1] + v3[v3.length - 1][1]
+    const uniqueDates = new Set<number>()
+    data.v2.forEach((item) => uniqueDates.add(item.date * 1000))
+    data.v3.forEach((item) => uniqueDates.add(item.date * 1000))
 
-    const currentDate = xData[0]
+    const sortedDates = Array.from(uniqueDates).sort((a, b) => a - b)
+    const v2 = sortedDates.map((date) => [date, v2Map.get(date) ?? 0])
+    const v3 = sortedDates.map((date) => [date, v3Map.get(date) ?? 0])
+
+    const combinedTVL = v2[v2.length - 1][1] + v3[v3.length - 1][1]
+    const currentDate = sortedDates[sortedDates.length - 1]
 
     return [v2, v3, combinedTVL, currentDate]
   }, [data])

--- a/apps/web/src/ui/explore/volume-chart.tsx
+++ b/apps/web/src/ui/explore/volume-chart.tsx
@@ -13,9 +13,10 @@ import { formatUSD } from 'sushi/format'
 interface VolumeChart {
   data: AnalyticsDayBuckets
   chainId: ChainId
+  startDate?: Date
 }
 
-export const VolumeChart: FC<VolumeChart> = ({ data, chainId }) => {
+export const VolumeChart: FC<VolumeChart> = ({ data, chainId, startDate }) => {
   const { resolvedTheme } = useTheme()
 
   const [v2, v3, totalVolume] = useMemo(() => {
@@ -23,9 +24,12 @@ export const VolumeChart: FC<VolumeChart> = ({ data, chainId }) => {
     data.v2.forEach((item) => uniqueDates.add(item.date * 1000))
     data.v3.forEach((item) => uniqueDates.add(item.date * 1000))
 
-    const sortedDates = Array.from(uniqueDates)
-      .sort((a, b) => a - b)
-      .slice(-30)
+    const startTimestamp = startDate ? startDate.getTime() : 0
+    const filteredDates = startTimestamp
+      ? Array.from(uniqueDates).filter((date) => date >= startTimestamp)
+      : Array.from(uniqueDates)
+
+    const sortedDates = filteredDates.sort((a, b) => a - b)
     const v2Map = new Map(
       data.v2.map((item) => [item.date * 1000, item.volumeUSD]),
     )
@@ -41,7 +45,7 @@ export const VolumeChart: FC<VolumeChart> = ({ data, chainId }) => {
       v3.reduce((sum, [_, value]) => sum + value, 0)
 
     return [v2, v3, totalVolume]
-  }, [data])
+  }, [data, startDate])
 
   const onMouseOver = useCallback((params: { data: number[] }[]) => {
     const volumeNode = document.getElementById('hoveredVolume')

--- a/apps/web/src/ui/explore/volume-chart.tsx
+++ b/apps/web/src/ui/explore/volume-chart.tsx
@@ -19,20 +19,26 @@ export const VolumeChart: FC<VolumeChart> = ({ data, chainId }) => {
   const { resolvedTheme } = useTheme()
 
   const [v2, v3, totalVolume] = useMemo(() => {
-    const xData = (data.v2.length > data.v3.length ? data.v2 : data.v3)
-      .slice(0, 30)
-      .map((data) => data.date * 1000)
+    const uniqueDates = new Set<number>()
+    data.v2.forEach((item) => uniqueDates.add(item.date * 1000))
+    data.v3.forEach((item) => uniqueDates.add(item.date * 1000))
 
-    const v2 = xData
-      .map((xData, i) => [xData, data.v2[i]?.volumeUSD ?? 0])
-      .reverse()
-    const v3 = xData
-      .map((xData, i) => [xData, data.v3[i]?.volumeUSD ?? 0])
-      .reverse()
-    const totalVolume = xData.reduce(
-      (sum, _, i) => sum + v2[i][1] + v3[i][1],
-      0,
+    const sortedDates = Array.from(uniqueDates)
+      .sort((a, b) => a - b)
+      .slice(-30)
+    const v2Map = new Map(
+      data.v2.map((item) => [item.date * 1000, item.volumeUSD]),
     )
+    const v3Map = new Map(
+      data.v3.map((item) => [item.date * 1000, item.volumeUSD]),
+    )
+
+    const v2 = sortedDates.map((date) => [date, v2Map.get(date) ?? 0])
+    const v3 = sortedDates.map((date) => [date, v3Map.get(date) ?? 0])
+
+    const totalVolume =
+      v2.reduce((sum, [_, value]) => sum + value, 0) +
+      v3.reduce((sum, [_, value]) => sum + value, 0)
 
     return [v2, v3, totalVolume]
   }, [data])


### PR DESCRIPTION
**Changes:**
- Fixed data misalignment when v2 and v3 datasets contain different dates by creating a unified timeline with the dates of each dataset.
- Added optional startDate prop. The ideal scenario for TVL chart is to show the data for the last 500 days, as the analytics query returns the last 500 daily datapoints (some days may be missing so it could span a period of more than 500 days in some scenarios). For the volume chart, it's to show the data for the last 30 days.
- Used the same date to format the current date and hovered date in the TVL chart.