### PR TITLE
fix: relax v3 fee collection minimums

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/[position]/_common/ui/concentrated-liquidity-collect-button.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/[position]/_common/ui/concentrated-liquidity-collect-button.tsx
@@ -10,7 +10,7 @@ import { type FC, type ReactElement, useCallback, useMemo } from 'react'
 import { logger } from 'src/lib/logger'
 import { isUserRejectedError } from 'src/lib/wagmi/errors'
 import type { ConcentratedLiquidityPosition } from 'src/lib/wagmi/hooks/positions/types'
-import { Amount } from 'sushi'
+import { Amount, Fraction } from 'sushi'
 import {
   type EvmCurrency,
   NonfungiblePositionManager,
@@ -77,12 +77,17 @@ export const ConcentratedLiquidityCollectButton: FC<
         : undefined
 
       const { calldata, value } =
-        NonfungiblePositionManager.collectCallParameters({
-          tokenId: positionDetails.tokenId.toString(),
-          expectedCurrencyOwed0: feeValue0 ?? new Amount(token0, 0),
-          expectedCurrencyOwed1: feeValue1 ?? new Amount(token1, 0),
-          recipient: account,
-        })
+        NonfungiblePositionManager.collectCallParameters(
+          {
+            tokenId: positionDetails.tokenId.toString(),
+            expectedCurrencyOwed0: feeValue0 ?? new Amount(token0, 0),
+            expectedCurrencyOwed1: feeValue1 ?? new Amount(token1, 0),
+            recipient: account,
+          },
+          {
+            minimumAmountTolerance: new Fraction(1),
+          },
+        )
 
       return {
         to: SUSHISWAP_V3_POSITION_MANAGER[chainId],

--- a/apps/web/src/app/(networks)/(evm)/_ui/concentrated-liquidity-collect-all-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/_ui/concentrated-liquidity-collect-all-dialog.tsx
@@ -23,7 +23,7 @@ import { useTokenAmountDollarValues } from 'src/lib/hooks'
 import { logger } from 'src/lib/logger'
 import { isUserRejectedError } from 'src/lib/wagmi/errors'
 import type { ConcentratedLiquidityPositionWithV3Pool } from 'src/lib/wagmi/hooks/positions/types'
-import { Amount } from 'sushi'
+import { Amount, Fraction } from 'sushi'
 import {
   type EvmChainId,
   type EvmCurrency,
@@ -166,8 +166,12 @@ const _ConcentratedLiquidityCollectAllDialog: FC<
 
     if (positionsToCollect.length === 0) return
 
-    const { calldata, value } =
-      NonfungiblePositionManager.collectCallParameters(positionsToCollect)
+    const { calldata, value } = NonfungiblePositionManager.collectCallParameters(
+      positionsToCollect,
+      {
+        minimumAmountTolerance: new Fraction(1),
+      },
+    )
 
     return {
       to: SUSHISWAP_V3_POSITION_MANAGER[chainId],

--- a/apps/web/src/app/(networks)/(evm)/_ui/concentrated-liquidity-collect-all-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/_ui/concentrated-liquidity-collect-all-dialog.tsx
@@ -166,12 +166,10 @@ const _ConcentratedLiquidityCollectAllDialog: FC<
 
     if (positionsToCollect.length === 0) return
 
-    const { calldata, value } = NonfungiblePositionManager.collectCallParameters(
-      positionsToCollect,
-      {
+    const { calldata, value } =
+      NonfungiblePositionManager.collectCallParameters(positionsToCollect, {
         minimumAmountTolerance: new Fraction(1),
-      },
-    )
+      })
 
     return {
       to: SUSHISWAP_V3_POSITION_MANAGER[chainId],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 3.2.2
       version: 3.2.2
     sushi:
-      specifier: 6.5.5
-      version: 6.5.5
+      specifier: 6.6.4
+      version: 6.6.4
     wagmi:
       specifier: 3.3.2
       version: 3.3.2
@@ -128,7 +128,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 8.4.7
@@ -582,7 +582,7 @@ importers:
         version: 2.3.3
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tiny-invariant:
         specifier: 1.3.1
         version: 1.3.1
@@ -764,7 +764,7 @@ importers:
         version: 1.0.0
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       viem:
         specifier: 2.44.4
         version: 2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11)
@@ -826,7 +826,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.3.2(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.8.3))
@@ -872,7 +872,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -926,7 +926,7 @@ importers:
         version: 6.0.3
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -942,7 +942,7 @@ importers:
         version: 6.0.3
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.8.3
@@ -1207,7 +1207,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       sushi:
         specifier: catalog:web3
-        version: 6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.3.2(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.8.3))
@@ -10475,7 +10475,7 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -13903,8 +13903,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  sushi@6.5.5:
-    resolution: {integrity: sha512-XbawNAFcso+d4QEBbiryMYJw75tcO1cW95dG3sRFV2/VnXpSu+2bgROD/BHcKQa7AOYoj/kB3ODBRQIrSyy/EQ==}
+  sushi@6.6.4:
+    resolution: {integrity: sha512-I4Sj4jen687w/YHP77VP7GoLXs1XDq6UW1CN+0m194Rem2MWlUWtodUjSVQ1q7cpNcsmsG4u6HQNLim9UTCRAA==}
     peerDependencies:
       '@solana/addresses': 6.0.1
       typescript: 5.8.3
@@ -32076,7 +32076,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  sushi@6.5.5(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
+  sushi@6.6.4(@solana/addresses@6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(typescript@5.8.3)(viem@2.44.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
     dependencies:
       '@uniswap/token-lists': 1.0.0-beta.33
       tiny-invariant: 1.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalogs:
     "@wagmi/core": 3.2.2
     "viem": 2.44.4
     "@solana/addresses": 6.0.1
-    "sushi": 6.5.5
+    "sushi": 6.6.4
 
   react:
     "next": 16.2.6


### PR DESCRIPTION
## Summary
- upgrade the workspace `sushi` package to `6.6.4`
- use the SDK's `minimumAmountTolerance` option with `new Fraction(1)` in both V3 fee collection entry points
- prevent native fee collection from reverting when unwrap or sweep balances settle a few wei below estimated amounts