### PR TITLE
feat: cleanup stellar address types

### DIFF
--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/factory/use-create-and-initialize-pool.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/factory/use-create-and-initialize-pool.ts
@@ -7,15 +7,19 @@ import {
 } from '@sushiswap/notifications'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ChainId } from 'sushi'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { createAndInitializePool } from '../../soroban/dex-factory-helpers'
 import { formatAddress } from '../../utils/format'
 import { getStellarTxnLink } from '../../utils/stellarchain-helpers'
 import { invalidatePoolInitializedQuery } from '../pool/use-pool-initialized'
 
 export interface CreateAndInitializePoolParams {
-  userAddress: string
-  tokenA: string
-  tokenB: string
+  userAddress: StellarAccountAddress
+  tokenA: StellarContractAddress
+  tokenB: StellarContractAddress
   fee: number
   sqrtPriceX96: bigint
   signTransaction: (xdr: string) => Promise<string>

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/factory/use-get-pool.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/factory/use-get-pool.ts
@@ -1,11 +1,12 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { getPoolDirectSDK } from '../../soroban/dex-factory-helpers'
 
 export interface GetPoolParams {
-  tokenA: string
-  tokenB: string
+  tokenA: StellarContractAddress
+  tokenB: StellarContractAddress
   fee: number
 }
 

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/liquidity/use-add-liquidity.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/liquidity/use-add-liquidity.ts
@@ -8,14 +8,18 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { addMinutes } from 'date-fns'
 import { ChainId } from 'sushi'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { createSushiStellarService } from '../../services/sushi-stellar-service'
 import type { AddLiquidityParams } from '../../services/swap-service'
 import { extractErrorMessage } from '../../utils/error-helpers'
 import { getStellarTxnLink } from '../../utils/stellarchain-helpers'
 
 export interface UseAddLiquidityParams {
-  userAddress: string
-  poolAddress: string
+  userAddress: StellarAccountAddress
+  poolAddress: StellarContractAddress
   token0Amount: string
   token1Amount: string
   token0Decimals: number

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/liquidity/use-remove-liquidity.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/liquidity/use-remove-liquidity.ts
@@ -8,6 +8,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { addMinutes } from 'date-fns'
 import { ChainId, MAX_UINT128 } from 'sushi'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import { decreaseLiquidity } from '~stellar/_common/lib/soroban/position-manager-helpers'
 import { getStellarTxnLink } from '~stellar/_common/lib/utils/stellarchain-helpers'
@@ -23,7 +24,7 @@ export interface RemovePoolLiquidityParams {
   amount1Min: bigint
   token0: Token
   token1: Token
-  poolAddress: string
+  poolAddress: StellarContractAddress
 }
 
 export const useRemoveLiquidity = ({
@@ -138,7 +139,7 @@ export const useRemoveLiquidity = ({
       }
     },
     mutationFn: async (params: {
-      poolAddress: string
+      poolAddress: StellarContractAddress
       tokenId: number
       recipient: string
       amount0Max: bigint

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-calculate-dependent-amount.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-calculate-dependent-amount.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import {
   calculateAmountsFromLiquidity,
@@ -18,7 +19,7 @@ export type Field = 'token0' | 'token1'
  * Calculate the dependent token amount based on independent token input
  */
 export function useCalculateDependentAmount(
-  poolAddress: string | null,
+  poolAddress: StellarContractAddress | null,
   amount: string,
   independentField: Field,
   tickLower: number,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-calculate-paired-amount.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-calculate-paired-amount.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import {
   calculateAmountsFromLiquidity,
@@ -16,7 +17,7 @@ import { usePoolInitialized } from './use-pool-initialized'
  * Matches the implementation from stellar-auth-test
  */
 export function useCalculatePairedAmount(
-  poolAddress: string | null,
+  poolAddress: StellarContractAddress | null,
   token0Amount: string,
   tickLower: number | null,
   tickUpper: number | null,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-max-paired-amount.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-max-paired-amount.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import { useCalculatePairedAmount } from './use-calculate-paired-amount'
 import { usePoolInitialized } from './use-pool-initialized'
@@ -10,7 +11,7 @@ import { usePoolInitialized } from './use-pool-initialized'
  * Calculate the maximum token0 and token1 amounts based on token0 and token1 balances
  */
 export function useMaxPairedAmount(
-  poolAddress: string | null,
+  poolAddress: StellarContractAddress | null,
   token0Balance: string,
   token1Balance: string,
   tickLower: number | null,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-balances.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-balances.ts
@@ -2,24 +2,27 @@
 
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
-import type { StellarAddress } from 'sushi/stellar'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { getPoolBalances } from '../../soroban/pool-helpers'
 
 export const usePoolBalances = (
-  address: string | null,
-  connectedAddress: StellarAddress | undefined,
+  poolAddress: StellarContractAddress | null,
+  connectedAddress: StellarAccountAddress | undefined,
 ) => {
   return useQuery({
-    queryKey: ['stellar', 'pool', 'balances', address, connectedAddress],
+    queryKey: ['stellar', 'pool', 'balances', poolAddress, connectedAddress],
     queryFn: async () => {
-      if (!address || !connectedAddress) {
+      if (!poolAddress || !connectedAddress) {
         throw new Error(
           'Address and connected address are required to fetch pool balances',
         )
       }
-      return await getPoolBalances(address, connectedAddress)
+      return await getPoolBalances(poolAddress, connectedAddress)
     },
-    enabled: Boolean(address && connectedAddress),
+    enabled: Boolean(poolAddress && connectedAddress),
     staleTime: ms('10s'),
   })
 }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-info.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-info.ts
@@ -2,17 +2,18 @@
 
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { getPoolInfo } from '../../soroban/pool-helpers'
 import type { PoolInfo } from '../../types/pool.type'
 
-export const usePoolInfo = (address: string | null) => {
+export const usePoolInfo = (poolAddress: StellarContractAddress | null) => {
   return useQuery<PoolInfo | null>({
-    queryKey: ['stellar', 'pool', 'info', address],
+    queryKey: ['stellar', 'pool', 'info', poolAddress],
     queryFn: async () => {
-      if (!address) {
+      if (!poolAddress) {
         return null
       }
-      const poolInfo = await getPoolInfo(address)
+      const poolInfo = await getPoolInfo(poolAddress)
       // If getPoolInfo returns null, it might be a transient error
       // Throw to trigger retry logic
       if (!poolInfo) {
@@ -24,7 +25,7 @@ export const usePoolInfo = (address: string | null) => {
         ...poolInfo,
       }
     },
-    enabled: Boolean(address),
+    enabled: Boolean(poolAddress),
     staleTime: ms('10s'),
     retry: 3, // Retry up to 3 times on RPC failures
     retryDelay: (attemptIndex) =>

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-initialized.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-initialized.ts
@@ -2,25 +2,25 @@
 
 import { type QueryClient, useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { isPoolInitialized } from '~stellar/_common/lib/soroban/pool-initialization'
 
-const poolInitializedQueryKey = (address: string | null | undefined) => [
-  'stellar',
-  'pool',
-  'initialized',
-  address,
-]
+const poolInitializedQueryKey = (
+  address: StellarContractAddress | null | undefined,
+) => ['stellar', 'pool', 'initialized', address]
 
-export const usePoolInitialized = (address: string | null | undefined) => {
+export const usePoolInitialized = (
+  poolAddress: StellarContractAddress | null | undefined,
+) => {
   return useQuery({
-    queryKey: poolInitializedQueryKey(address),
+    queryKey: poolInitializedQueryKey(poolAddress),
     queryFn: () => {
-      if (!address) {
+      if (!poolAddress) {
         return false
       }
-      return isPoolInitialized(address)
+      return isPoolInitialized(poolAddress)
     },
-    enabled: Boolean(address),
+    enabled: Boolean(poolAddress),
     staleTime: ms('30s'),
     retry: 3, // Retry up to 3 times on RPC failures
     retryDelay: (attemptIndex) =>
@@ -30,11 +30,11 @@ export const usePoolInitialized = (address: string | null | undefined) => {
 
 export const invalidatePoolInitializedQuery = (
   queryClient: QueryClient,
-  address: string | null | undefined,
+  poolAddress: StellarContractAddress | null | undefined,
 ) => {
-  if (!address) return
+  if (!poolAddress) return
 
   queryClient.invalidateQueries({
-    queryKey: poolInitializedQueryKey(address),
+    queryKey: poolInitializedQueryKey(poolAddress),
   })
 }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-price.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-pool-price.ts
@@ -2,23 +2,24 @@
 
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import {
   calculatePriceFromSqrtPrice,
   getCurrentSqrtPrice,
 } from '../../soroban/pool-helpers'
 
-export const usePoolPrice = (address: string | null) => {
+export const usePoolPrice = (poolAddress: StellarContractAddress | null) => {
   return useQuery({
-    queryKey: ['stellar', 'pool', 'price', address],
+    queryKey: ['stellar', 'pool', 'price', poolAddress],
     queryFn: async () => {
-      if (!address) {
-        return null
+      if (!poolAddress) {
+        throw new Error('Pool address is required')
       }
-      const sqrtPriceX96 = await getCurrentSqrtPrice(address)
+      const sqrtPriceX96 = await getCurrentSqrtPrice(poolAddress)
       const price = calculatePriceFromSqrtPrice(sqrtPriceX96)
       return price
     },
-    enabled: Boolean(address),
+    enabled: Boolean(poolAddress),
     staleTime: ms('10s'), // 10 seconds
   })
 }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-slot-hints.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-slot-hints.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import type { StellarContractAddress } from 'sushi/stellar'
 import {
   type PoolOracleHints,
   fetchOracleHints,
@@ -13,7 +14,7 @@ import {
  * @returns Query result with oracle hints
  */
 export function useOracleHints(
-  poolAddress: string | undefined,
+  poolAddress: StellarContractAddress | undefined,
   enabled = true,
 ) {
   return useQuery<PoolOracleHints, Error>({

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-top-pools.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/pool/use-top-pools.ts
@@ -4,6 +4,7 @@ import {
 } from '@sushiswap/graph-client/data-api'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { ChainId } from 'sushi'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { getPoolDirectSDK } from '../../soroban'
 import { getTokenByContract } from '../../soroban/token-helpers'
 import type { Token } from '../../types/token.type'
@@ -42,8 +43,14 @@ export function useTopPools({ isLegacy = false }: { isLegacy?: boolean } = {}) {
       const topPoolsWithTokens = await Promise.all(
         topPools.map(async (pool) => {
           const [token0, token1] = await Promise.all([
-            getTokenByContract(pool.token0Address, tokens),
-            getTokenByContract(pool.token1Address, tokens),
+            getTokenByContract(
+              pool.token0Address as StellarContractAddress,
+              tokens,
+            ),
+            getTokenByContract(
+              pool.token1Address as StellarContractAddress,
+              tokens,
+            ),
           ])
           return {
             ...pool,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-my-position.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-my-position.ts
@@ -1,6 +1,7 @@
 import { useQueries } from '@tanstack/react-query'
 import ms from 'ms'
 import { useMemo } from 'react'
+import type { StellarContractAddress } from 'sushi/stellar'
 import {
   type PositionInfo,
   positionService,
@@ -18,7 +19,7 @@ export interface PositionSummary {
   principalToken1: bigint
   feesToken0: bigint
   feesToken1: bigint
-  pool: string
+  pool: StellarContractAddress
   tickLower: number
   tickUpper: number
   fee: number
@@ -35,7 +36,7 @@ const getPositionKey = (position: PositionInfo) => {
 }
 
 type PoolData = {
-  address: string
+  address: StellarContractAddress
   token0: Token
   token1: Token
 }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-position-active-liquidity.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-position-active-liquidity.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import {
   calculateActiveLiquidity,
   getCurrentSqrtPrice,
@@ -19,7 +20,7 @@ export function usePositionActiveLiquidity({
   tickLower,
   tickUpper,
 }: {
-  poolAddress: string | null
+  poolAddress: StellarContractAddress | null
   scaledAmount0: bigint
   scaledAmount1: bigint
   tickLower: number

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-position-pool-ownership.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-position-pool-ownership.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
+import type { StellarContractAddress } from 'sushi/stellar'
 import type { Token } from '../../types/token.type'
 import { usePoolInfo } from '../pool'
 import { useLPUsdValue } from '../pool/use-pool-usd-value'
 
 type UsePoolOwnershipProps = {
-  pairAddress: string | undefined | null
+  pairAddress: StellarContractAddress | undefined | null
   token0: Token
   token1: Token
   reserve0: bigint

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-positions.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/position/use-positions.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { positionService } from '../../services/position-service'
 import { waitForTransaction } from '../../soroban/transaction-helpers'
 
@@ -111,7 +112,7 @@ export function useCollectFees({
       signTransaction,
       signAuthEntry,
     }: {
-      poolAddress: string
+      poolAddress: StellarContractAddress
       tokenId: number
       recipient: string
       amount0Max: bigint

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/price/use-stable-price.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/price/use-stable-price.ts
@@ -13,7 +13,7 @@ export const useStablePrice = ({ token }: { token: Token | undefined }) => {
   const additionalTokens = [
     token?.contract,
     ...stableTokens.map((t) => t.contract),
-  ].filter((t): t is string => !!t)
+  ].filter((t): t is NonNullable<typeof t> => Boolean(t))
 
   // Get the pool graph, augmented with input/output tokens
   const { data: poolGraphData } = usePoolGraph({
@@ -31,7 +31,7 @@ export const useStablePrice = ({ token }: { token: Token | undefined }) => {
         ],
         queryFn: async (): Promise<string | null> => {
           if (!token || !poolGraphData) {
-            return null
+            throw new Error('Token and pool graph data are required')
           }
           const bestRoute = await getBestRoute({
             tokenIn: token,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/swap/use-execute-swap.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/swap/use-execute-swap.ts
@@ -10,6 +10,7 @@ import { addMinutes } from 'date-fns'
 import { nanoid } from 'nanoid'
 import { toast } from 'react-toastify'
 import { ChainId } from 'sushi'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import { useStellarWallet } from '~stellar/providers'
 import { SwapService } from '../../services/swap-service'
@@ -19,7 +20,7 @@ import { getStellarTxnLink } from '../../utils/stellarchain-helpers'
 
 export interface UseExecuteSwapParams {
   userAddress: string
-  pool: string
+  pool: StellarContractAddress
   tokenIn: Token
   tokenOut: Token
   amountIn: bigint
@@ -138,7 +139,7 @@ export const useExecuteSwap = () => {
 
 export interface UseExecuteMultiHopSwapParams {
   userAddress: string
-  pools: string[]
+  pools: StellarContractAddress[]
   path: string[]
   fees: number[]
   amountIn: bigint

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/get-stellar-portfolio-wallet.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/get-stellar-portfolio-wallet.ts
@@ -1,11 +1,13 @@
 import { getChainById } from 'sushi'
-import { StellarChainId } from 'sushi/stellar'
+import { type StellarAccountAddress, StellarChainId } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import { getTokenBalance } from '../../soroban'
 import type { TokenWithBalance } from '../../types/token.type'
 import { fetchCommonTokensQueryFn } from './use-common-tokens'
 
-export const getStellarPortfolioWallet = async (address: `G${string}`) => {
+export const getStellarPortfolioWallet = async (
+  address: StellarAccountAddress,
+) => {
   const tokens = await fetchCommonTokensQueryFn()
   const tokensWithBalances: TokenWithBalance[] = []
   for (const token of Object.values(tokens)) {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-common-tokens.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-common-tokens.ts
@@ -1,13 +1,28 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import {
+  type StellarAccountAddress,
+  type StellarContractAddress,
+  isStellarAccountAddress,
+  isStellarContractAddress,
+  normalizeStellarAddress,
+} from 'sushi/stellar'
 import { z } from 'zod'
 import { staticTokens } from '~stellar/_common/lib/assets/token-assets'
 import type { Token } from '~stellar/_common/lib/types/token.type'
 
 const stellarExpertAssetSchema = z.object({
   code: z.string(),
-  issuer: z.string(),
-  contract: z.string(),
+  issuer: z
+    .custom<StellarAccountAddress>((val) =>
+      isStellarAccountAddress(val as string),
+    )
+    .transform(normalizeStellarAddress),
+  contract: z
+    .custom<StellarContractAddress>((val) =>
+      isStellarContractAddress(val as string),
+    )
+    .transform(normalizeStellarAddress),
   name: z.string(),
   org: z.string(),
   decimals: z.number(),

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-custom-tokens.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-custom-tokens.ts
@@ -1,19 +1,22 @@
 import { useLocalStorage } from '@sushiswap/hooks'
 import { useCallback, useMemo } from 'react'
+import {
+  type StellarContractAddress,
+  normalizeStellarAddress,
+} from 'sushi/stellar'
 import type { Token } from '../../types/token.type'
 
 export const STELLAR_CUSTOM_TOKEN_KEY = 'sushi.stellar.custom-tokens'
 
 export function useCustomTokens() {
-  const [value, setValue] = useLocalStorage<Record<string, Token>>(
-    STELLAR_CUSTOM_TOKEN_KEY,
-    {},
-  )
+  const [value, setValue] = useLocalStorage<
+    Record<StellarContractAddress, Token>
+  >(STELLAR_CUSTOM_TOKEN_KEY, {})
 
-  const hydrate = useCallback((data: Record<string, Token>) => {
-    return Object.entries(data).reduce<Record<string, Token>>(
+  const hydrate = useCallback((data: Record<StellarContractAddress, Token>) => {
+    return Object.entries(data).reduce<Record<StellarContractAddress, Token>>(
       (acc, [k, token]) => {
-        acc[k] = { ...token }
+        acc[k as StellarContractAddress] = { ...token }
         return acc
       },
       {},
@@ -24,7 +27,7 @@ export function useCustomTokens() {
     (token: Token) => {
       setValue((prev) => {
         const updated = { ...prev }
-        updated[token.contract.toUpperCase()] = token
+        updated[normalizeStellarAddress(token.contract)] = token
         return updated
       })
     },
@@ -34,27 +37,30 @@ export function useCustomTokens() {
   const removeCustomToken = useCallback(
     (currency: Token) => {
       setValue((prev) => {
-        return Object.entries(prev).reduce<Record<string, Token>>(
-          (acc, cur) => {
-            if (cur[0].toUpperCase() === `${currency.contract}`.toUpperCase()) {
-              return acc // filter
-            }
-            acc[cur[0]] = cur[1] // add
-            return acc
-          },
-          {},
-        )
+        const normalizedTarget = normalizeStellarAddress(currency.contract)
+        return Object.entries(prev).reduce<
+          Record<StellarContractAddress, Token>
+        >((acc, cur) => {
+          if (
+            normalizeStellarAddress(cur[0] as StellarContractAddress) ===
+            normalizedTarget
+          ) {
+            return acc // filter
+          }
+          acc[cur[0] as StellarContractAddress] = cur[1] // add
+          return acc
+        }, {})
       })
     },
     [setValue],
   )
 
   const hasToken = useCallback(
-    (currency: Token | string) => {
+    (currency: Token | StellarContractAddress) => {
       if (typeof currency === 'string') {
-        return Boolean(value[currency.toUpperCase()])
+        return Boolean(value[normalizeStellarAddress(currency)])
       }
-      return Boolean(value[currency.contract.toUpperCase()])
+      return Boolean(value[normalizeStellarAddress(currency.contract)])
     },
     [value],
   )

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-allowance.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-allowance.ts
@@ -1,18 +1,21 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import type { StellarAddress, StellarContractAddress } from 'sushi/stellar'
 import { getTokenAllowance } from '../../soroban/token-helpers'
 
 export const useTokenAllowance = (
-  owner: string | null,
-  spender: string | null,
-  tokenAddress: string | null,
+  owner: StellarAddress | null,
+  spender: StellarAddress | null,
+  tokenAddress: StellarContractAddress | null,
 ) => {
   return useQuery({
     queryKey: ['stellar', 'token', 'allowance', owner, spender, tokenAddress],
     queryFn: async () => {
       if (!owner || !spender || !tokenAddress) {
-        return null
+        throw new Error(
+          'Owner, spender, and token address are required to fetch allowance',
+        )
       }
       return await getTokenAllowance(owner, spender, tokenAddress)
     },

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-approval.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-approval.ts
@@ -1,12 +1,13 @@
 'use client'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { StellarAddress, StellarContractAddress } from 'sushi/stellar'
 import { approveToken } from '../../soroban/token-helpers'
 
 export interface ApproveTokenParams {
-  spender: string
+  spender: StellarAddress
   amount: bigint
-  tokenAddress: string
+  tokenAddress: StellarContractAddress
 }
 
 export const useApproveToken = () => {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-balance.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-balance.ts
@@ -1,7 +1,11 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import type { StellarAddress } from 'sushi/stellar'
+import {
+  type StellarAccountAddress,
+  type StellarContractAddress,
+  isStellarContractAddress,
+} from 'sushi/stellar'
 import {
   getTokenBalance,
   getTokenBalanceFromToken,
@@ -9,14 +13,14 @@ import {
 import type { Token, TokenWithBalance } from '../../types/token.type'
 
 export const useTokenBalance = (
-  address: StellarAddress | undefined,
-  tokenContractId: string | null,
+  address: StellarAccountAddress | undefined,
+  tokenContractId: StellarContractAddress | null,
 ) => {
   return useQuery({
     queryKey: ['stellar', 'token', 'balance', address, tokenContractId],
     queryFn: async () => {
       if (!address || !tokenContractId) {
-        return null
+        throw new Error('Address and token contract ID are required')
       }
       return await getTokenBalance(address, tokenContractId)
     },
@@ -25,7 +29,7 @@ export const useTokenBalance = (
 }
 
 export const useTokenBalanceFromToken = (
-  address: string | null,
+  address: StellarAccountAddress | null,
   token: Token | null,
 ) => {
   return useQuery({
@@ -38,7 +42,7 @@ export const useTokenBalanceFromToken = (
     ],
     queryFn: async () => {
       if (!address || !token) {
-        return null
+        throw new Error('Address and token are required')
       }
       return await getTokenBalanceFromToken(address, token)
     },
@@ -53,7 +57,7 @@ export const useTokenBalanceFromToken = (
  * @returns The original tokens array with new `balance` and `balanceFormatted` fields for each
  */
 export const useTokenBalances = (
-  address: StellarAddress | undefined,
+  address: StellarAccountAddress | undefined,
   tokens: Token[],
 ) => {
   return useQuery({
@@ -92,17 +96,20 @@ export const useTokenBalances = (
  * @returns A map of contract addresses to balance amounts (as strings)
  */
 export const useTokenBalancesMap = (
-  address: StellarAddress | undefined,
-  contracts: string[],
+  address: StellarAccountAddress | undefined,
+  contracts: StellarContractAddress[],
 ) => {
   return useQuery({
     queryKey: ['stellar', 'token', 'balancesMap', address, contracts],
     queryFn: async () => {
       if (!address || contracts.length === 0) {
-        return contracts.reduce<Record<string, string>>((acc, contract) => {
-          acc[contract] = '0'
-          return acc
-        }, {})
+        return contracts.reduce<Record<StellarContractAddress, string>>(
+          (acc, contract) => {
+            acc[contract] = '0'
+            return acc
+          },
+          {},
+        )
       }
 
       const balanceMap: Record<string, string> = {}

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-transfer.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-transfer.ts
@@ -1,19 +1,20 @@
 'use client'
 
 import { useMutation } from '@tanstack/react-query'
+import type { StellarAddress, StellarContractAddress } from 'sushi/stellar'
 import { transferFromToken, transferToken } from '../../soroban/token-helpers'
 
 export interface TransferTokenParams {
-  to: string
+  to: StellarAddress
   amount: bigint
-  tokenAddress: string
+  tokenAddress: StellarContractAddress
 }
 
 export interface TransferFromTokenParams {
-  from: string
-  to: string
+  from: StellarAddress
+  to: StellarAddress
   amount: bigint
-  tokenAddress: string
+  tokenAddress: StellarContractAddress
 }
 
 export const useTransferToken = () => {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-utilities.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-utilities.ts
@@ -2,6 +2,11 @@
 
 import { useQuery } from '@tanstack/react-query'
 import {
+  type StellarAddress,
+  type StellarContractAddress,
+  isStellarContractAddress,
+} from 'sushi/stellar'
+import {
   getMultipleTokenAllowances,
   getMultipleTokenBalances,
   hasSufficientAllowance,
@@ -9,8 +14,8 @@ import {
 } from '../../soroban/token-helpers'
 
 export const useHasSufficientBalance = (
-  address: string | null,
-  tokenAddress: string | null,
+  address: StellarAddress | null,
+  tokenAddress: StellarContractAddress | null,
   amount: bigint | null,
 ) => {
   return useQuery({
@@ -33,9 +38,9 @@ export const useHasSufficientBalance = (
 }
 
 export const useHasSufficientAllowance = (
-  owner: string | null,
-  spender: string | null,
-  tokenAddress: string | null,
+  owner: StellarAddress | null,
+  spender: StellarAddress | null,
+  tokenAddress: StellarContractAddress | null,
   amount: bigint | null,
 ) => {
   return useQuery({
@@ -49,24 +54,36 @@ export const useHasSufficientAllowance = (
       amount,
     ],
     queryFn: async () => {
-      if (!owner || !spender || !tokenAddress || amount === null) {
+      if (
+        !owner ||
+        !spender ||
+        !tokenAddress ||
+        !isStellarContractAddress(tokenAddress) ||
+        amount === null
+      ) {
         return null
       }
       return await hasSufficientAllowance(owner, spender, tokenAddress, amount)
     },
-    enabled: Boolean(owner && spender && tokenAddress && amount !== null),
+    enabled: Boolean(
+      owner &&
+        spender &&
+        tokenAddress &&
+        isStellarContractAddress(tokenAddress) &&
+        amount !== null,
+    ),
   })
 }
 
 export const useMultipleTokenBalances = (
-  address: string | null,
-  tokenAddresses: string[],
+  address: StellarAddress | null,
+  tokenAddresses: StellarContractAddress[],
 ) => {
   return useQuery({
     queryKey: ['stellar', 'token', 'multipleBalances', address, tokenAddresses],
     queryFn: async () => {
       if (!address || tokenAddresses.length === 0) {
-        return null
+        throw new Error('Address and token addresses are required')
       }
       return await getMultipleTokenBalances(address, tokenAddresses)
     },
@@ -75,9 +92,9 @@ export const useMultipleTokenBalances = (
 }
 
 export const useMultipleTokenAllowances = (
-  owner: string | null,
-  spender: string | null,
-  tokenAddresses: string[],
+  owner: StellarAddress | null,
+  spender: StellarAddress | null,
+  tokenAddresses: StellarContractAddress[],
 ) => {
   return useQuery({
     queryKey: [
@@ -90,7 +107,7 @@ export const useMultipleTokenAllowances = (
     ],
     queryFn: async () => {
       if (!owner || !spender || tokenAddresses.length === 0) {
-        return null
+        throw new Error('Owner, spender, and token addresses are required')
       }
       return await getMultipleTokenAllowances(owner, spender, tokenAddresses)
     },

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-with-cache.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/token/use-token-with-cache.ts
@@ -1,9 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
+import {
+  type StellarContractAddress,
+  normalizeStellarAddress,
+} from 'sushi/stellar'
 import { getTokenByContract } from '../../soroban'
 import { useCustomTokens } from './use-custom-tokens'
 
 interface UseTokenParams {
-  address: string
+  address: StellarContractAddress | undefined
   enabled?: boolean
   keepPreviousData?: boolean
 }
@@ -22,7 +26,7 @@ export function useTokenWithCache({
         throw new Error('Address is required')
       }
 
-      const cachedToken = customTokens[address.toUpperCase()]
+      const cachedToken = customTokens[normalizeStellarAddress(address)]
       if (cachedToken) {
         return cachedToken
       }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/trustline/use-trustline.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/trustline/use-trustline.ts
@@ -6,6 +6,11 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import ms from 'ms'
 import { ChainId } from 'sushi'
+import {
+  type StellarAccountAddress,
+  type StellarContractAddress,
+  isStellarAccountAddress,
+} from 'sushi/stellar'
 import { useStellarWallet } from '~stellar/providers'
 import {
   checkTrustlineRequired,
@@ -18,14 +23,14 @@ import { getStellarTxnLink } from '../../utils/stellarchain-helpers'
 
 type TrustlineParams = {
   assetCode: string
-  assetIssuer: string
+  assetIssuer: StellarAccountAddress
   limit?: string
 }
 
 type TrustlineResult = {
   hasTrustline: boolean
   needsTrustline: boolean
-  issuer: string | null
+  issuer: StellarAccountAddress | null
 }
 
 const NO_TRUSTLINE_NEEDED: TrustlineResult = {
@@ -39,10 +44,10 @@ const NO_TRUSTLINE_NEEDED: TrustlineResult = {
  * Now uses dynamic lookup from Horizon if issuer is not known
  */
 async function checkTokenTrustline(
-  connectedAddress: string,
+  connectedAddress: StellarAccountAddress,
   code: string,
-  contract: string,
-  issuer: string,
+  contract: StellarContractAddress,
+  issuer: StellarAccountAddress | '',
 ): Promise<TrustlineResult> {
   // Use the new async function that can look up issuers dynamically
   const { required, issuer: resolvedIssuer } = await checkTrustlineRequired(
@@ -70,7 +75,10 @@ async function checkTokenTrustline(
 /**
  * Hook to check if a user has a trustline for a specific asset
  */
-export function useHasTrustline(assetCode: string, assetIssuer: string) {
+export function useHasTrustline(
+  assetCode: string,
+  assetIssuer: StellarAccountAddress,
+) {
   const { connectedAddress } = useStellarWallet()
 
   return useQuery({
@@ -188,8 +196,8 @@ export function useCreateTrustline() {
 type TokenTrustlineInfo =
   | {
       code: string
-      contract: string
-      issuer?: string
+      contract: StellarContractAddress
+      issuer: StellarAccountAddress | ''
     }
   | null
   | undefined
@@ -226,7 +234,9 @@ export function useNeedsTrustlines(tokens: TokenTrustlineInfo[]) {
             connectedAddress,
             token.code,
             token.contract,
-            token.issuer || '',
+            token.issuer && isStellarAccountAddress(token.issuer)
+              ? token.issuer
+              : '',
           )
         }),
       )
@@ -252,13 +262,13 @@ export function useNeedsTrustlines(tokens: TokenTrustlineInfo[]) {
  * Works with SAC-wrapped classic assets even if issuer wasn't pre-populated.
  */
 export function useNeedsTrustline(
-  assetCode: string,
-  assetContract: string,
-  assetIssuer?: string,
+  params: {
+    code: string
+    contract: StellarContractAddress
+    issuer: StellarAccountAddress | ''
+  } | null,
 ) {
-  const { results, isLoading } = useNeedsTrustlines([
-    { code: assetCode, contract: assetContract, issuer: assetIssuer },
-  ])
+  const { results, isLoading } = useNeedsTrustlines([params])
   const result = results[0] || NO_TRUSTLINE_NEEDED
 
   return {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/zap/use-zap.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/hooks/zap/use-zap.ts
@@ -9,6 +9,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { addMinutes } from 'date-fns'
 import { ChainId } from 'sushi'
+import type { StellarContractAddress } from 'sushi/stellar'
 import type { RouteWithTokens } from '~stellar/swap/lib/swap-get-route'
 import { calculateAmountOutMinimum } from '../../services/router-service'
 import { DEFAULT_TIMEOUT, contractAddresses } from '../../soroban'
@@ -28,7 +29,7 @@ import {
 import { getStellarTxnLink } from '../../utils/stellarchain-helpers'
 
 export interface UseZapParams {
-  poolAddress: string
+  poolAddress: StellarContractAddress
   tokenIn: Token
   amountIn: string
   tokenInDecimals: number
@@ -173,7 +174,7 @@ export const useZap = () => {
         )
       }
 
-      const poolsTouched = new Set<string>([
+      const poolsTouched = new Set<StellarContractAddress>([
         ...(routeToken0 ? routeToken0.pools : []),
         ...(routeToken1 ? routeToken1.pools : []),
         params.poolAddress,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/services/position-service.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/services/position-service.ts
@@ -4,6 +4,7 @@ import type {
   PositionTuple,
   UserPositionInfo,
 } from '@sushiswap/stellar-contract-binding-position-manager'
+import type { StellarContractAddress } from 'sushi/stellar'
 import {
   getPoolContractClient,
   getPositionManagerContractClient,
@@ -23,8 +24,8 @@ import {
 
 export interface PositionInfo {
   tokenId: number
-  token0: string
-  token1: string
+  token0: StellarContractAddress
+  token1: StellarContractAddress
   tickLower: number
   tickUpper: number
   liquidity: bigint
@@ -38,7 +39,7 @@ export interface CollectParams {
   recipient: string
   amount0Max: bigint
   amount1Max: bigint
-  poolAddress: string
+  poolAddress: StellarContractAddress
 }
 
 export interface CollectResult {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/services/swap-service.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/services/swap-service.ts
@@ -2,6 +2,7 @@ import * as StellarSdk from '@stellar/stellar-sdk'
 import { scValToBigInt } from '@stellar/stellar-sdk'
 import { DEFAULT_TIMEOUT } from '@stellar/stellar-sdk/contract'
 import { sub } from 'date-fns'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { contractAddresses } from '../soroban'
 import { getRouterContractClient } from '../soroban/client'
 import {
@@ -18,7 +19,7 @@ import {
  * Parameters for adding liquidity
  */
 export interface AddLiquidityParams {
-  poolAddress: string
+  poolAddress: StellarContractAddress
   token0Amount: string
   token1Amount: string
   token0Decimals: number
@@ -33,7 +34,7 @@ export interface AddLiquidityParams {
  * Parameters for single-hop swap
  */
 export interface SwapExactInputSingleParams {
-  pool: string
+  pool: StellarContractAddress
   tokenIn: string
   tokenOut: string
   fee: number
@@ -48,7 +49,7 @@ export interface SwapExactInputSingleParams {
  * Parameters for multi-hop swap
  */
 export interface SwapExactInputParams {
-  pools: string[]
+  pools: StellarContractAddress[]
   path: string[]
   fees: number[]
   recipient: string

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/dex-factory-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/dex-factory-helpers.ts
@@ -1,5 +1,9 @@
 import { Address } from '@stellar/stellar-sdk'
 import ms from 'ms'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { FEE_TIERS } from '../utils/ticks'
 import { getFactoryContractClient, getFactoryContractId } from './client'
 import { DEFAULT_TIMEOUT, isAddressLower } from './constants'
@@ -25,13 +29,13 @@ export async function createAndInitializePool({
   sourceAccount,
   signTransaction,
 }: {
-  tokenA: string
-  tokenB: string
+  tokenA: StellarContractAddress
+  tokenB: StellarContractAddress
   fee: number
   sqrtPriceX96: bigint
-  sourceAccount: string
+  sourceAccount: StellarAccountAddress
   signTransaction: (xdr: string) => Promise<string>
-}): Promise<{ poolAddress: string; txHash?: string }> {
+}): Promise<{ poolAddress: StellarContractAddress; txHash?: string }> {
   try {
     // Validate inputs
     if (!tokenA || !tokenB) {
@@ -110,7 +114,9 @@ export async function createAndInitializePool({
 
     if (txResult.status === 'SUCCESS' && txResult.returnValue !== undefined) {
       // Extract pool address from result
-      const poolAddress = Address.fromScVal(txResult.returnValue).toString()
+      const poolAddress = Address.fromScVal(
+        txResult.returnValue,
+      ).toString() as StellarContractAddress
 
       return {
         poolAddress,
@@ -190,11 +196,11 @@ export async function getPoolDirectSDK({
   fee,
   isLegacy = false,
 }: {
-  tokenA: string
-  tokenB: string
+  tokenA: StellarContractAddress
+  tokenB: StellarContractAddress
   fee: number
   isLegacy?: boolean
-}): Promise<string | null> {
+}): Promise<StellarContractAddress | null> {
   try {
     // Order tokens by decoded bytes - EXACTLY like the router and getPoolTransactionBuilder does
     // Note: Must compare decoded bytes, not base32 strings (base32 doesn't preserve byte ordering)
@@ -216,7 +222,9 @@ export async function getPoolDirectSDK({
       token_b: token1,
       fee: fee,
     })
-    const result = assembledTransaction.result
+    const result = assembledTransaction.result as
+      | StellarContractAddress
+      | undefined
 
     // Handle the result - it should be an Option<string>
     // where Option<T> is defined as T | undefined

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/pool-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/pool-helpers.ts
@@ -1,3 +1,8 @@
+import {
+  type StellarAccountAddress,
+  type StellarContractAddress,
+  isStellarContractAddress,
+} from 'sushi/stellar'
 import type { PoolInfo, PoolLiquidity, PoolReserves } from '../types/pool.type'
 import type { Token } from '../types/token.type'
 import { MAX_TICK_RANGE } from '../utils/ticks'
@@ -6,7 +11,7 @@ import { contractAddresses } from './contracts'
 import { getTokenBalance, getTokenByContract } from './token-helpers'
 
 export interface PoolBasicInfo {
-  address: string
+  address: StellarContractAddress
   tokenA: Token
   tokenB: Token
   fee: number
@@ -30,7 +35,7 @@ export interface ContractPoolData {
  * @param address - The pool contract address
  */
 export async function getPoolInfoFromContract(
-  address: string,
+  address: StellarContractAddress,
 ): Promise<ContractPoolData | null> {
   try {
     const poolLensContractClient = getPoolLensContractClient({
@@ -63,8 +68,8 @@ export async function getPoolInfoFromContract(
     } = poolData.state
 
     const [token0, token1] = await Promise.all([
-      getTokenByContract(token0Address),
-      getTokenByContract(token1Address),
+      getTokenByContract(token0Address as StellarContractAddress),
+      getTokenByContract(token1Address as StellarContractAddress),
     ])
 
     return {
@@ -90,7 +95,9 @@ export async function getPoolInfoFromContract(
  * @param address - The pool contract address
  * @returns Complete pool information with all fields populated
  */
-export async function getPoolInfo(address: string): Promise<PoolInfo | null> {
+export async function getPoolInfo(
+  address: StellarContractAddress,
+): Promise<PoolInfo | null> {
   try {
     const contractPoolInfo = await getPoolInfoFromContract(address)
 
@@ -142,8 +149,8 @@ export async function getPoolInfo(address: string): Promise<PoolInfo | null> {
  * @returns The balances for each token in the pool for the connected address
  */
 export async function getPoolBalances(
-  address: string,
-  connectedAddress: string,
+  address: StellarContractAddress,
+  connectedAddress: StellarAccountAddress,
 ): Promise<PoolReserves> {
   const config = await getPoolInfoFromContract(address)
 
@@ -226,7 +233,7 @@ export const formatPriceBound = (tick: number, bound: 'lower' | 'upper') => {
  * @returns Current sqrt price as BigInt
  */
 export async function getCurrentSqrtPrice(
-  poolAddress: string,
+  poolAddress: StellarContractAddress,
 ): Promise<bigint> {
   const poolLensContractClient = getPoolLensContractClient({
     contractId: contractAddresses.POOL_LENS,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/pool-initialization.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/pool-initialization.ts
@@ -1,3 +1,7 @@
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { getPoolContractClient } from './client'
 
 /**
@@ -6,7 +10,9 @@ import { getPoolContractClient } from './client'
  * @returns true if pool is initialized, false otherwise
  * @throws Error if there's an RPC/network error (not a "pool not initialized" error)
  */
-export async function isPoolInitialized(address: string): Promise<boolean> {
+export async function isPoolInitialized(
+  address: StellarContractAddress,
+): Promise<boolean> {
   try {
     const poolContractClient = getPoolContractClient({
       contractId: address,
@@ -47,9 +53,9 @@ export async function isPoolInitialized(address: string): Promise<boolean> {
  * @returns Result of the initialization transaction
  */
 export async function initializePool(
-  poolAddress: string,
+  poolAddress: StellarContractAddress,
   sqrtPriceX96: bigint,
-  publicKey: string,
+  publicKey: StellarAccountAddress,
 ) {
   const poolClient = getPoolContractClient({
     contractId: poolAddress,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/position-manager-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/position-manager-helpers.ts
@@ -1,4 +1,5 @@
 import * as StellarSdk from '@stellar/stellar-sdk'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { extractErrorMessage } from '../utils/error-helpers'
 import {
   type PoolOracleHints,
@@ -36,7 +37,7 @@ export async function mintPosition({
   signTransaction,
   signAuthEntry,
 }: {
-  poolAddress: string
+  poolAddress: StellarContractAddress
   recipient: string
   tickLower: number
   tickUpper: number
@@ -186,7 +187,7 @@ export async function increaseLiquidity({
   signTransaction,
   signAuthEntry,
 }: {
-  pool: string
+  pool: StellarContractAddress
   tokenId: number
   amount0Desired: bigint
   amount1Desired: bigint
@@ -313,7 +314,7 @@ export async function decreaseLiquidity({
   signAuthEntry,
   isLegacy = false,
 }: {
-  pool: string
+  pool: StellarContractAddress
   tokenId: number
   liquidity: bigint
   amount0Min: bigint

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/token-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/token-helpers.ts
@@ -1,4 +1,10 @@
 import type { AssembledTransaction } from '@stellar/stellar-sdk/contract'
+import {
+  type StellarAddress,
+  type StellarContractAddress,
+  isStellarContractAddress,
+  normalizeStellarAddress,
+} from 'sushi/stellar'
 import { staticTokens } from '../assets/token-assets'
 import type { Token } from '../types/token.type'
 import { formatAddress } from '../utils/format'
@@ -59,7 +65,7 @@ function findTokenInMap(
  * @returns A Token object
  */
 export async function getTokenByContract(
-  contract: string,
+  contract: StellarContractAddress,
   dynamicTokens?: Record<string, Token>,
 ): Promise<Token> {
   // Check dynamic tokens first (includes StellarExpert tokens)
@@ -80,7 +86,8 @@ export async function getTokenByContract(
   }
 
   // Fallback: fetch from chain
-  const canonicalContract = contract.toUpperCase()
+  const canonicalContract = normalizeStellarAddress(contract)
+
   try {
     const metadata = await getTokenMetadata(canonicalContract)
     return {
@@ -114,8 +121,8 @@ export async function getTokenByContract(
  * @returns The balance of the address
  */
 export async function getTokenBalance(
-  address: string,
-  tokenAddress: string,
+  address: StellarAddress,
+  tokenAddress: StellarContractAddress,
 ): Promise<bigint> {
   try {
     const tokenContractClient = getTokenContractClient({
@@ -149,7 +156,7 @@ export async function getTokenBalance(
  * @returns The balance of the address
  */
 export async function getTokenBalanceFromToken(
-  address: string,
+  address: StellarAddress,
   token: Token,
 ): Promise<bigint> {
   return getTokenBalance(address, token.contract)
@@ -163,9 +170,9 @@ export async function getTokenBalanceFromToken(
  * @returns The allowance amount
  */
 export async function getTokenAllowance(
-  owner: string,
-  spender: string,
-  tokenAddress: string,
+  owner: StellarAddress,
+  spender: StellarAddress,
+  tokenAddress: StellarContractAddress,
 ): Promise<bigint> {
   try {
     const tokenContractClient = getTokenContractClient({
@@ -197,9 +204,9 @@ export async function getTokenAllowance(
  * @returns The approval result
  */
 export async function approveToken(
-  spender: string,
+  spender: StellarAddress,
   amount: bigint,
-  tokenAddress: string,
+  tokenAddress: StellarContractAddress,
 ): Promise<AssembledTransaction<null>> {
   try {
     const tokenContractClient = getTokenContractClient({
@@ -234,9 +241,9 @@ export async function approveToken(
  * @returns The transfer result
  */
 export async function transferToken(
-  to: string,
+  to: StellarAddress,
   amount: bigint,
-  tokenAddress: string,
+  tokenAddress: StellarContractAddress,
 ): Promise<AssembledTransaction<null>> {
   try {
     const tokenContractClient = getTokenContractClient({
@@ -271,10 +278,10 @@ export async function transferToken(
  * @returns The transfer result
  */
 export async function transferFromToken(
-  from: string,
-  to: string,
+  from: StellarAddress,
+  to: StellarAddress,
   amount: bigint,
-  tokenAddress: string,
+  tokenAddress: StellarContractAddress,
 ): Promise<AssembledTransaction<null>> {
   try {
     const tokenContractClient = getTokenContractClient({
@@ -306,7 +313,7 @@ export async function transferFromToken(
  * @param tokenAddress - The token contract address
  * @returns Token metadata
  */
-async function getTokenMetadata(tokenAddress: string): Promise<{
+async function getTokenMetadata(tokenAddress: StellarContractAddress): Promise<{
   name: string
   symbol: string
   decimals: number
@@ -381,8 +388,8 @@ async function getTokenMetadata(tokenAddress: string): Promise<{
  * @returns True if balance is sufficient, false otherwise
  */
 export async function hasSufficientBalance(
-  address: string,
-  tokenAddress: string,
+  address: StellarAddress,
+  tokenAddress: StellarContractAddress,
   requiredAmount: bigint,
 ): Promise<boolean> {
   const balance = await getTokenBalance(address, tokenAddress)
@@ -398,9 +405,9 @@ export async function hasSufficientBalance(
  * @returns True if allowance is sufficient, false otherwise
  */
 export async function hasSufficientAllowance(
-  owner: string,
-  spender: string,
-  tokenAddress: string,
+  owner: StellarAddress,
+  spender: StellarAddress,
+  tokenAddress: StellarContractAddress,
   requiredAmount: bigint,
 ): Promise<boolean> {
   const allowance = await getTokenAllowance(owner, spender, tokenAddress)
@@ -414,9 +421,9 @@ export async function hasSufficientAllowance(
  * @returns Object mapping token addresses to balances
  */
 export async function getMultipleTokenBalances(
-  address: string,
-  tokenAddresses: string[],
-): Promise<Record<string, bigint>> {
+  address: StellarAddress,
+  tokenAddresses: StellarContractAddress[],
+): Promise<Record<StellarContractAddress, bigint>> {
   const balancePromises = tokenAddresses.map(async (tokenAddress) => {
     const balance = await getTokenBalance(address, tokenAddress)
     return { tokenAddress, balance }
@@ -429,7 +436,7 @@ export async function getMultipleTokenBalances(
       acc[tokenAddress] = balance
       return acc
     },
-    {} as Record<string, bigint>,
+    {} as Record<StellarContractAddress, bigint>,
   )
 }
 
@@ -441,10 +448,10 @@ export async function getMultipleTokenBalances(
  * @returns Object mapping token addresses to allowances
  */
 export async function getMultipleTokenAllowances(
-  owner: string,
-  spender: string,
-  tokenAddresses: string[],
-): Promise<Record<string, bigint>> {
+  owner: StellarAddress,
+  spender: StellarAddress,
+  tokenAddresses: StellarContractAddress[],
+): Promise<Record<StellarContractAddress, bigint>> {
   const allowancePromises = tokenAddresses.map(async (tokenAddress) => {
     const allowance = await getTokenAllowance(owner, spender, tokenAddress)
     return { tokenAddress, allowance }
@@ -457,7 +464,7 @@ export async function getMultipleTokenAllowances(
       acc[tokenAddress] = allowance
       return acc
     },
-    {} as Record<string, bigint>,
+    {} as Record<StellarContractAddress, bigint>,
   )
 }
 

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/transaction-retry-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/transaction-retry-helpers.ts
@@ -1,3 +1,4 @@
+import type { StellarContractAddress } from 'sushi/stellar'
 import {
   getOracleErrorMessage,
   isOracleFootprintError,
@@ -17,7 +18,7 @@ import {
  * @returns Result of the transaction
  */
 export async function executeTransactionWithRetry<T>(
-  poolAddresses: string[],
+  poolAddresses: StellarContractAddress[],
   operation: (hints: PoolOracleHints[]) => Promise<T>,
   maxRetries = 2,
 ): Promise<T> {
@@ -43,7 +44,7 @@ export async function executeTransactionWithRetry<T>(
  * @returns Array of results from each transaction
  */
 export async function executeTransactionsSequentially<T>(
-  poolAddresses: string[],
+  poolAddresses: StellarContractAddress[],
   operations: Array<(hints: PoolOracleHints[]) => Promise<T>>,
   maxRetries = 2,
 ): Promise<T[]> {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/trustline-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/trustline-helpers.ts
@@ -1,5 +1,10 @@
 import * as StellarSdk from '@stellar/stellar-sdk'
 import { Horizon } from '@stellar/stellar-sdk'
+import { isStellarAccountAddress } from 'sushi/stellar'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { HORIZON_URL, NETWORK_PASSPHRASE } from '../constants'
 
 const horizonServer = new Horizon.Server(HORIZON_URL)
@@ -17,15 +22,15 @@ export interface HorizonAssetInfo {
 /**
  * Cache for asset issuer lookups to avoid repeated API calls
  */
-const assetIssuerCache = new Map<string, string | null>()
+const assetIssuerCache = new Map<string, StellarAccountAddress | null>()
 
 /**
  * Look up asset info from StellarExpert by contract address
  * This is more reliable than looking up by asset code since it uses the exact contract
  */
 async function lookupAssetByContract(
-  contractAddress: string,
-): Promise<{ code: string; issuer: string } | null> {
+  contractAddress: StellarContractAddress,
+): Promise<{ code: string; issuer: StellarAccountAddress } | null> {
   try {
     // StellarExpert has an API to get asset info by contract address
     const response = await fetch(
@@ -46,14 +51,18 @@ async function lookupAssetByContract(
       const assetStr = data.asset
       if (typeof assetStr === 'string' && assetStr.includes('-')) {
         const [code, issuer] = assetStr.split('-')
-        if (code && issuer?.startsWith('G')) {
+        if (code && issuer && isStellarAccountAddress(issuer)) {
           return { code, issuer }
         }
       }
     }
 
     // Alternative: check if there's issuer info directly
-    if (data?.issuer && typeof data.issuer === 'string') {
+    if (
+      data?.issuer &&
+      typeof data.issuer === 'string' &&
+      isStellarAccountAddress(data.issuer)
+    ) {
       return { code: data.code || '', issuer: data.issuer }
     }
 
@@ -69,8 +78,8 @@ async function lookupAssetByContract(
  */
 async function lookupIssuerFromHorizon(
   assetCode: string,
-  contractAddress: string,
-): Promise<string | null> {
+  contractAddress: StellarContractAddress,
+): Promise<StellarAccountAddress | null> {
   try {
     // Query Horizon for assets with this code
     const assets = await horizonServer
@@ -94,7 +103,9 @@ async function lookupIssuerFromHorizon(
 
           // Compare with the contract address we're looking for
           if (sacContractId.toUpperCase() === contractAddress.toUpperCase()) {
-            return asset.asset_issuer
+            if (isStellarAccountAddress(asset.asset_issuer)) {
+              return asset.asset_issuer
+            }
           }
         } catch {}
       }
@@ -120,17 +131,17 @@ async function lookupIssuerFromHorizon(
  * @returns Object with whether trustline is required and the issuer if found
  */
 export async function checkTrustlineRequired(
-  contractAddress: string,
+  contractAddress: StellarContractAddress,
   assetCode: string,
-  assetIssuer?: string,
-): Promise<{ required: boolean; issuer: string | null }> {
+  assetIssuer?: StellarAccountAddress | '',
+): Promise<{ required: boolean; issuer: StellarAccountAddress | null }> {
   // XLM (native) never needs a trustline
   if (assetCode === 'XLM' || assetCode === 'native') {
     return { required: false, issuer: null }
   }
 
   // If we already have an issuer, use it
-  if (assetIssuer?.startsWith('G')) {
+  if (assetIssuer) {
     return { required: true, issuer: assetIssuer }
   }
 
@@ -182,7 +193,7 @@ export async function checkTrustlineRequired(
  */
 export async function getAssetInfo(
   assetCode: string,
-  assetIssuer?: string,
+  assetIssuer?: StellarAccountAddress,
 ): Promise<HorizonAssetInfo | null> {
   try {
     if (!assetIssuer) {
@@ -237,9 +248,9 @@ export async function getAssetInfo(
  * @param assetIssuer - Issuer account (G... address)
  */
 export async function hasTrustline(
-  userAddress: string,
+  userAddress: StellarAccountAddress,
   assetCode: string,
-  assetIssuer: string,
+  assetIssuer: StellarAccountAddress,
 ): Promise<boolean> {
   try {
     // Fetch account details using publicKey
@@ -267,9 +278,9 @@ export async function hasTrustline(
  * This is required before a user can receive or swap native Stellar assets
  */
 export async function createTrustline(
-  userAddress: string,
+  userAddress: StellarAccountAddress,
   assetCode: string,
-  assetIssuer: string,
+  assetIssuer: StellarAccountAddress,
   signTransaction: (xdr: string) => Promise<string>,
   limit?: string,
 ): Promise<{ success: boolean; txHash?: string; error?: string }> {
@@ -402,10 +413,12 @@ export async function createTrustline(
 /**
  * Get all trustlines for a user
  */
-export async function getUserTrustlines(userAddress: string): Promise<
+export async function getUserTrustlines(
+  userAddress: StellarAccountAddress,
+): Promise<
   Array<{
     assetCode: string
-    assetIssuer: string
+    assetIssuer: StellarAccountAddress
     balance: string
     limit: string
   }>
@@ -419,7 +432,12 @@ export async function getUserTrustlines(userAddress: string): Promise<
           b.asset_type !== 'native' && 'asset_code' in b && 'asset_issuer' in b,
       )
       .map((b) => {
-        if ('asset_code' in b && 'asset_issuer' in b && 'limit' in b) {
+        if (
+          'asset_code' in b &&
+          'asset_issuer' in b &&
+          'limit' in b &&
+          isStellarAccountAddress(b.asset_issuer)
+        ) {
           return {
             assetCode: b.asset_code,
             assetIssuer: b.asset_issuer,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/xlm-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/soroban/xlm-helpers.ts
@@ -1,3 +1,4 @@
+import type { StellarAccountAddress } from 'sushi/stellar'
 import { getTokenContractClient } from './client'
 import { contractAddresses } from './contracts'
 
@@ -6,7 +7,9 @@ import { contractAddresses } from './contracts'
  * @param address The address to get the balance of
  * @returns The balance of the address
  */
-export const getXlmBalance = async (address: string): Promise<bigint> => {
+export const getXlmBalance = async (
+  address: StellarAccountAddress,
+): Promise<bigint> => {
   try {
     const xlmContractClient = getTokenContractClient({
       contractId: contractAddresses.TOKENS.XLM,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/types/contract-addresses.type.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/types/contract-addresses.type.ts
@@ -1,17 +1,17 @@
-type ContractAddress = string
+import type { StellarContractAddress } from 'sushi/stellar'
 
 export type ContractAddresses = {
-  FACTORY: ContractAddress
-  LEGACY_FACTORY?: ContractAddress
-  ROUTER: ContractAddress
-  POSITION_MANAGER: ContractAddress
-  LEGACY_POSITION_MANAGER?: ContractAddress
-  TOKEN_DESCRIPTOR: ContractAddress
-  POOL_LENS: ContractAddress
-  FLASH_EXECUTOR: ContractAddress
-  ZAP_ROUTER: ContractAddress
+  FACTORY: StellarContractAddress
+  LEGACY_FACTORY?: StellarContractAddress
+  ROUTER: StellarContractAddress
+  POSITION_MANAGER: StellarContractAddress
+  LEGACY_POSITION_MANAGER?: StellarContractAddress
+  TOKEN_DESCRIPTOR: StellarContractAddress
+  POOL_LENS: StellarContractAddress
+  FLASH_EXECUTOR: StellarContractAddress
+  ZAP_ROUTER: StellarContractAddress
   POOL_WASM_HASH: string
   TOKENS: {
-    XLM: ContractAddress
+    XLM: StellarContractAddress
   }
 }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/types/pool.type.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/types/pool.type.ts
@@ -1,3 +1,4 @@
+import type { StellarContractAddress } from 'sushi/stellar'
 import type { Token } from './token.type'
 
 export interface PoolLiquidity {
@@ -20,7 +21,7 @@ export interface PoolBalances {
 
 export interface PoolInfo {
   name: string
-  address: string
+  address: StellarContractAddress
   token0: Token
   token1: Token
   fee: number

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/types/token.type.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/types/token.type.ts
@@ -1,8 +1,13 @@
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
+
 // See https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0042.md
 export interface Token {
   code: string
-  issuer: string
-  contract: string
+  issuer: StellarAccountAddress | ''
+  contract: StellarContractAddress
   name: string
   org: string
   domain?: string

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/utils/slot-hint-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/utils/slot-hint-helpers.ts
@@ -1,5 +1,6 @@
 import type { OracleHints } from '@sushiswap/stellar-contract-binding-pool'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { getPoolContractClient } from '../soroban/client'
 
 export type PoolOracleHints = {
@@ -14,7 +15,7 @@ export type PoolOracleHints = {
  * @returns Oracle hints containing slot and checkpoint
  */
 export async function fetchOracleHints(
-  poolAddress: string,
+  poolAddress: StellarContractAddress,
   maxRetries = 2,
 ): Promise<PoolOracleHints> {
   let lastError: Error | null = null
@@ -109,7 +110,7 @@ export function isObservationTooOldError(error: unknown): boolean {
  * @returns Result of the operation
  */
 export async function executeWithOracleHints<T>(
-  poolAddresses: string[],
+  poolAddresses: StellarContractAddress[],
   operation: (hints: PoolOracleHints[]) => Promise<T>,
   maxRetries = 2,
 ): Promise<T> {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/utils/stellarchain-helpers.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/lib/utils/stellarchain-helpers.ts
@@ -1,6 +1,12 @@
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { IS_FUTURENET } from '~stellar/_common/lib/constants'
 
-export const getStellarAddressLink = (address: string): string => {
+export const getStellarAddressLink = (
+  address: StellarAccountAddress,
+): string => {
   if (IS_FUTURENET) {
     return `https://futurenet.steexp.com/account/${address}`
   } else {
@@ -8,7 +14,9 @@ export const getStellarAddressLink = (address: string): string => {
   }
 }
 
-export const getStellarContractLink = (contractId: string): string => {
+export const getStellarContractLink = (
+  contractId: StellarContractAddress,
+): string => {
   if (IS_FUTURENET) {
     return `https://futurenet.steexp.com/contract/${contractId}`
   } else {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/PoolDetails/ManageLiquidityCard.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/PoolDetails/ManageLiquidityCard.tsx
@@ -17,6 +17,7 @@ import type React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { Checker } from 'src/lib/wagmi/systems/Checker'
 import { useAccount } from 'src/lib/wallet'
+import type { StellarAccountAddress } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import { ToggleZapCard } from '~evm/[chainId]/pool/_ui/toggle-zap-card'
 import { useRemoveLiquidity } from '~stellar/_common/lib/hooks/liquidity/use-remove-liquidity'
@@ -85,25 +86,25 @@ export const ManageLiquidityCard: React.FC<ManageLiquidityCardProps> = ({
     needsTrustline: needsToken0Trustline,
     isLoading: isLoadingToken0Trustline,
     issuer: token0ResolvedIssuer,
-  } = useNeedsTrustline(
-    pool.token0.code,
-    pool.token0.contract,
-    pool.token0.issuer,
-  )
+  } = useNeedsTrustline({
+    code: pool.token0.code,
+    contract: pool.token0.contract,
+    issuer: pool.token0.issuer,
+  })
   const {
     needsTrustline: needsToken1Trustline,
     isLoading: isLoadingToken1Trustline,
     issuer: token1ResolvedIssuer,
-  } = useNeedsTrustline(
-    pool.token1.code,
-    pool.token1.contract,
-    pool.token1.issuer,
-  )
+  } = useNeedsTrustline({
+    code: pool.token1.code,
+    contract: pool.token1.contract,
+    issuer: pool.token1.issuer,
+  })
   const isLoadingTrustlines =
     isLoadingToken0Trustline || isLoadingToken1Trustline
   // Use the resolved issuers from the trustline check (looked up from Horizon if not already known)
   const tokensNeedingTrustline = useMemo(() => {
-    const tokens: Array<{ code: string; issuer: string }> = []
+    const tokens: Array<{ code: string; issuer: StellarAccountAddress }> = []
     if (needsToken0Trustline && token0ResolvedIssuer) {
       tokens.push({ code: pool.token0.code, issuer: token0ResolvedIssuer })
     }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/PoolDetails/PoolHeader.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/PoolDetails/PoolHeader.tsx
@@ -10,6 +10,7 @@ import {
   SkeletonText,
   typographyVariants,
 } from '@sushiswap/ui'
+import type { StellarContractAddress } from 'sushi/stellar'
 import type { PoolInfo } from '~stellar/_common/lib/types/pool.type'
 import { formatAddress, formatFee } from '~stellar/_common/lib/utils/format'
 import { usePoolInfo } from '../../lib/hooks/pool/use-pool-info'
@@ -19,7 +20,7 @@ import { TokenIcon } from '../General/TokenIcon'
 interface PoolHeaderProps {
   pool?: PoolInfo | null
   backUrl: string
-  address?: string
+  address?: StellarContractAddress
 }
 
 export const PoolHeader = ({ pool, backUrl, address }: PoolHeaderProps) => {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/Swap/simple/simple-swap-execute-button.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/Swap/simple/simple-swap-execute-button.tsx
@@ -45,9 +45,13 @@ export const SimpleSwapExecuteButton = () => {
   // Note: Input token (token0) doesn't need trustline check - user must already have it to swap FROM it
   const { needsTrustline: needsToken1Trustline, issuer: token1ResolvedIssuer } =
     useNeedsTrustline(
-      token1?.code || '',
-      token1?.contract || '',
-      token1?.issuer,
+      token1
+        ? {
+            code: token1.code,
+            contract: token1.contract,
+            issuer: token1.issuer,
+          }
+        : null,
     )
   const [, { slippageTolerance }] = useSlippageTolerance(
     SlippageToleranceStorageKey.Swap,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/Trustline/CreateTrustlineButton.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/Trustline/CreateTrustlineButton.tsx
@@ -10,10 +10,11 @@ import {
   HoverCardTrigger,
 } from '@sushiswap/ui'
 import { useState } from 'react'
+import type { StellarAccountAddress } from 'sushi/stellar'
 import { useCreateTrustline } from '~stellar/_common/lib/hooks/trustline/use-trustline'
 
 interface CreateTrustlineButtonProps extends ButtonProps {
-  tokens: Array<{ code: string; issuer: string }>
+  tokens: Array<{ code: string; issuer: StellarAccountAddress }>
 }
 
 export const CreateTrustlineButton = ({

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/token-selector/token-selector.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/token-selector/token-selector.tsx
@@ -21,6 +21,11 @@ import React, {
 } from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { FixedSizeList } from 'react-window'
+import {
+  type StellarContractAddress,
+  isStellarContractAddress,
+  normalizeStellarAddress,
+} from 'sushi/stellar'
 import { useCommonTokens } from '~stellar/_common/lib/hooks/token/use-common-tokens'
 import { useCustomTokens } from '~stellar/_common/lib/hooks/token/use-custom-tokens'
 import { useSortedTokenList } from '~stellar/_common/lib/hooks/token/use-sorted-token-list'
@@ -58,22 +63,22 @@ export default function TokenSelector({
   const { data: customTokens, mutate: customTokenMutate } = useCustomTokens()
   const { data: queryToken, isLoading: isLoadingQueryToken } =
     useTokenWithCache({
-      address: query,
-      enabled: StrKey.isValidContract(query),
+      address: isStellarContractAddress(query) ? query : undefined,
+      enabled: isStellarContractAddress(query),
       keepPreviousData: false,
     })
 
   // Merge common tokens (from StellarExpert + hardcoded) into the main token map
   const allTokens = useMemo(() => {
-    const merged = {} as Record<string, Token>
+    const merged = {} as Record<StellarContractAddress, Token>
     if (customTokens) {
       Object.entries(customTokens).forEach(([contract, token]) => {
-        merged[contract] = token
+        merged[contract as StellarContractAddress] = token
       })
     }
     if (commonTokens) {
       Object.entries(commonTokens).forEach(([contract, token]) => {
-        merged[contract] = token
+        merged[contract as StellarContractAddress] = token
       })
     }
     return merged
@@ -81,7 +86,7 @@ export default function TokenSelector({
 
   const { data: tokenBalances } = useTokenBalancesMap(
     connectedAddress,
-    Object.keys(allTokens),
+    Object.keys(allTokens) as StellarContractAddress[],
   )
 
   const { data: sortedTokenList } = useSortedTokenList({
@@ -190,14 +195,15 @@ export default function TokenSelector({
               'data-[state=active]:block data-[state=active]:flex-1 data-[state=inactive]:hidden',
             )}
           >
-            {queryToken && !allTokens[queryToken.contract.toUpperCase()] && (
-              <TokenSelectorImportRow
-                token={queryToken}
-                onImport={() => {
-                  queryToken && handleImport(queryToken)
-                }}
-              />
-            )}
+            {queryToken &&
+              !allTokens[normalizeStellarAddress(queryToken.contract)] && (
+                <TokenSelectorImportRow
+                  token={queryToken}
+                  onImport={() => {
+                    queryToken && handleImport(queryToken)
+                  }}
+                />
+              )}
             <AutoSizer disableWidth>
               {({ height }: { height: number }) => (
                 <FixedSizeList

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/legacy-positions/migrate-banner.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/legacy-positions/migrate-banner.tsx
@@ -28,7 +28,7 @@ export const MigrateBanner: FC = () => {
         same position and price range.
       </p>
       <p className="font-bold text-md text-yellow-950">
-        If you are unable to withdrawal your funds, please{' '}
+        If you are unable to withdraw your funds, please{' '}
         <LinkExternal
           href={'https://sushi.com/discord'}
           target="_blank"

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/legacy-positions/table/LegacyPositionMigrateCell.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/legacy-positions/table/LegacyPositionMigrateCell.tsx
@@ -2,6 +2,7 @@ import { useLocalStorage } from '@sushiswap/hooks'
 import { createErrorToast } from '@sushiswap/notifications'
 import { Button } from '@sushiswap/ui'
 import { useState } from 'react'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import {
   useAddLiquidity,
@@ -90,7 +91,7 @@ export const LegacyPositionMigrateCell = ({
         })
       }
 
-      let newPoolAddress: string
+      let newPoolAddress: StellarContractAddress
       if (existingNewPoolAddress && isExistingNewPoolInitialized === true) {
         newPoolAddress = existingNewPoolAddress
       } else {

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/pool/[address]/layout.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/pool/[address]/layout.tsx
@@ -1,5 +1,7 @@
 import { Container } from '@sushiswap/ui'
 import { headers } from 'next/headers'
+import { notFound } from 'next/navigation'
+import { isStellarContractAddress } from 'sushi/stellar'
 import { PoolHeader } from '~stellar/_common/ui/PoolDetails/PoolHeader'
 
 export default async function PoolLayout(props: {
@@ -10,6 +12,9 @@ export default async function PoolLayout(props: {
   const params = await props.params
 
   const address = decodeURIComponent(params.address)
+  if (!isStellarContractAddress(address)) {
+    return notFound()
+  }
 
   const headersList = await headers()
   const referer = headersList.get('referer')

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/pool/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/pool/[address]/page.tsx
@@ -9,8 +9,13 @@ import {
   LinkInternal,
   SkeletonBox,
 } from '@sushiswap/ui'
+import { notFound } from 'next/navigation'
 import React, { use } from 'react'
 import { Checker } from 'src/lib/wagmi/systems/Checker'
+import {
+  type StellarContractAddress,
+  isStellarContractAddress,
+} from 'sushi/stellar'
 import { usePoolInfo } from '~stellar/_common/lib/hooks/pool/use-pool-info'
 import { usePoolInitialized } from '~stellar/_common/lib/hooks/pool/use-pool-initialized'
 import {
@@ -21,13 +26,17 @@ import { MyPosition } from '~stellar/_common/ui/PoolDetails/MyPosition'
 
 interface PoolPageProps {
   params: Promise<{
-    address: string
+    address: StellarContractAddress
   }>
 }
 
 export default function PoolPage({ params }: PoolPageProps) {
   const resolvedParams = use(params)
   const address = decodeURIComponent(resolvedParams.address)
+  if (!isStellarContractAddress(address)) {
+    notFound()
+  }
+
   const {
     data: pool,
     isPending: isPendingPool,

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/pool/add/page.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/pool/add/page.tsx
@@ -5,6 +5,10 @@ import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { Checker } from 'src/lib/wagmi/systems/Checker'
 import { useAccount } from 'src/lib/wallet'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from 'sushi/stellar'
 import { formatUnits } from 'viem'
 import {
   useGetPool,
@@ -95,24 +99,32 @@ export default function AddPoolPage() {
     isLoading: isLoadingToken0Trustline,
     issuer: token0ResolvedIssuer,
   } = useNeedsTrustline(
-    orderedToken0?.code || '',
-    orderedToken0?.contract || '',
-    orderedToken0?.issuer,
+    orderedToken0
+      ? {
+          code: orderedToken0.code,
+          contract: orderedToken0.contract,
+          issuer: orderedToken0.issuer,
+        }
+      : null,
   )
   const {
     needsTrustline: needsToken1Trustline,
     isLoading: isLoadingToken1Trustline,
     issuer: token1ResolvedIssuer,
   } = useNeedsTrustline(
-    orderedToken1?.code || '',
-    orderedToken1?.contract || '',
-    orderedToken1?.issuer,
+    orderedToken1
+      ? {
+          code: orderedToken1.code,
+          contract: orderedToken1.contract,
+          issuer: orderedToken1.issuer,
+        }
+      : null,
   )
   const isLoadingTrustlines =
     isLoadingToken0Trustline || isLoadingToken1Trustline
   // Use the resolved issuers from the trustline check (looked up from Horizon if not already known)
   const tokensNeedingTrustline = useMemo(() => {
-    const tokens: Array<{ code: string; issuer: string }> = []
+    const tokens: Array<{ code: string; issuer: StellarAccountAddress }> = []
     if (needsToken0Trustline && orderedToken0 && token0ResolvedIssuer) {
       tokens.push({ code: orderedToken0.code, issuer: token0ResolvedIssuer })
     }
@@ -251,7 +263,7 @@ export default function AddPoolPage() {
       }
 
       try {
-        let poolAddress: string
+        let poolAddress: StellarContractAddress
 
         if (existingPoolAddress && poolInitialized === true) {
           poolAddress = existingPoolAddress

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/swap/lib/hooks/use-best-route.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/swap/lib/hooks/use-best-route.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { QuoteService } from '~stellar/_common/lib/services/quote-service'
 import { getTokenByContract } from '~stellar/_common/lib/soroban/token-helpers'
 import type { Token } from '~stellar/_common/lib/types/token.type'
@@ -13,9 +14,9 @@ interface UseBestRouteParams {
 }
 
 interface CandidateRoute {
-  path: string[]
+  path: StellarContractAddress[]
   fees: number[]
-  pools: string[]
+  pools: StellarContractAddress[]
   vertices: Vertex[]
 }
 
@@ -23,9 +24,9 @@ interface CandidateRoute {
  * Find all candidate routes between two tokens using the pool graph
  */
 function findCandidateRoutes(
-  tokenIn: string,
-  tokenOut: string,
-  tokenGraph: Map<string, string[]>,
+  tokenIn: StellarContractAddress,
+  tokenOut: StellarContractAddress,
+  tokenGraph: Map<StellarContractAddress, StellarContractAddress[]>,
   vertices: Map<string, Vertex[]>,
   maxHops = 3,
 ): CandidateRoute[] {
@@ -33,11 +34,11 @@ function findCandidateRoutes(
 
   // DFS to find all paths
   function dfs(
-    current: string,
-    target: string,
+    current: StellarContractAddress,
+    target: StellarContractAddress,
     visited: Set<string>,
-    path: string[],
-    poolPath: string[],
+    path: StellarContractAddress[],
+    poolPath: StellarContractAddress[],
     feePath: number[],
     vertexPath: Vertex[],
     depth: number,
@@ -161,7 +162,7 @@ export async function getBestRoute({
   amountIn: bigint
   poolGraphData: {
     vertices: Map<string, Vertex[]>
-    tokenGraph: Map<string, string[]>
+    tokenGraph: Map<StellarContractAddress, StellarContractAddress[]>
   }
 }): Promise<RouteWithTokens | null> {
   try {
@@ -315,7 +316,7 @@ export function useBestRoute({
   // Build additional tokens list from swap input/output
   // This ensures the pool graph includes routes for the selected tokens
   const additionalTokens = [tokenIn?.contract, tokenOut?.contract].filter(
-    (t): t is string => !!t,
+    (t): t is NonNullable<typeof t> => Boolean(t),
   )
 
   // Get the pool graph, augmented with input/output tokens
@@ -334,7 +335,7 @@ export function useBestRoute({
     ],
     queryFn: async (): Promise<RouteWithTokens | null> => {
       if (!tokenIn || !tokenOut || !poolGraphData || amountIn === 0n) {
-        return null
+        throw new Error('Invalid parameters for finding best route')
       }
 
       return await getBestRoute({

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/swap/lib/swap-get-route/types.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/swap/lib/swap-get-route/types.ts
@@ -1,3 +1,4 @@
+import type { StellarContractAddress } from 'sushi/stellar'
 import type { Token } from '~stellar/_common/lib/types/token.type'
 
 /**
@@ -5,9 +6,9 @@ import type { Token } from '~stellar/_common/lib/types/token.type'
  */
 export interface Vertex {
   pair: string // "tokenA|||tokenB"
-  poolAddress: string
-  token0: string
-  token1: string
+  poolAddress: StellarContractAddress
+  token0: StellarContractAddress
+  token1: StellarContractAddress
   reserve0: bigint
   reserve1: bigint
   fee: number
@@ -21,7 +22,7 @@ export interface Vertex {
  */
 export interface Route {
   route: string[] // Array of token addresses forming the path
-  pools: string[] // Array of pool addresses used
+  pools: StellarContractAddress[] // Array of pool addresses used
   fees: number[] // Array of fee tiers
   amountOut: bigint
   priceImpact: number

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/swap/lib/swap-get-route/use-pool-graph.ts
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/swap/lib/swap-get-route/use-pool-graph.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
 import { useMemo } from 'react'
+import type { StellarContractAddress } from 'sushi/stellar'
 import { staticTokens } from '~stellar/_common/lib/assets/token-assets'
 import { getFees } from '~stellar/_common/lib/soroban'
 import {
@@ -18,23 +19,23 @@ type GetPoolsByTokenPairsBatchedParams = Array<{
 }>
 
 type PoolData = {
-  token0: string
-  token1: string
+  token0: StellarContractAddress
+  token1: StellarContractAddress
   tick: number
   sqrtPriceX96: bigint
   liquidity: bigint
-  poolAddress: string
+  poolAddress: StellarContractAddress
   fee: number
 }
 
 interface PoolGraphData {
   vertices: Map<string, Vertex[]>
-  tokenGraph: Map<string, string[]>
+  tokenGraph: Map<StellarContractAddress, StellarContractAddress[]>
 }
 
 interface UsePoolGraphParams {
   /** Additional token addresses to include in the graph (e.g., swap input/output tokens) */
-  additionalTokens?: string[]
+  additionalTokens?: StellarContractAddress[]
 }
 
 const getPoolsByTokenPairsBatched = async (
@@ -189,7 +190,10 @@ function useBasePoolGraph() {
     queryFn: async () => {
       // Store arrays of vertices per token pair to handle multiple fee tiers
       const vertices = new Map<string, Vertex[]>()
-      const tokenGraph = new Map<string, string[]>()
+      const tokenGraph = new Map<
+        StellarContractAddress,
+        StellarContractAddress[]
+      >()
 
       try {
         // Get factory client to discover pools
@@ -242,7 +246,10 @@ function useBasePoolGraph() {
         console.error('Error building pool graph:', error)
         return {
           vertices: new Map<string, Vertex[]>(),
-          tokenGraph: new Map<string, string[]>(),
+          tokenGraph: new Map<
+            StellarContractAddress,
+            StellarContractAddress[]
+          >(),
         }
       }
     },
@@ -264,7 +271,7 @@ async function augmentPoolGraph({
   additionalTokens,
 }: {
   baseGraph: PoolGraphData
-  additionalTokens: string[]
+  additionalTokens: StellarContractAddress[]
 }): Promise<PoolGraphData> {
   // Filter out additional tokens that are already in the base graph
   const baseTokens = Array.from(baseGraph.tokenGraph.keys())
@@ -389,7 +396,10 @@ export function usePoolGraph({
       if (!baseGraph) {
         return {
           vertices: new Map<string, Vertex[]>(),
-          tokenGraph: new Map<string, string[]>(),
+          tokenGraph: new Map<
+            StellarContractAddress,
+            StellarContractAddress[]
+          >(),
         }
       }
 

--- a/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-tokens/portfolio-stellar-tokens.tsx
+++ b/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-tokens/portfolio-stellar-tokens.tsx
@@ -8,14 +8,14 @@ import { useQuery } from '@tanstack/react-query'
 import { Fragment, useMemo } from 'react'
 import { useAccount } from 'src/lib/wallet'
 import { formatPercent, formatUSD } from 'sushi'
-import type { StellarAddress, StellarChainId } from 'sushi/stellar'
+import type { StellarAccountAddress } from 'sushi/stellar'
 import { useStablePrice } from '~stellar/_common/lib/hooks/price/use-stable-price'
 import { getStellarPortfolioWallet } from '~stellar/_common/lib/hooks/token/get-stellar-portfolio-wallet'
 import { TokenIcon } from '~stellar/_common/ui/General/TokenIcon'
 import { PortfolioInfoRow } from '../portfolio-info-row'
 
 function usePortfolioStellarWallet(
-  address: StellarAddress | undefined,
+  address: StellarAccountAddress | undefined,
   refetchInterval?: 600_000,
 ) {
   return useQuery({

--- a/apps/web/src/lib/hooks/react-query/cross-chain-trade/useCrossChainTradeRoutes.ts
+++ b/apps/web/src/lib/hooks/react-query/cross-chain-trade/useCrossChainTradeRoutes.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
 import type { XSwapSupportedChainId } from 'src/config'
+import type { WalletAddressFor } from 'src/lib/wallet'
 import { type Amount, type Percent, getNativeAddress } from 'sushi'
 import type { CrossChainRoutesResponse } from '~evm/api/cross-chain/routes/route'
 
@@ -10,7 +11,7 @@ export interface UseCrossChainTradeRoutesParms<
 > {
   fromAmount?: Amount<CurrencyFor<TChainId0>>
   toToken?: CurrencyFor<TChainId1>
-  fromAddress?: AddressFor<TChainId0>
+  fromAddress?: WalletAddressFor<TChainId0>
   toAddress?: AddressFor<TChainId1>
   slippage: Percent
   order?: 'CHEAPEST' | 'FASTEST'

--- a/apps/web/src/lib/wagmi/components/token-selector/hooks/use-my-tokens.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/hooks/use-my-tokens.ts
@@ -7,6 +7,7 @@ import { useCustomTokens } from '@sushiswap/hooks'
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
 import { useMemo } from 'react'
+import type { WalletAddressFor } from 'src/lib/wallet'
 import { type AddressFor, Amount, getNativeAddress } from 'sushi'
 import {
   type EvmAddress,
@@ -28,7 +29,7 @@ import type { Address } from 'viem'
 
 interface UseMyTokens<TChainId extends TokenListChainId> {
   chainId: TChainId | undefined
-  account?: AddressFor<TChainId>
+  account?: WalletAddressFor<TChainId>
   includeNative?: boolean
 }
 

--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-custom-list.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-custom-list.tsx
@@ -1,6 +1,7 @@
 import { isTokenListChainId } from '@sushiswap/graph-client/data-api'
 import { List } from '@sushiswap/ui'
 import { useMemo } from 'react'
+import type { WalletAddressFor } from 'src/lib/wallet'
 import type { EvmAddress, EvmCurrency, EvmNative } from 'sushi/evm'
 import type { EvmChainId } from 'sushi/evm'
 import type { SvmChainId } from 'sushi/svm'
@@ -11,7 +12,7 @@ import { TokenSelectorCurrencyList } from './common/token-selector-currency-list
 interface TokenSelectorCustomList<TChainId extends EvmChainId | SvmChainId> {
   currencies: Readonly<CurrencyFor<TChainId, { approved?: boolean }>[]>
   chainId: TChainId
-  account?: AddressFor<TChainId>
+  account?: WalletAddressFor<TChainId>
   selected: CurrencyFor<TChainId> | undefined
   onSelect(currency: CurrencyFor<TChainId>): void
   search?: string

--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-my-tokens.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-my-tokens.tsx
@@ -1,8 +1,6 @@
 import type { TokenListChainId } from '@sushiswap/graph-client/data-api'
 import { List } from '@sushiswap/ui'
 import { useAccount } from 'src/lib/wallet'
-import type { EvmChainId } from 'sushi/evm'
-import { useConnection } from 'wagmi'
 import { usePrices } from '~evm/_common/ui/price-provider/price-provider/use-prices'
 import { useMyTokens } from '../hooks/use-my-tokens'
 import {

--- a/apps/web/src/lib/wagmi/components/token-selector/token-selector-states.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-selector-states.tsx
@@ -5,6 +5,7 @@ import {
   isTrendingTokensChainId,
 } from '@sushiswap/graph-client/data-api'
 import { useMemo } from 'react'
+import type { WalletAddressFor } from 'src/lib/wallet'
 import { EVM_DEFAULT_BASES, type EvmChainId, isEvmChainId } from 'sushi/evm'
 import { SVM_DEFAULT_BASES, type SvmChainId, isSvmChainId } from 'sushi/svm'
 import { useMyTokens } from './hooks/use-my-tokens'
@@ -19,7 +20,7 @@ import { TokenSelectorTrendingTokens } from './token-lists/token-selector-trendi
 interface TokenSelectorStates<TChainId extends EvmChainId | SvmChainId> {
   selected: CurrencyFor<TChainId> | undefined
   chainId: TChainId
-  account?: AddressFor<TChainId>
+  account?: WalletAddressFor<TChainId>
   onSelect(currency: CurrencyFor<TChainId>): void
   onShowInfo(currency: CurrencyFor<TChainId> | false): void
   currencies?: CurrencyFor<TChainId, { approved?: boolean }>[]

--- a/apps/web/src/lib/wallet/hooks/use-account.ts
+++ b/apps/web/src/lib/wallet/hooks/use-account.ts
@@ -6,14 +6,18 @@ import type { StellarChainId } from 'sushi/stellar'
 import type { SvmChainId } from 'sushi/svm'
 import { getNamespaceForChainId } from '../namespaces/namespace-for-chain-id'
 import { useWalletContext } from '../provider'
-import type { ChainIdForNamespace, WalletNamespace } from '../types'
+import type {
+  ChainIdForNamespace,
+  WalletAddressFor,
+  WalletNamespace,
+} from '../types'
 
 export function useAccount<TNamespace extends WalletNamespace>(
   namespace?: TNamespace,
-): AddressFor<ChainIdForNamespace<TNamespace>> | undefined
+): WalletAddressFor<ChainIdForNamespace<TNamespace>> | undefined
 export function useAccount<
   TChainId extends EvmChainId | SvmChainId | StellarChainId,
->(chainId: TChainId): AddressFor<TChainId> | undefined
+>(chainId: TChainId): WalletAddressFor<TChainId> | undefined
 export function useAccount(
   filter?: EvmChainId | SvmChainId | StellarChainId | WalletNamespace,
 ) {

--- a/apps/web/src/lib/wallet/hooks/use-accounts.ts
+++ b/apps/web/src/lib/wallet/hooks/use-accounts.ts
@@ -2,7 +2,11 @@
 
 import { useMemo } from 'react'
 import { useWalletContext } from '../provider'
-import type { ChainIdForNamespace, WalletNamespace } from '../types'
+import type {
+  ChainIdForNamespace,
+  WalletAddressFor,
+  WalletNamespace,
+} from '../types'
 
 export function useAccounts() {
   const { connections } = useWalletContext()
@@ -13,7 +17,9 @@ export function useAccounts() {
     ) => {
       for (const c of connections) {
         if (c.namespace !== namespace) continue
-        return c.account as AddressFor<ChainIdForNamespace<typeof namespace>>
+        return c.account as WalletAddressFor<
+          ChainIdForNamespace<typeof namespace>
+        >
       }
       return undefined
     }

--- a/apps/web/src/lib/wallet/types.ts
+++ b/apps/web/src/lib/wallet/types.ts
@@ -1,18 +1,14 @@
 import type { EvmChainId } from 'sushi/evm'
-import type { StellarChainId } from 'sushi/stellar'
+import type { StellarAccountAddress, StellarChainId } from 'sushi/stellar'
 import type { SvmChainId } from 'sushi/svm'
 
 export type WalletNamespace = 'evm' | 'svm' | 'stellar'
 
-export type AddressFor<
+export type WalletAddressFor<
   TChainId extends EvmChainId | SvmChainId | StellarChainId,
-> = TChainId extends EvmChainId
-  ? `0x${string}`
-  : TChainId extends SvmChainId
-    ? string
-    : TChainId extends StellarChainId
-      ? string
-      : never
+> = TChainId extends StellarChainId
+  ? StellarAccountAddress
+  : AddressFor<TChainId>
 
 export type WalletNamespaceFor<
   TChainId extends EvmChainId | SvmChainId | StellarChainId,

--- a/packages/stellar/contract-bindings/pool-lens/package.json
+++ b/packages/stellar/contract-bindings/pool-lens/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.1.1",
-    "buffer": "6.0.3"
+    "buffer": "6.0.3",
+    "sushi": "catalog:web3"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/stellar/contract-bindings/pool-lens/src/index.ts
+++ b/packages/stellar/contract-bindings/pool-lens/src/index.ts
@@ -21,6 +21,7 @@ import type {
   Typepoint,
   Duration,
 } from '@stellar/stellar-sdk/contract';
+import type { StellarContractAddress } from "sushi/stellar";
 export * from '@stellar/stellar-sdk'
 export * as contract from '@stellar/stellar-sdk/contract'
 export * as rpc from '@stellar/stellar-sdk/rpc'
@@ -70,11 +71,11 @@ tick_spacing: i32;
   /**
  * First token in the pair (lower address)
  */
-token0: string;
+token0: StellarContractAddress;
   /**
  * Second token in the pair (higher address)
  */
-token1: string;
+token1: StellarContractAddress;
 }
 
 
@@ -117,7 +118,7 @@ export interface PoolData {
   /**
  * The pool contract address
  */
-pool: string;
+pool: StellarContractAddress;
   /**
  * Pool state result - Found(state) if initialized, NotFound otherwise
  */
@@ -134,7 +135,7 @@ export interface PoolDataWithBalances {
   /**
  * The pool contract address
  */
-pool: string;
+pool: StellarContractAddress;
   /**
  * Pool state result with reserves
  */
@@ -584,7 +585,7 @@ export interface Client {
    * # Returns
    * PoolData struct with all pool information
    */
-  get_pool_data: ({pool}: {pool: string}, options?: {
+  get_pool_data: ({pool}: {pool: StellarContractAddress}, options?: {
     /**
      * The fee to pay for the transaction. Default: BASE_FEE
      */
@@ -643,7 +644,7 @@ export interface Client {
    * # Returns
    * PoolDataWithBalances struct with pool state and reserves
    */
-  get_pool_data_with_bal: ({pool}: {pool: string}, options?: {
+  get_pool_data_with_bal: ({pool}: {pool: StellarContractAddress}, options?: {
     /**
      * The fee to pay for the transaction. Default: BASE_FEE
      */
@@ -912,7 +913,7 @@ export interface Client {
    * 3. For each populated bit, calculates the actual tick and fetches its data
    * 4. Returns results in reverse order (matching Solidity's behavior)
    */
-  get_populated_ticks_in_word: ({pool, tick_bitmap_index}: {pool: string, tick_bitmap_index: i32}, options?: {
+  get_populated_ticks_in_word: ({pool, tick_bitmap_index}: {pool: StellarContractAddress, tick_bitmap_index: i32}, options?: {
     /**
      * The fee to pay for the transaction. Default: BASE_FEE
      */
@@ -958,7 +959,7 @@ export interface Client {
    * - `start_word` was near i32::MAX causing range reduction
    * - More than MAX_TICKS_BATCH (2
    */
-  get_populated_ticks_in_range: ({pool, start_word, count}: {pool: string, start_word: i32, count: u32}, options?: {
+  get_populated_ticks_in_range: ({pool, start_word, count}: {pool: StellarContractAddress, start_word: i32, count: u32}, options?: {
     /**
      * The fee to pay for the transaction. Default: BASE_FEE
      */

--- a/packages/stellar/contract-bindings/position-manager/package.json
+++ b/packages/stellar/contract-bindings/position-manager/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.1.1",
-    "buffer": "6.0.3"
+    "buffer": "6.0.3",
+    "sushi": "catalog:web3"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/stellar/contract-bindings/position-manager/src/index.ts
+++ b/packages/stellar/contract-bindings/position-manager/src/index.ts
@@ -8,6 +8,7 @@ import {
   Result,
   Spec as ContractSpec,
 } from '@stellar/stellar-sdk/contract';
+import type { StellarContractAddress } from 'sushi/stellar'
 import type {
   u32,
   i32,
@@ -32,8 +33,8 @@ export type CountryCode = string;
 // PositionTuple is the return type of positions() - matches UserPositionInfo structure
 export interface PositionTuple {
   nonce: u64;
-  token0: string;
-  token1: string;
+  token0: StellarContractAddress;
+  token1: StellarContractAddress;
   fee: u32;
   tickLower: i32;
   tickUpper: i32;
@@ -123,8 +124,8 @@ export interface PositionFeeDataReturn {
 
 export interface PoolKeyData {
   fee: u32;
-  token0: string;
-  token1: string;
+  token0: StellarContractAddress;
+  token1: StellarContractAddress;
 }
 
 
@@ -154,8 +155,8 @@ export interface AddLiquidityParams {
   sender: string;
   tick_lower: i32;
   tick_upper: i32;
-  token0: string;
-  token1: string;
+  token0: StellarContractAddress;
+  token1: StellarContractAddress;
 }
 
 
@@ -200,8 +201,8 @@ export interface MintParams {
   sender: string;
   tick_lower: i32;
   tick_upper: i32;
-  token0: string;
-  token1: string;
+  token0: StellarContractAddress;
+  token1: StellarContractAddress;
 }
 
 
@@ -216,8 +217,8 @@ export interface UserPositionInfo {
   nonce: u64;
   tick_lower: i32;
   tick_upper: i32;
-  token0: string;
-  token1: string;
+  token0: StellarContractAddress;
+  token1: StellarContractAddress;
   token_id: u32;
   tokens_owed0: u128;
   tokens_owed1: u128;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 3.2.2
       version: 3.2.2
     sushi:
-      specifier: 6.5.4
-      version: 6.5.4
+      specifier: 6.5.5
+      version: 6.5.5
     wagmi:
       specifier: 3.3.2
       version: 3.3.2
@@ -128,7 +128,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       sushi:
         specifier: catalog:web3
-        version: 6.5.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 8.4.7
@@ -582,7 +582,7 @@ importers:
         version: 2.3.3
       sushi:
         specifier: catalog:web3
-        version: 6.5.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tiny-invariant:
         specifier: 1.3.1
         version: 1.3.1
@@ -764,7 +764,7 @@ importers:
         version: 1.0.0
       sushi:
         specifier: catalog:web3
-        version: 6.5.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       viem:
         specifier: 2.44.4
         version: 2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11)
@@ -826,7 +826,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       sushi:
         specifier: catalog:web3
-        version: 6.5.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.3.2(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.8.3))
@@ -872,7 +872,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       sushi:
         specifier: catalog:web3
-        version: 6.5.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -924,6 +924,9 @@ importers:
       buffer:
         specifier: 6.0.3
         version: 6.0.3
+      sushi:
+        specifier: catalog:web3
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -937,6 +940,9 @@ importers:
       buffer:
         specifier: 6.0.3
         version: 6.0.3
+      sushi:
+        specifier: catalog:web3
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -1201,7 +1207,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       sushi:
         specifier: catalog:web3
-        version: 6.5.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.3.2(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.8.3))
@@ -13897,8 +13903,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  sushi@6.5.4:
-    resolution: {integrity: sha512-bxCoytaMq+rRLJouw83Yys/NNmO/PaI1+ra1WisNkjSgaBVb/F5gPxaEVI/Cd2d4ZQvWvw58OsSLxEHEgUwrnQ==}
+  sushi@6.5.5:
+    resolution: {integrity: sha512-XbawNAFcso+d4QEBbiryMYJw75tcO1cW95dG3sRFV2/VnXpSu+2bgROD/BHcKQa7AOYoj/kB3ODBRQIrSyy/EQ==}
     peerDependencies:
       '@solana/addresses': 6.0.1
       typescript: 5.8.3
@@ -23868,7 +23874,7 @@ snapshots:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.18.0(jiti@1.21.6))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6))(jest@29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.14)(typescript@5.8.3)))(typescript@5.8.3)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-playwright: 1.6.2(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6))(jest@29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.14)(typescript@5.8.3)))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6))
@@ -26735,8 +26741,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3)
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y: 6.10.0(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-react: 7.37.4(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.18.0(jiti@1.21.6))
@@ -26758,7 +26764,7 @@ snapshots:
 
   eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0):
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -26768,19 +26774,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
       enhanced-resolve: 5.17.1
       eslint: 9.18.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -26793,13 +26799,13 @@ snapshots:
       debug: 4.4.0
       enhanced-resolve: 5.17.1
       eslint: 9.18.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -26827,6 +26833,17 @@ snapshots:
       - bluebird
       - supports-color
 
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3)
+      eslint: 9.18.0(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
@@ -26834,16 +26851,6 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3)
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3)
-      eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
     transitivePeerDependencies:
       - supports-color
@@ -26854,7 +26861,7 @@ snapshots:
       eslint: 9.18.0(jiti@1.21.6)
       ignore: 5.3.2
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -26865,7 +26872,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -32069,7 +32076,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  sushi@6.5.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
+  sushi@6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
     dependencies:
       '@uniswap/token-lists': 1.0.0-beta.33
       tiny-invariant: 1.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalogs:
     "@wagmi/core": 3.2.2
     "viem": 2.44.4
     "@solana/addresses": 6.0.1
-    "sushi": 6.5.4
+    "sushi": 6.5.5
 
   react:
     "next": 16.2.6


### PR DESCRIPTION
## Summary
Re-targets #2105 to master (was accidentally merged into `migrate-legacy-stellar-position`).

Cherry-pick of 4b50d95481, which threads branded `StellarAccountAddress` / `StellarContractAddress` types from `sushi/stellar` through hooks, services, soroban helpers, contract bindings, and the wallet layer; renames `AddressFor` → `WalletAddressFor` so Stellar wallet hooks return account addresses; adds runtime guards (`isStellarAccountAddress`, `isStellarContractAddress`, `normalizeStellarAddress`).

## Test plan
- [x] e2e passing on previous PR
- [x] Confirm CI green here