### PR TITLE
fix: missing privy frame_src

### DIFF
--- a/apps/web/content-security-policy.mjs
+++ b/apps/web/content-security-policy.mjs
@@ -130,6 +130,7 @@ const FRAME_SOURCES = [
   'https://id.porto.sh',
   'https://stg.id.porto.sh',
   'https://vercel.live',
+  'https://privy.sushi.com',
 ]
 
 const FRAME_ANCESTORS = [


### PR DESCRIPTION
adds missing  'https://privy.sushi.com', to frame_src csp