### PR TITLE
fix(stellar): preserve precision in positions-table price range

### DIFF
--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/Pools/PositionsTable/PositionPriceRangeCell.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/Pools/PositionsTable/PositionPriceRangeCell.tsx
@@ -1,7 +1,7 @@
 import { ArrowSmLeftIcon, ArrowSmRightIcon } from '@heroicons/react-v1/solid'
-import { FormattedNumber, SkeletonText, classNames } from '@sushiswap/ui'
+import { SkeletonText, classNames } from '@sushiswap/ui'
 import { usePoolInfo } from '~stellar/_common/lib/hooks'
-import { calculatePriceFromTick } from '~stellar/_common/lib/soroban'
+import { formatPriceBound } from '~stellar/_common/lib/soroban'
 import type { IPositionRowData } from './PositionsTable'
 
 export const PositionPriceRangeCell = ({
@@ -30,7 +30,7 @@ export const PositionPriceRangeCell = ({
           )}
         />
         <span className="whitespace-nowrap text-sm flex items-center gap-1 text-gray-900 dark:text-slate-50">
-          <FormattedNumber number={calculatePriceFromTick(tickLower)} />
+          <span>{formatPriceBound(tickLower, 'lower')}</span>
           {token1.code}
           <div className="flex items-center">
             <ArrowSmLeftIcon
@@ -44,7 +44,7 @@ export const PositionPriceRangeCell = ({
               className="text-gray-500 dark:text-slate-500 ml-[-7px]"
             />
           </div>
-          <FormattedNumber number={calculatePriceFromTick(tickUpper)} />
+          <span>{formatPriceBound(tickUpper, 'upper')}</span>
 
           {token1.code}
         </span>
@@ -54,7 +54,7 @@ export const PositionPriceRangeCell = ({
         {isPendingPoolInfo || !poolInfo ? (
           <SkeletonText />
         ) : (
-          <FormattedNumber number={calculatePriceFromTick(poolInfo.tick)} />
+          <span>{formatPriceBound(poolInfo.tick, 'upper')}</span>
         )}
         {token1.code} per {token0.code}{' '}
       </span>


### PR DESCRIPTION
## Summary

On the Stellar positions page (`sushi.com/stellar/pool`), the **Price Range** column collapses to a single value for positions on low-priced assets. A real position with bounds `0.1655` and `0.1725` XLM/USDC is shown as `0.17 ↔ 0.17 USDC`, which hides the actual range and makes the `Current:` line look inconsistent with both the position and the pool detail page.

This PR changes the positions table to use the same price formatter the pool detail page already uses, restoring precision while keeping the existing sentinel handling (`0` / `∞`) at the tick limits.

## Reproduction

Open an XLM/USDC position with `tickLower` and `tickUpper` that correspond to prices between `0.16` and `0.18`:

| Field | Actual | Displayed (before) |
| --- | --- | --- |
| priceLower | `0.1655` | `0.17` |
| priceUpper | `0.1725` | `0.17` |
| current    | `0.16928` | `0.17` |

Result in the table:

```
● 0.17 USDC ↔ 0.17 USDC
Current: 0.17 USDC per XLM
```

## Root cause

`PositionPriceRangeCell.tsx` renders each bound with:

```tsx
<FormattedNumber number={calculatePriceFromTick(tickLower)} />
```

`FormattedNumber` (`packages/ui/src/components/formatted-number.tsx`) delegates to `formatNumber` from the `sushi` package. For any value `>= 0.01`, that function ultimately calls `toFixed(maxDecimalPlaces)` with a default of **2**:

```js
if (value < 0.0001) return value.toFixed(6)
if (value < 0.001)  return value.toFixed(4)
if (value < 0.01)   return value.toFixed(3)
// otherwise: toFixed(2) via formatValueWithSuffix
```

So `0.1655` and `0.1725` both round to `"0.17"`. This is fine for dollar-denominated prices but wrong for a concentrated-liquidity price range, where adjacent ticks on a cheap asset routinely fall inside the same 2-decimal bucket.

## Fix

Replace the three `FormattedNumber` / `calculatePriceFromTick` call sites in `PositionPriceRangeCell.tsx` with the existing `formatPriceBound` helper from `~stellar/_common/lib/soroban/pool-helpers.ts`:

```ts
// pool-helpers.ts (existing)
export const formatPriceBound = (tick: number, bound: 'lower' | 'upper') => {
  if (bound === 'lower' && tick <= MAX_TICK_RANGE.lower) return '0'
  if (bound === 'upper' && tick >= MAX_TICK_RANGE.upper) return '∞'
  const price = calculatePriceFromTick(tick)
  if (!Number.isFinite(price) || price <= 0) return bound === 'lower' ? '0' : '∞'
  if (price >= 1_000_000) return price.toExponential(2)
  if (price <= 0.0001)    return '<0.0001'
  return price.toLocaleString(undefined, { maximumSignificantDigits: 6 })
}
```

This helper:

1. formats with up to **6 significant digits**, so `0.1655` and `0.1725` stay distinct;
2. already handles the tick-range sentinels (`MAX_TICK_RANGE.lower` → `"0"`, `MAX_TICK_RANGE.upper` → `"∞"`), which the previous implementation did not;
3. handles degenerate prices (`NaN`, `<= 0`, `>= 1e6`, `<= 0.0001`) consistently.

Using it here also makes the positions table match what the pool detail page (`ManageLiquidityCard.tsx:778,783`) already renders, so the same position shows the same numbers in both places.

After the change:

```
● 0.1655 USDC ↔ 0.1725 USDC
Current: 0.16928 USDC per XLM
```

## Why not fix `FormattedNumber` instead?

`FormattedNumber` has no precision prop today, so widening its API would touch every call site in the app and the EVM code relies on its current rounding behavior for USD amounts. The EVM equivalent (`apps/web/src/app/(networks)/(evm)/[chainId]/pool/_ui/ConcentratedPositionsTable/price-range-cell.tsx`) already passes `price.toSignificant(6)` into `FormattedNumber`, which then re-rounds to 2 decimals — so the same latent bug exists there, it's just rarely visible because ETH-denominated prices are usually far from the 2-decimal boundary.

A broader fix (e.g. a `significantDigits` prop on `FormattedNumber`, or switching EVM to a similar dedicated bound formatter) is worth doing but has a larger blast radius and is best discussed separately. Happy to follow up with that in another PR if maintainers prefer.

## Scope

Single file changed: `apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/Pools/PositionsTable/PositionPriceRangeCell.tsx`.

No new dependencies. No changes to shared UI components. No changes to the `sushi` package.

## Test plan

- [ ] Verify an XLM/USDC position with a narrow range (e.g. `0.1655` – `0.1725`) now displays both bounds distinctly on `/stellar/pool`.
- [ ] Verify a position at max range still renders `0 ↔ ∞`.
- [ ] Verify a position with a very high price (`>= 1e6`) falls back to exponential notation.
- [ ] Verify a position with a very low price (`<= 0.0001`) renders as `<0.0001`.
- [ ] Visually confirm the positions table and the pool detail page (`ManageLiquidityCard`) now display the same numbers for the same position.
- [ ] `pnpm lint` / `pnpm check` pass.