### PR TITLE
fix: skip if token is missing

### DIFF
--- a/apps/web/src/lib/perps/subscription/use-asset-list.ts
+++ b/apps/web/src/lib/perps/subscription/use-asset-list.ts
@@ -55,6 +55,8 @@ const formatSpotCtxs = (
   return universe.reduce((acc, u) => {
     const ctx = ctxs[u.index] ?? {}
     const tokens = u.tokens.map((tokenIndex) => _tokens[tokenIndex])
+    //if u.token index is missing, skip
+    if (tokens.some((t) => !t)) return acc
     const markPrice = Number.parseFloat(ctx.markPx)
     const last = ctx.midPx ? Number.parseFloat(ctx.midPx) : markPrice
     const prev = Number.parseFloat(ctx.prevDayPx)


### PR DESCRIPTION
If a tokenIndex was returned but not found on the token universe, all spot balances and values would be off.