### PR TITLE
fix: add account to useMyTokens queryKey

### DIFF
--- a/apps/web/src/lib/wagmi/components/token-selector/hooks/use-my-tokens.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/hooks/use-my-tokens.ts
@@ -28,7 +28,7 @@ export function useMyTokens({ chainId, account, includeNative }: UseMyTokens) {
   const query = useQuery({
     queryKey: [
       'data-api-token-list-balances',
-      { chainId, customTokens, includeNative },
+      { chainId, account, customTokens, includeNative },
     ],
     queryFn: async () => {
       if (!account) throw new Error('Account is required')


### PR DESCRIPTION
resolves a bug where token selector shows balances for a previously connected account

reproduction steps (without this patch):
1. load /swap with wallet A connected
2. open token selector
3. from wallet extension itself, change connected wallet to wallet B

result: token selector still shows balances for wallet A while the app is connected to wallet B