### PR TITLE
Feat: basis trade

### DIFF
--- a/apps/web/content-security-policy.mjs
+++ b/apps/web/content-security-policy.mjs
@@ -59,6 +59,7 @@ const SUSHI_CONNECT_SOURCES = [
   'https://sepolia-rollup.arbitrum.io',
   'https://rpc.tatara.katanarpc.com',
   'https://rpc-bokuto.katanarpc.com',
+  'https://migration-claim-api-production.up.railway.app',
 ]
 
 const PRODUCT_CONNECT_SOURCES = [

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/_common/checkbox-setting.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/_common/checkbox-setting.tsx
@@ -1,4 +1,5 @@
 import { Checkbox } from '@sushiswap/ui'
+import type { ReactNode } from 'react'
 
 export const CheckboxSetting = ({
   value,
@@ -7,7 +8,7 @@ export const CheckboxSetting = ({
 }: {
   value: boolean
   onChange: (value: boolean) => void
-  label: string
+  label: string | ReactNode
 }) => {
   return (
     <div

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/_common/checkbox-setting.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/_common/checkbox-setting.tsx
@@ -8,7 +8,7 @@ export const CheckboxSetting = ({
 }: {
   value: boolean
   onChange: (value: boolean) => void
-  label: string | ReactNode
+  label: ReactNode
 }) => {
   return (
     <div

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/account-management/settings-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/account-management/settings-dialog.tsx
@@ -25,7 +25,6 @@ export const SettingsDialog = () => {
       disableBgFillNotifs,
       hidePnl,
       optOutOfSpotDustCollection,
-      isDexAbstractionEnabled,
       showPnlCardOnMarketClose,
     },
     mutate: {
@@ -38,7 +37,6 @@ export const SettingsDialog = () => {
       setDisableBgFillNotifs,
       setHidePnl,
       setOptOutOfSpotDustCollection,
-      setDexAbstractionEnabled,
       setShowPnlCardOnMarketClose,
     },
   } = useUserSettingsState()
@@ -119,16 +117,43 @@ export const SettingsDialog = () => {
             {activeAccount?.type === 'vault' ? null : (
               <>
                 <div className="bg-accent w-full h-[1px]" />
-                <CheckboxSetting
-                  value={!isDexAbstractionEnabled}
-                  onChange={setDexAbstractionEnabled}
-                  label="Disable HIP-3 Dex Abstraction"
-                />
-                <CheckboxSetting
-                  value={!isUnifiedAccountModeEnabled}
-                  onChange={setUnifiedAccountModeEnabled}
-                  label="Disable Unified Account Mode"
-                />
+                <div className="flex flex-col gap-1">
+                  <h4 className="font-semibold">Account Mode</h4>
+                  <div className="flex flex-col gap-4">
+                    <CheckboxSetting
+                      value={!isUnifiedAccountModeEnabled}
+                      onChange={setUnifiedAccountModeEnabled}
+                      label={
+                        <div className="flex flex-col gap-0.5">
+                          <p className="font-medium text-perps-muted">Manual</p>
+                          <div className="!whitespace-normal">
+                            Only recommended for automated traders. All DEXs
+                            have separate balances and cross margin applies
+                            separately within each DEX.
+                          </div>
+                        </div>
+                      }
+                    />
+                    <CheckboxSetting
+                      value={isUnifiedAccountModeEnabled}
+                      onChange={(val) => setUnifiedAccountModeEnabled(!val)}
+                      label={
+                        <div className="flex flex-col gap-0.5">
+                          <p className="font-medium text-perps-muted">
+                            Unified Account (Recommended)
+                          </p>
+                          <div className="!whitespace-normal">
+                            The default account setting where each collateral
+                            asset has a separate balance. Perps can only use the
+                            settlement asset as collateral, and margining is
+                            only shared across cross margin assets with the same
+                            collateral asset.
+                          </div>
+                        </div>
+                      }
+                    />
+                  </div>
+                </div>
               </>
             )}
           </div>

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-list-provider.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-list-provider.tsx
@@ -1,13 +1,49 @@
 'use client'
 import type { SymbolConverter } from '@nktkas/hyperliquid/utils'
 import { type FC, createContext, useContext, useMemo } from 'react'
-import { useAssetList, useSymbolConverter } from 'src/lib/perps'
+import {
+  type PerpOrSpotAsset,
+  useAssetList,
+  useSymbolConverter,
+} from 'src/lib/perps'
+
+type SpotBasisAsset = PerpOrSpotAsset & { marketType: 'spot' }
+type PerpBasisAsset = PerpOrSpotAsset & { marketType: 'perp' }
+
+export type BasisTradeAsset = {
+  spotAsset: SpotBasisAsset
+  perpAsset: PerpBasisAsset
+}
+
+function getBasisAssetKey(
+  symbol: string,
+  separator: '/' | '-',
+): string | undefined {
+  const separatorIndex = symbol.lastIndexOf(separator)
+
+  if (separatorIndex === -1) return undefined
+
+  const base = symbol.slice(0, separatorIndex)
+
+  if (!base) return undefined
+
+  return base.toLowerCase()
+}
+
+function isSpotBasisAsset(asset: PerpOrSpotAsset): asset is SpotBasisAsset {
+  return asset.marketType === 'spot'
+}
+
+function isPerpBasisAsset(asset: PerpOrSpotAsset): asset is PerpBasisAsset {
+  return asset.marketType === 'perp'
+}
 
 interface State {
   state: {
     assetListQuery: ReturnType<typeof useAssetList>
     uniqueDexes: string[]
     spotCollateralTokens: string[]
+    basisTradeAssets: BasisTradeAsset[]
     symbolConverter: SymbolConverter | undefined
     dexQuoteMap: Map<string, string>
   }
@@ -57,6 +93,44 @@ const AssetListProvider: FC<AssetListProviderProps> = ({ children }) => {
     return Array.from(tokensSet)
   }, [assetListQuery.data])
 
+  const basisTradeAssets = useMemo(() => {
+    if (!assetListQuery.data) return []
+
+    const perpsByAsset = new Map<string, PerpBasisAsset[]>()
+
+    assetListQuery.data.forEach((asset) => {
+      if (!isPerpBasisAsset(asset)) return
+
+      const assetKey = getBasisAssetKey(asset.symbol, '-')
+      if (!assetKey) return
+
+      const perpAssets = perpsByAsset.get(assetKey)
+      if (perpAssets) {
+        perpAssets.push(asset)
+      } else {
+        perpsByAsset.set(assetKey, [asset])
+      }
+    })
+
+    const pairs: BasisTradeAsset[] = []
+
+    assetListQuery.data.forEach((asset) => {
+      if (!isSpotBasisAsset(asset)) return
+
+      const assetKey = getBasisAssetKey(asset.symbol, '/')
+      if (!assetKey) return
+
+      const perpAssets = perpsByAsset.get(assetKey)
+      if (!perpAssets) return
+
+      perpAssets.forEach((perpAsset) => {
+        pairs.push({ spotAsset: asset, perpAsset })
+      })
+    })
+
+    return pairs
+  }, [assetListQuery.data])
+
   return (
     <AssetListContext.Provider
       value={useMemo(() => {
@@ -65,6 +139,7 @@ const AssetListProvider: FC<AssetListProviderProps> = ({ children }) => {
             assetListQuery,
             uniqueDexes,
             spotCollateralTokens,
+            basisTradeAssets,
             symbolConverter,
             dexQuoteMap,
           },
@@ -73,6 +148,7 @@ const AssetListProvider: FC<AssetListProviderProps> = ({ children }) => {
         assetListQuery,
         uniqueDexes,
         spotCollateralTokens,
+        basisTradeAssets,
         symbolConverter,
         dexQuoteMap,
       ])}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-tabs.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-tabs.tsx
@@ -10,16 +10,17 @@ import {
 import { BankIcon } from '@sushiswap/ui/icons/BankIcon'
 import { CirclesIcon } from '@sushiswap/ui/icons/CirclesIcon'
 import { ClockIcon } from '@sushiswap/ui/icons/ClockIcon'
+import { FireIcon } from '@sushiswap/ui/icons/FireIcon'
 import { InfinityIcon } from '@sushiswap/ui/icons/InfinityIcon'
 import { LightningIcon } from '@sushiswap/ui/icons/LightningIcon'
 import { useEffect } from 'react'
 import { FavoriteIcon } from '../_common'
 import { AllAssets } from './all-assets'
+import { BasisTradeAssets } from './basis-trade-assets'
 import { FavoriteAssets } from './favorite-assets'
 import { HIP3Assets } from './hip-3-assets'
 import { SpotAssets } from './spot-assets'
 import { TradfiAssets } from './tradfi-assets'
-// import { FireIcon } from '@sushiswap/ui/icons/FireIcon';
 
 const TABS = [
   { value: 'all', icon: <ClockIcon className="w-3 h-3" /> },
@@ -29,6 +30,7 @@ const TABS = [
   { value: 'Tradfi', icon: <BankIcon className="w-3 h-3" /> },
   { value: 'HIP-3', icon: <LightningIcon className="w-3 h-3" /> },
   // { value: 'trending', icon: <FireIcon className="w-3 h-3" /> },
+  { value: 'basis trade', icon: <FireIcon className="w-3 h-3" /> },
   { value: 'watchlist', icon: <FavoriteIcon className="w-3 h-3" /> },
 ] as const
 type TabType = (typeof TABS)[number]['value']
@@ -117,6 +119,9 @@ export const AssetTabs = () => {
         </TabsContent>
         <TabsContent value="HIP-3" className="!mt-0">
           <HIP3Assets />
+        </TabsContent>
+        <TabsContent value="basis trade" className="!mt-0">
+          <BasisTradeAssets />
         </TabsContent>
         <TabsContent value="watchlist" className="!mt-0">
           <FavoriteAssets />

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-tabs.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-tabs.tsx
@@ -1,5 +1,6 @@
 import { useLocalStorage } from '@sushiswap/hooks'
 import {
+  Chip,
   Tabs,
   TabsContent,
   TabsList,
@@ -30,7 +31,7 @@ const TABS = [
   { value: 'Tradfi', icon: <BankIcon className="w-3 h-3" /> },
   { value: 'HIP-3', icon: <LightningIcon className="w-3 h-3" /> },
   // { value: 'trending', icon: <FireIcon className="w-3 h-3" /> },
-  { value: 'basis trade', icon: <FireIcon className="w-3 h-3" /> },
+  { value: 'basis trade', icon: <FireIcon className="w-3 h-3" />, isNew: true },
   { value: 'watchlist', icon: <FavoriteIcon className="w-3 h-3" /> },
 ] as const
 type TabType = (typeof TABS)[number]['value']
@@ -90,6 +91,11 @@ export const AssetTabs = () => {
           >
             {<span className="mr-1">{tab.icon}</span>}
             {tab.value}
+            {'isNew' in tab && tab.isNew ? (
+              <Chip variant="perps-green" className="!px-1 !text-[10px] ml-1">
+                New
+              </Chip>
+            ) : null}
             {idx !== TABS.length - 1 ? (
               <span className="h-[10px] w-px bg-perps-muted-20 ml-3" />
             ) : null}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/basis-trade-assets.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/basis-trade-assets.tsx
@@ -97,7 +97,6 @@ export const BasisTradeAssets = () => {
       thClassName="!h-8 pl-0"
       trClassName="transform-gpu"
       hideScrollbar={true}
-      overscan={2}
     />
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/basis-trade-assets.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/basis-trade-assets.tsx
@@ -1,0 +1,103 @@
+'use client'
+import { DataTableVirtual, Slot } from '@sushiswap/ui'
+import type { Row, SortingState, TableState } from '@tanstack/react-table'
+import { type ReactNode, useCallback, useMemo, useState } from 'react'
+import { useAssetState } from '../trade-widget'
+import { type BasisTradeAsset, useAssetListState } from './asset-list-provider'
+import { useAssetSelectorState } from './asset-selector-provider'
+import {
+  BASIS_DAY_CHANGE_COLUMN,
+  BASIS_EIGHT_HOUR_FUNDING_COLUMN,
+  BASIS_LAST_PRICE_COLUMN,
+  BASIS_OPEN_INTEREST_COLUMN,
+  BASIS_SYMBOL_COLUMN,
+  BASIS_VOLUME_COLUMN,
+} from './columns'
+
+const COLUMNS = [
+  BASIS_SYMBOL_COLUMN,
+  BASIS_LAST_PRICE_COLUMN,
+  BASIS_DAY_CHANGE_COLUMN,
+  BASIS_EIGHT_HOUR_FUNDING_COLUMN,
+  BASIS_VOLUME_COLUMN,
+  BASIS_OPEN_INTEREST_COLUMN,
+]
+
+export const BasisTradeAssets = () => {
+  const {
+    state: {
+      assetListQuery: { isLoading },
+      basisTradeAssets,
+    },
+  } = useAssetListState()
+  const {
+    mutate: { setOpen },
+  } = useAssetSelectorState()
+  const {
+    state: { search },
+  } = useAssetSelectorState()
+  const {
+    mutate: { setActiveBasisTradeAsset },
+  } = useAssetState()
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'volume24hUsd', desc: true },
+  ])
+  const filtered = useMemo(() => {
+    if (!basisTradeAssets) return []
+    const baseData = basisTradeAssets
+    return baseData.filter((i) => {
+      if (search) {
+        return (
+          i.spotAsset.symbol.toLowerCase().includes(search.toLowerCase()) ||
+          i.spotAsset.name.toLowerCase().includes(search.toLowerCase()) ||
+          i.perpAsset.symbol.toLowerCase().includes(search.toLowerCase()) ||
+          i.perpAsset.name.toLowerCase().includes(search.toLowerCase())
+        )
+      }
+      return true
+    })
+  }, [basisTradeAssets, search])
+
+  const state: Partial<TableState> = useMemo(() => {
+    return {
+      sorting,
+      pagination: {
+        pageIndex: 0,
+        pageSize: filtered?.length,
+      },
+    }
+  }, [filtered, sorting])
+
+  const rowRenderer = useCallback(
+    (row: Row<BasisTradeAsset>, rowNode: ReactNode) => {
+      return (
+        <Slot
+          className="cursor-pointer"
+          onClick={() => {
+            setActiveBasisTradeAsset(row.original)
+            setOpen(false)
+          }}
+          key={`${row.original.spotAsset.name}-${row.original.perpAsset.name}-slot`}
+        >
+          {rowNode}
+        </Slot>
+      )
+    },
+    [setActiveBasisTradeAsset, setOpen],
+  )
+
+  return (
+    <DataTableVirtual
+      state={state}
+      onSortingChange={setSorting}
+      loading={isLoading}
+      rowRenderer={rowRenderer}
+      columns={COLUMNS}
+      data={filtered}
+      thClassName="!h-8 pl-0"
+      trClassName="transform-gpu"
+      hideScrollbar={true}
+      overscan={2}
+    />
+  )
+}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/columns.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/columns.tsx
@@ -1,6 +1,5 @@
 import { Chip, SkeletonText, classNames } from '@sushiswap/ui'
 import type { ColumnDef } from '@tanstack/react-table'
-import { useMemo } from 'react'
 import {
   type PerpOrSpotAsset,
   currencyFormatter,
@@ -10,8 +9,10 @@ import {
   perpsNumberFormatter,
 } from 'src/lib/perps'
 import { formatPercent } from 'sushi'
-import { AssetIcon } from '../_common'
+import type { BasisTradeAsset } from './asset-list-provider'
 import { FavoriteButton } from './favorite-button'
+
+type AssetSelectorColumnRow = PerpOrSpotAsset | BasisTradeAsset
 
 const columnBodyMeta = {
   className: '!py-0.5 !pr-1 !pl-2.5 !h-[25px] !max-h-[25px] !text-xs',
@@ -24,193 +25,299 @@ const columnBodyMeta = {
   ),
 }
 
-export const SYMBOL_COLUMN: ColumnDef<PerpOrSpotAsset, unknown> = {
-  id: 'symbol',
-  header: 'Symbol',
-  accessorFn: (row) => row.symbol,
-  cell: (props) => {
-    const asset = useMemo(() => props.row.original, [props.row.original])
+function isBasisTradeAsset(
+  asset: AssetSelectorColumnRow,
+): asset is BasisTradeAsset {
+  return 'spotAsset' in asset && 'perpAsset' in asset
+}
+
+function getStatsAsset(asset: AssetSelectorColumnRow): PerpOrSpotAsset {
+  return isBasisTradeAsset(asset) ? asset.perpAsset : asset
+}
+
+function getMarketCapAsset(asset: AssetSelectorColumnRow): PerpOrSpotAsset {
+  return isBasisTradeAsset(asset) ? asset.spotAsset : asset
+}
+
+function getSymbolAccessorValue(asset: AssetSelectorColumnRow): string {
+  if (!isBasisTradeAsset(asset)) return asset.symbol
+
+  return `${asset.spotAsset.symbol} ${asset.perpAsset.symbol} ${asset.perpAsset.dex}`
+}
+
+function renderSymbolCell(asset: AssetSelectorColumnRow) {
+  if (isBasisTradeAsset(asset)) {
+    const { perpAsset, spotAsset } = asset
+
     return (
-      <div
-        className={classNames(
-          'whitespace-nowrap flex items-center gap-1 pb-1 lg:pb-0',
-          asset?.marketType === 'perp' ? '!min-w-[215px]' : '',
-        )}
-      >
+      <div className="whitespace-nowrap flex items-center gap-1 pb-1 lg:pb-0 !min-w-[260px]">
         <div className="flex items-center gap-1">
-          <FavoriteButton assetString={asset.name} />
-          {/* <AssetIcon asset={asset} size={'sm'} /> */}
-          <span>{asset.symbol}</span>
+          <span>{spotAsset.symbol}</span>
+          <span className="text-muted-foreground">/</span>
+          <span>{perpAsset.symbol}</span>
         </div>
         <div className="flex items-center gap-1">
           <Chip variant="perps-blue" className="!px-1 !font-medium">
-            {asset.maxLeverage ? `${asset.maxLeverage}x` : 'SPOT'}
+            SPOT
           </Chip>
-          {asset?.dex ? (
+          <Chip variant="perps-blue" className="!px-1 !font-medium">
+            {`${perpAsset.maxLeverage}x`}
+          </Chip>
+          {perpAsset.dex ? (
             <Chip variant="perps-blue" className="!px-1 !py-0 rounded-md ml-1">
-              {asset.dex}
+              {perpAsset.dex}
             </Chip>
           ) : null}
         </div>
       </div>
     )
-  },
-  meta: {
-    body: {
-      className: classNames(columnBodyMeta.className, '!pl-0'),
-      skeleton: columnBodyMeta.skeleton,
-    },
-    header: {
-      className: '!pl-2',
-    },
-  },
-}
-export const LAST_PRICE_COLUMN: ColumnDef<PerpOrSpotAsset, unknown> = {
-  id: 'lastPrice',
-  header: 'Last Price',
-  accessorFn: (row) => row.lastPrice,
-  sortingFn: ({ original: rowA }, { original: rowB }) =>
-    Number.parseFloat(rowA.lastPrice) - Number.parseFloat(rowB.lastPrice),
-  cell: (props) => {
-    const token = props.row.original
-    const price = token.lastPrice
+  }
 
-    return (
-      <div className="tabular-nums">
-        {formatPrice(
-          price?.toString() ?? '',
-          token?.decimals ?? 0,
-          token.marketType,
-        )}
-      </div>
-    )
-  },
-  meta: {
-    body: columnBodyMeta,
-  },
-}
-export const DAY_CHANGE_COLUMN: ColumnDef<PerpOrSpotAsset, unknown> = {
-  id: 'change24hPct',
-  header: '24H Change',
-  accessorFn: (row) => row.change24hPct,
-  sortingFn: ({ original: rowA }, { original: rowB }) =>
-    Number.parseFloat(rowA.change24hPct ?? '0') -
-    Number.parseFloat(rowB.change24hPct ?? '0'),
-  cell: (props) => {
-    const change24hAbs = props.row.original.change24hAbs
-    const change24hPct = props.row.original.change24hPct
-    return (
-      <p
-        className={classNames(
-          'text-xs whitespace-nowrap tabular-nums',
-          change24hAbs && getTextColorClass(Number(change24hAbs)),
-        )}
-      >
-        {getSignForValue(Number(change24hAbs ?? 0))}
-        {perpsNumberFormatter({
-          value: Number(change24hAbs ?? 0),
-          maxFraxDigits: 4,
-        })}{' '}
-        / {getSignForValue(Number(change24hPct ?? 0))}
-        {formatPercent(change24hPct)}
-      </p>
-    )
-  },
-  meta: {
-    body: columnBodyMeta,
-  },
-}
-
-export const EIGHT_HOUR_FUNDING_COLUMN: ColumnDef<PerpOrSpotAsset, unknown> = {
-  id: 'funding8hPct',
-  header: '8H Funding',
-  accessorFn: (row) => Number(row.funding8hPct || '0'),
-  sortingFn: ({ original: rowA }, { original: rowB }) =>
-    Number.parseFloat(rowA.funding8hPct || '0') -
-    Number.parseFloat(rowB.funding8hPct || '0'),
-  cell: (props) => {
-    const funding8h = props.row.original.funding8hPct
-
-    if (!funding8h) {
-      return <div className="tabular-nums">--</div>
-    }
-    return (
-      <div className="tabular-nums">
-        {(Number(funding8h ?? 0) * 100).toFixed(4)}%
-      </div>
-    )
-  },
-  meta: {
-    body: columnBodyMeta,
-  },
-}
-
-export const VOLUME_COLUMN: ColumnDef<PerpOrSpotAsset, unknown> = {
-  id: 'volume24hUsd',
-  header: 'Volume',
-  accessorFn: (row) => row.volume24hUsd,
-  sortingFn: ({ original: rowA }, { original: rowB }) =>
-    Number.parseFloat(rowA.volume24hUsd ?? '0') -
-    Number.parseFloat(rowB.volume24hUsd ?? '0'),
-  cell: (props) => (
-    <div className="tabular-nums">
-      {currencyFormatter.format(
-        Number.parseFloat(props.row.original.volume24hUsd ?? '0'),
+  return (
+    <div
+      className={classNames(
+        'whitespace-nowrap flex items-center gap-1 pb-1 lg:pb-0',
+        asset?.marketType === 'perp' ? '!min-w-[215px]' : '',
       )}
+    >
+      <div className="flex items-center gap-1">
+        <FavoriteButton assetString={asset.name} />
+        <span>{asset.symbol}</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <Chip variant="perps-blue" className="!px-1 !font-medium">
+          {asset.maxLeverage ? `${asset.maxLeverage}x` : 'SPOT'}
+        </Chip>
+        {asset?.dex ? (
+          <Chip variant="perps-blue" className="!px-1 !py-0 rounded-md ml-1">
+            {asset.dex}
+          </Chip>
+        ) : null}
+      </div>
     </div>
-  ),
-  meta: {
-    body: columnBodyMeta,
-  },
+  )
 }
-export const OPEN_INTEREST_COLUMN: ColumnDef<PerpOrSpotAsset, unknown> = {
-  id: 'openInterestUsd',
-  header: 'Open Interest',
-  accessorFn: (row) => row.openInterestUsd,
-  sortingFn: ({ original: rowA }, { original: rowB }) =>
-    Number.parseFloat(rowA.openInterestUsd ?? '0') -
-    Number.parseFloat(rowB.openInterestUsd ?? '0'),
-  cell: (props) => {
-    const openInterestUsd = props.row.original.openInterestUsd
 
-    if (!openInterestUsd) {
-      return <div className="tabular-nums mx-4">--</div>
-    }
-    return (
+function createSymbolColumn<TRow extends AssetSelectorColumnRow>(): ColumnDef<
+  TRow,
+  unknown
+> {
+  return {
+    id: 'symbol',
+    header: 'Symbol',
+    accessorFn: (row) => getSymbolAccessorValue(row),
+    cell: (props) => renderSymbolCell(props.row.original),
+    meta: {
+      body: {
+        className: classNames(columnBodyMeta.className, '!pl-0'),
+        skeleton: columnBodyMeta.skeleton,
+      },
+      header: {
+        className: '!pl-2',
+      },
+    },
+  }
+}
+
+function createLastPriceColumn<
+  TRow extends AssetSelectorColumnRow,
+>(): ColumnDef<TRow, unknown> {
+  return {
+    id: 'lastPrice',
+    header: 'Last Price',
+    accessorFn: (row) => getStatsAsset(row).lastPrice,
+    sortingFn: ({ original: rowA }, { original: rowB }) =>
+      Number.parseFloat(getStatsAsset(rowA).lastPrice) -
+      Number.parseFloat(getStatsAsset(rowB).lastPrice),
+    cell: (props) => {
+      const token = getStatsAsset(props.row.original)
+      const price = token.lastPrice
+
+      return (
+        <div className="tabular-nums">
+          {formatPrice(
+            price?.toString() ?? '',
+            token?.decimals ?? 0,
+            token.marketType,
+          )}
+        </div>
+      )
+    },
+    meta: {
+      body: columnBodyMeta,
+    },
+  }
+}
+
+function createDayChangeColumn<
+  TRow extends AssetSelectorColumnRow,
+>(): ColumnDef<TRow, unknown> {
+  return {
+    id: 'change24hPct',
+    header: '24H Change',
+    accessorFn: (row) => getStatsAsset(row).change24hPct,
+    sortingFn: ({ original: rowA }, { original: rowB }) =>
+      Number.parseFloat(getStatsAsset(rowA).change24hPct ?? '0') -
+      Number.parseFloat(getStatsAsset(rowB).change24hPct ?? '0'),
+    cell: (props) => {
+      const asset = getStatsAsset(props.row.original)
+      const change24hAbs = asset.change24hAbs
+      const change24hPct = asset.change24hPct
+
+      return (
+        <p
+          className={classNames(
+            'text-xs whitespace-nowrap tabular-nums',
+            change24hAbs && getTextColorClass(Number(change24hAbs)),
+          )}
+        >
+          {getSignForValue(Number(change24hAbs ?? 0))}
+          {perpsNumberFormatter({
+            value: Number(change24hAbs ?? 0),
+            maxFraxDigits: 4,
+          })}{' '}
+          / {getSignForValue(Number(change24hPct ?? 0))}
+          {formatPercent(change24hPct)}
+        </p>
+      )
+    },
+    meta: {
+      body: columnBodyMeta,
+    },
+  }
+}
+
+function createEightHourFundingColumn<
+  TRow extends AssetSelectorColumnRow,
+>(): ColumnDef<TRow, unknown> {
+  return {
+    id: 'funding8hPct',
+    header: '8H Funding',
+    accessorFn: (row) => Number(getStatsAsset(row).funding8hPct || '0'),
+    sortingFn: ({ original: rowA }, { original: rowB }) =>
+      Number.parseFloat(getStatsAsset(rowA).funding8hPct || '0') -
+      Number.parseFloat(getStatsAsset(rowB).funding8hPct || '0'),
+    cell: (props) => {
+      const funding8h = getStatsAsset(props.row.original).funding8hPct
+
+      if (!funding8h) {
+        return <div className="tabular-nums">--</div>
+      }
+      return (
+        <div className="tabular-nums">
+          {(Number(funding8h ?? 0) * 100).toFixed(4)}%
+        </div>
+      )
+    },
+    meta: {
+      body: columnBodyMeta,
+    },
+  }
+}
+
+function createVolumeColumn<TRow extends AssetSelectorColumnRow>(): ColumnDef<
+  TRow,
+  unknown
+> {
+  return {
+    id: 'volume24hUsd',
+    header: 'Volume',
+    accessorFn: (row) => getStatsAsset(row).volume24hUsd,
+    sortingFn: ({ original: rowA }, { original: rowB }) =>
+      Number.parseFloat(getStatsAsset(rowA).volume24hUsd ?? '0') -
+      Number.parseFloat(getStatsAsset(rowB).volume24hUsd ?? '0'),
+    cell: (props) => (
       <div className="tabular-nums">
-        {currencyFormatter.format(Number.parseFloat(openInterestUsd ?? '0'))}
+        {currencyFormatter.format(
+          Number.parseFloat(
+            getStatsAsset(props.row.original).volume24hUsd ?? '0',
+          ),
+        )}
       </div>
-    )
-  },
-  meta: {
-    body: columnBodyMeta,
-  },
+    ),
+    meta: {
+      body: columnBodyMeta,
+    },
+  }
 }
-export const MARKET_CAP_COLUMN: ColumnDef<PerpOrSpotAsset, unknown> = {
-  id: 'marketCap',
-  header: 'Market Cap',
-  accessorFn: (row) => row.marketCap,
-  sortingFn: ({ original: rowA }, { original: rowB }) =>
-    Number.parseFloat(rowA.marketCap ?? '0') -
-    Number.parseFloat(rowB.marketCap ?? '0'),
-  cell: (props) => {
-    const marketCap = props.row.original.marketCap
-    const token = props.row.original.tokens?.[1]
-    if (!marketCap) {
-      return <div className="tabular-nums mr-4">--</div>
-    }
-    return (
-      <div className="tabular-nums whitespace-nowrap !min-w-[210px]">
-        {perpsNumberFormatter({
-          value: marketCap ?? '0',
-          maxFraxDigits: 2,
-          minFraxDigits: 2,
-        })}{' '}
-        {token?.name}
-      </div>
-    )
-  },
-  meta: {
-    body: columnBodyMeta,
-  },
+
+function createOpenInterestColumn<
+  TRow extends AssetSelectorColumnRow,
+>(): ColumnDef<TRow, unknown> {
+  return {
+    id: 'openInterestUsd',
+    header: 'Open Interest',
+    accessorFn: (row) => getStatsAsset(row).openInterestUsd,
+    sortingFn: ({ original: rowA }, { original: rowB }) =>
+      Number.parseFloat(getStatsAsset(rowA).openInterestUsd ?? '0') -
+      Number.parseFloat(getStatsAsset(rowB).openInterestUsd ?? '0'),
+    cell: (props) => {
+      const openInterestUsd = getStatsAsset(props.row.original).openInterestUsd
+
+      if (!openInterestUsd) {
+        return <div className="tabular-nums mx-4">--</div>
+      }
+      return (
+        <div className="tabular-nums">
+          {currencyFormatter.format(Number.parseFloat(openInterestUsd ?? '0'))}
+        </div>
+      )
+    },
+    meta: {
+      body: columnBodyMeta,
+    },
+  }
 }
+
+function createMarketCapColumn<
+  TRow extends AssetSelectorColumnRow,
+>(): ColumnDef<TRow, unknown> {
+  return {
+    id: 'marketCap',
+    header: 'Market Cap',
+    accessorFn: (row) => getMarketCapAsset(row).marketCap,
+    sortingFn: ({ original: rowA }, { original: rowB }) =>
+      Number.parseFloat(getMarketCapAsset(rowA).marketCap ?? '0') -
+      Number.parseFloat(getMarketCapAsset(rowB).marketCap ?? '0'),
+    cell: (props) => {
+      const asset = getMarketCapAsset(props.row.original)
+      const marketCap = asset.marketCap
+      const token = asset.tokens?.[1]
+      if (!marketCap) {
+        return <div className="tabular-nums mr-4">--</div>
+      }
+      return (
+        <div className="tabular-nums whitespace-nowrap !min-w-[210px]">
+          {perpsNumberFormatter({
+            value: marketCap ?? '0',
+            maxFraxDigits: 2,
+            minFraxDigits: 2,
+          })}{' '}
+          {token?.name}
+        </div>
+      )
+    },
+    meta: {
+      body: columnBodyMeta,
+    },
+  }
+}
+
+export const SYMBOL_COLUMN = createSymbolColumn<PerpOrSpotAsset>()
+export const LAST_PRICE_COLUMN = createLastPriceColumn<PerpOrSpotAsset>()
+export const DAY_CHANGE_COLUMN = createDayChangeColumn<PerpOrSpotAsset>()
+export const EIGHT_HOUR_FUNDING_COLUMN =
+  createEightHourFundingColumn<PerpOrSpotAsset>()
+export const VOLUME_COLUMN = createVolumeColumn<PerpOrSpotAsset>()
+export const OPEN_INTEREST_COLUMN = createOpenInterestColumn<PerpOrSpotAsset>()
+export const MARKET_CAP_COLUMN = createMarketCapColumn<PerpOrSpotAsset>()
+
+export const BASIS_SYMBOL_COLUMN = createSymbolColumn<BasisTradeAsset>()
+export const BASIS_LAST_PRICE_COLUMN = createLastPriceColumn<BasisTradeAsset>()
+export const BASIS_DAY_CHANGE_COLUMN = createDayChangeColumn<BasisTradeAsset>()
+export const BASIS_EIGHT_HOUR_FUNDING_COLUMN =
+  createEightHourFundingColumn<BasisTradeAsset>()
+export const BASIS_VOLUME_COLUMN = createVolumeColumn<BasisTradeAsset>()
+export const BASIS_OPEN_INTEREST_COLUMN =
+  createOpenInterestColumn<BasisTradeAsset>()
+export const BASIS_MARKET_CAP_COLUMN = createMarketCapColumn<BasisTradeAsset>()

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/perps-checker/basis-trade-amount.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/perps-checker/basis-trade-amount.tsx
@@ -1,5 +1,6 @@
 import { Button, type ButtonProps } from '@sushiswap/ui'
 import { type FC, useMemo } from 'react'
+import { parseUnits } from 'viem'
 import { useAssetState, useBasisTradeAccountBalances } from '../trade-widget'
 
 export const BasisTradeAmount: FC<ButtonProps> = ({
@@ -9,15 +10,20 @@ export const BasisTradeAmount: FC<ButtonProps> = ({
   ...props
 }) => {
   const {
-    state: { basisTradeAsset, basisTradeSize, tradeSide },
+    state: {
+      basisTradeAsset,
+      basisTradeSize,
+      maxTradeSizeLong,
+      maxTradeSizeShort,
+      tradeSide,
+    },
   } = useAssetState()
   const {
     isLoading,
-    perpsBalance,
-    perpQuoteSymbol,
     spotBaseBalance,
     spotBaseSymbol,
-    spotEquity,
+    spotQuoteBalance,
+    spotQuoteSymbol,
   } = useBasisTradeAccountBalances({ basisTradeAsset })
 
   const { isSizeValid, buttonText } = useMemo(() => {
@@ -45,10 +51,11 @@ export const BasisTradeAmount: FC<ButtonProps> = ({
     }
 
     if (tradeSide === 'long') {
-      if (Number(basisTradeSize.spot.quote) > spotEquity) {
+      const availableQuote = Number(spotQuoteBalance?.availableBalance ?? 0)
+      if (Number(basisTradeSize.spot.quote) > availableQuote) {
         return {
           isSizeValid: false,
-          buttonText: 'Insufficient Spot Equity',
+          buttonText: `Insufficient ${spotQuoteSymbol}`,
         }
       }
     } else {
@@ -61,11 +68,14 @@ export const BasisTradeAmount: FC<ButtonProps> = ({
       }
     }
 
-    if (Number(basisTradeSize.perp.quote) > Number(perpsBalance ?? 0)) {
-      return {
-        isSizeValid: false,
-        buttonText: `Insufficient ${perpQuoteSymbol} Perp Balance`,
-      }
+    const maxPerpTradeSize =
+      tradeSide === 'long' ? maxTradeSizeShort : maxTradeSizeLong
+
+    const parsedPerpSize = parseUnits(basisTradeSize.perp.base, 18)
+    const parsedMaxPerpTradeSize = parseUnits(maxPerpTradeSize, 18)
+
+    if (parsedPerpSize > parsedMaxPerpTradeSize) {
+      return { isSizeValid: false, buttonText: 'Invalid Perp Size' }
     }
 
     return { isSizeValid: true, buttonText: '' }
@@ -73,11 +83,12 @@ export const BasisTradeAmount: FC<ButtonProps> = ({
     basisTradeAsset,
     basisTradeSize,
     isLoading,
-    perpsBalance,
-    perpQuoteSymbol,
+    maxTradeSizeLong,
+    maxTradeSizeShort,
     spotBaseBalance,
     spotBaseSymbol,
-    spotEquity,
+    spotQuoteBalance,
+    spotQuoteSymbol,
     tradeSide,
   ])
 

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/perps-checker/basis-trade-amount.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/perps-checker/basis-trade-amount.tsx
@@ -1,0 +1,93 @@
+import { Button, type ButtonProps } from '@sushiswap/ui'
+import { type FC, useMemo } from 'react'
+import { useAssetState, useBasisTradeAccountBalances } from '../trade-widget'
+
+export const BasisTradeAmount: FC<ButtonProps> = ({
+  children,
+  fullWidth = true,
+  size = 'xl',
+  ...props
+}) => {
+  const {
+    state: { basisTradeAsset, basisTradeSize, tradeSide },
+  } = useAssetState()
+  const {
+    isLoading,
+    perpsBalance,
+    perpQuoteSymbol,
+    spotBaseBalance,
+    spotBaseSymbol,
+    spotEquity,
+  } = useBasisTradeAccountBalances({ basisTradeAsset })
+
+  const { isSizeValid, buttonText } = useMemo(() => {
+    if (isLoading) {
+      return { isSizeValid: false, buttonText: 'Loading Balances' }
+    }
+
+    if (!basisTradeAsset) {
+      return { isSizeValid: false, buttonText: 'Select Basis Pair' }
+    }
+
+    if (
+      Number(basisTradeSize.spot.base) === 0 ||
+      Number(basisTradeSize.perp.base) === 0
+    ) {
+      return { isSizeValid: false, buttonText: 'Enter Sizes' }
+    }
+
+    if (Number(basisTradeSize.spot.quote) < 11) {
+      return { isSizeValid: false, buttonText: 'Min. Spot Size is $11' }
+    }
+
+    if (Number(basisTradeSize.perp.quote) < 11) {
+      return { isSizeValid: false, buttonText: 'Min. Perp Size is $11' }
+    }
+
+    if (tradeSide === 'long') {
+      if (Number(basisTradeSize.spot.quote) > spotEquity) {
+        return {
+          isSizeValid: false,
+          buttonText: 'Insufficient Spot Equity',
+        }
+      }
+    } else {
+      const availableBase = Number(spotBaseBalance?.availableBalance ?? 0)
+      if (Number(basisTradeSize.spot.base) > availableBase) {
+        return {
+          isSizeValid: false,
+          buttonText: `Insufficient ${spotBaseSymbol}`,
+        }
+      }
+    }
+
+    if (Number(basisTradeSize.perp.quote) > Number(perpsBalance ?? 0)) {
+      return {
+        isSizeValid: false,
+        buttonText: `Insufficient ${perpQuoteSymbol} Perp Balance`,
+      }
+    }
+
+    return { isSizeValid: true, buttonText: '' }
+  }, [
+    basisTradeAsset,
+    basisTradeSize,
+    isLoading,
+    perpsBalance,
+    perpQuoteSymbol,
+    spotBaseBalance,
+    spotBaseSymbol,
+    spotEquity,
+    tradeSide,
+  ])
+
+  if (!isSizeValid) {
+    return (
+      <Button fullWidth={fullWidth} size={size} disabled {...props}>
+        {buttonText}
+      </Button>
+    )
+  }
+
+  return <>{children}</>
+}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/perps-checker/index.ts
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/perps-checker/index.ts
@@ -1,5 +1,6 @@
 import type { ButtonProps } from '@headlessui/react'
 import type { ComponentType } from 'react'
+import { BasisTradeAmount } from './basis-trade-amount'
 import { BuilderFee } from './builder-fee'
 import { Deposit } from './deposit'
 import { EnableTrading } from './enable-trading'
@@ -18,6 +19,7 @@ export type PerpsCheckerProps = {
   Deposit: ComponentType<ButtonProps>
   BuilderFee: ComponentType<ButtonProps>
   OrderAmount: ComponentType<ButtonProps>
+  BasisTradeAmount: ComponentType<ButtonProps>
   TwapRunningTime: ComponentType<ButtonProps>
   TwapSuborder: ComponentType<ButtonProps>
   TakeStopTrigger: ComponentType<ButtonProps>
@@ -32,6 +34,7 @@ export const PerpsChecker = {
   Deposit,
   BuilderFee,
   OrderAmount,
+  BasisTradeAmount,
   TwapRunningTime,
   TwapSuborder,
   TakeStopTrigger,

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-tables/_common/share-closed-pnl-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-tables/_common/share-closed-pnl-dialog.tsx
@@ -1626,7 +1626,7 @@ function drawTextTopHighlight(
     0,
     y,
     0,
-    y + textHeight * 0,
+    y + textHeight * 0.55,
   )
 
   highlightGradient.addColorStop(0, 'rgba(255, 255, 255, 0.38)')

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/asset-state-provider.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/asset-state-provider.tsx
@@ -18,17 +18,26 @@ import {
   useUserPositions,
 } from 'src/lib/perps'
 import { useActiveAccountState } from '~evm/perps/active-account-provider'
-import { useAssetListState } from '../asset-selector'
+import { type BasisTradeAsset, useAssetListState } from '../asset-selector'
+
+type OrderSize = { base: string; quote: string }
+
 interface State {
   mutate: {
     setActiveAsset: (asset: string) => void
+    setActiveBasisTradeAsset: (basisTradeAsset: BasisTradeAsset) => void
     setTradeType: (tradeType: TradeType) => void
     setTradeSide: (tradeSide: TradeSideType) => void
     setReduceOnly: (reduceOnly: boolean) => void
-    setSize: (size: { base: string; quote: string }) => void
+    setSize: (size: OrderSize) => void
+    setBasisTradeSize: (leg: BasisTradeSizeKey, size: OrderSize) => void
     setLimitPrice: (limitPrice: string) => void
     setTimeInForce: (timeInForce: TimeInForceType) => void
     setSizeSide: (sizeSide: 'base' | 'quote') => void
+    setBasisTradeSizeSide: (
+      leg: BasisTradeSizeKey,
+      sizeSide: 'base' | 'quote',
+    ) => void
     setPercentage: (percentage: number) => void
     setTpPrice: (tpPrice: string) => void
     setSlPrice: (slPrice: string) => void
@@ -48,13 +57,18 @@ interface State {
     tradeType: TradeType
     tradeSide: TradeSideType
     reduceOnly: boolean
-    size: { base: string; quote: string }
+    size: OrderSize
+    basisTradeSize: BasisTradeSize
     limitPrice: string
     timeInForce: TimeInForceType
     sizeSide: 'base' | 'quote'
+    basisTradeSizeSide: BasisTradeSizeSide
     asset: PerpOrSpotAsset | undefined
+    basisTradeAsset: BasisTradeAsset | undefined
     percentage: number
     maxTradeSize: string
+    maxTradeSizeLong: string
+    maxTradeSizeShort: string
     availableToLong: string
     availableToShort: string
     markPrice: string
@@ -88,9 +102,21 @@ export type ScaleStartEnd = {
   end: string
 }
 
+export type BasisTradeSizeKey = 'spot' | 'perp'
+
+export type BasisTradeSize = Record<BasisTradeSizeKey, OrderSize>
+
+export type BasisTradeSizeSide = Record<BasisTradeSizeKey, 'base' | 'quote'>
+
+type BasisTradeAssetKeys = {
+  spotAsset: string
+  perpAsset: string
+}
+
 export const TRADE_TYPES = [
   'market',
   'limit',
+  'basis trade',
   'scale',
   'stop limit',
   'stop market',
@@ -113,11 +139,22 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
   const [lastUsedLeverages, setLastUsedLeverages] = useLocalStorage<
     Record<string, number>
   >('hyperliquid.last_used_leverage', {})
-  const [tradeType, setTradeType] = useState<TradeType>('market')
+  const [tradeType, _setTradeType] = useState<TradeType>('market')
   const [tradeSide, setTradeSide] = useState<TradeSideType>('long')
   const [reduceOnly, _setReduceOnly] = useState(false)
   const [size, setSize] = useState({ base: '', quote: '' })
+  const [basisTradeAssetKeys, setBasisTradeAssetKeys] =
+    useState<BasisTradeAssetKeys>()
+  const [basisTradeSize, setBasisTradeSizeState] = useState<BasisTradeSize>({
+    spot: { base: '', quote: '' },
+    perp: { base: '', quote: '' },
+  })
   const [sizeSide, setSizeSide] = useState<'base' | 'quote'>('base')
+  const [basisTradeSizeSide, setBasisTradeSizeSideState] =
+    useState<BasisTradeSizeSide>({
+      spot: 'base',
+      perp: 'base',
+    })
   const [limitPrice, setLimitPrice] = useState('')
   const [timeInForce, setTimeInForce] = useState<TimeInForceType>('Gtc')
   const [percentage, setPercentage] = useState(0)
@@ -145,6 +182,7 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
   const {
     state: {
       assetListQuery: { data: assetList },
+      basisTradeAssets,
     },
   } = useAssetListState()
   const pathname = usePathname()
@@ -154,12 +192,16 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
   const setActiveAsset = useCallback(
     (asset: string) => {
       _setActiveAsset(asset)
+      setBasisTradeAssetKeys(undefined)
+      if (tradeType === 'basis trade') {
+        _setTradeType('market')
+      }
       reset()
       if (!isTradePage) {
         push('/perps')
       }
     },
-    [_setActiveAsset, push, isTradePage],
+    [_setActiveAsset, push, isTradePage, tradeType],
   )
 
   const reset = useCallback(() => {
@@ -172,6 +214,14 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
     setReduceOnly(false)
     setTimeInForce('Gtc')
     setSize({ base: '', quote: '' })
+    setBasisTradeSizeState({
+      spot: { base: '', quote: '' },
+      perp: { base: '', quote: '' },
+    })
+    setBasisTradeSizeSideState({
+      spot: 'base',
+      perp: 'base',
+    })
     setScaleStartEnd({ start: '', end: '' })
     setTotalOrders('2')
     setSizeSkew('1')
@@ -184,6 +234,83 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
     if (!assetList) return _activeAsset
     return assetList.has(_activeAsset) ? _activeAsset : 'BTC'
   }, [_activeAsset, assetList])
+
+  const basisTradeAsset = useMemo(() => {
+    if (!basisTradeAssets.length) return undefined
+
+    if (basisTradeAssetKeys) {
+      return basisTradeAssets.find(
+        (asset) =>
+          asset.spotAsset.name === basisTradeAssetKeys.spotAsset &&
+          asset.perpAsset.name === basisTradeAssetKeys.perpAsset,
+      )
+    }
+
+    return basisTradeAssets.find(
+      (asset) =>
+        asset.perpAsset.name === activeAsset ||
+        asset.spotAsset.name === activeAsset,
+    )
+  }, [activeAsset, basisTradeAssetKeys, basisTradeAssets])
+
+  const setActiveBasisTradeAsset = useCallback(
+    (_basisTradeAsset: BasisTradeAsset) => {
+      _setActiveAsset(_basisTradeAsset.perpAsset.name)
+      setBasisTradeAssetKeys({
+        spotAsset: _basisTradeAsset.spotAsset.name,
+        perpAsset: _basisTradeAsset.perpAsset.name,
+      })
+      reset()
+      _setTradeType('basis trade')
+      if (!isTradePage) {
+        push('/perps')
+      }
+    },
+    [_setActiveAsset, push, isTradePage, reset],
+  )
+
+  const setTradeType = useCallback(
+    (_tradeType: TradeType) => {
+      if (_tradeType === 'basis trade') {
+        if (basisTradeAsset) {
+          setBasisTradeAssetKeys({
+            spotAsset: basisTradeAsset.spotAsset.name,
+            perpAsset: basisTradeAsset.perpAsset.name,
+          })
+          _setActiveAsset(basisTradeAsset.perpAsset.name)
+        }
+        _setReduceOnly(false)
+        _setHasTpSl(false)
+        _setTradeType(_tradeType)
+        return
+      }
+
+      if (tradeType === 'basis trade') {
+        setBasisTradeAssetKeys(undefined)
+        setBasisTradeSizeState({
+          spot: { base: '', quote: '' },
+          perp: { base: '', quote: '' },
+        })
+      }
+
+      _setTradeType(_tradeType)
+    },
+    [_setActiveAsset, basisTradeAsset, tradeType],
+  )
+
+  const setBasisTradeSize = useCallback(
+    (leg: BasisTradeSizeKey, _size: OrderSize) => {
+      setBasisTradeSizeState((prev) => ({ ...prev, [leg]: _size }))
+    },
+    [],
+  )
+
+  const setBasisTradeSizeSide = useCallback(
+    (leg: BasisTradeSizeKey, _sizeSide: 'base' | 'quote') => {
+      setBasisTradeSizeSideState((prev) => ({ ...prev, [leg]: _sizeSide }))
+    },
+    [],
+  )
 
   const activeAssetDataQuery = useActiveAssetData({
     address,
@@ -351,13 +478,16 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
         return {
           mutate: {
             setActiveAsset,
+            setActiveBasisTradeAsset,
             setTradeType,
             setTradeSide,
             setReduceOnly,
             setSize,
+            setBasisTradeSize,
             setLimitPrice,
             setTimeInForce,
             setSizeSide,
+            setBasisTradeSizeSide,
             setPercentage,
             setTpPrice,
             setSlPrice,
@@ -375,12 +505,17 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
             tradeSide,
             reduceOnly,
             size,
+            basisTradeSize,
             limitPrice,
             timeInForce,
             sizeSide,
+            basisTradeSizeSide,
             asset,
+            basisTradeAsset,
             percentage,
             maxTradeSize,
+            maxTradeSizeLong,
+            maxTradeSizeShort,
             availableToLong,
             availableToShort,
             markPrice,
@@ -405,16 +540,23 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
       }, [
         activeAsset,
         setActiveAsset,
+        setActiveBasisTradeAsset,
+        setTradeType,
         tradeType,
         tradeSide,
         reduceOnly,
         size,
+        basisTradeSize,
         limitPrice,
         timeInForce,
         sizeSide,
+        basisTradeSizeSide,
         asset,
+        basisTradeAsset,
         percentage,
         maxTradeSize,
+        maxTradeSizeLong,
+        maxTradeSizeShort,
         availableToLong,
         availableToShort,
         markPrice,
@@ -436,6 +578,8 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
         twapRandomize,
         totalRunningTimeInMinutes,
         isLimitOrder,
+        setBasisTradeSize,
+        setBasisTradeSizeSide,
       ])}
     >
       {children}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/asset-state-provider.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/asset-state-provider.tsx
@@ -140,7 +140,7 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
     Record<string, number>
   >('hyperliquid.last_used_leverage', {})
   const [tradeType, _setTradeType] = useState<TradeType>('market')
-  const [tradeSide, setTradeSide] = useState<TradeSideType>('long')
+  const [tradeSide, _setTradeSide] = useState<TradeSideType>('long')
   const [reduceOnly, _setReduceOnly] = useState(false)
   const [size, setSize] = useState({ base: '', quote: '' })
   const [basisTradeAssetKeys, setBasisTradeAssetKeys] =
@@ -267,6 +267,20 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
       }
     },
     [_setActiveAsset, push, isTradePage, reset],
+  )
+
+  const setTradeSide = useCallback(
+    (_tradeSide: TradeSideType) => {
+      if (tradeType === 'basis trade' && _tradeSide !== tradeSide) {
+        setBasisTradeSizeState({
+          spot: { base: '', quote: '' },
+          perp: { base: '', quote: '' },
+        })
+      }
+
+      _setTradeSide(_tradeSide)
+    },
+    [tradeSide, tradeType],
   )
 
   const setTradeType = useCallback(
@@ -542,6 +556,7 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
         setActiveAsset,
         setActiveBasisTradeAsset,
         setTradeType,
+        setTradeSide,
         tradeType,
         tradeSide,
         reduceOnly,

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/asset-state-provider.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/asset-state-provider.tsx
@@ -239,17 +239,21 @@ const AssetStateProvider: FC<AssetStateProviderProps> = ({ children }) => {
     if (!basisTradeAssets.length) return undefined
 
     if (basisTradeAssetKeys) {
-      return basisTradeAssets.find(
+      const matchingBasisTradeAsset = basisTradeAssets.find(
         (asset) =>
           asset.spotAsset.name === basisTradeAssetKeys.spotAsset &&
           asset.perpAsset.name === basisTradeAssetKeys.perpAsset,
       )
+
+      if (matchingBasisTradeAsset) return matchingBasisTradeAsset
     }
 
-    return basisTradeAssets.find(
-      (asset) =>
-        asset.perpAsset.name === activeAsset ||
-        asset.spotAsset.name === activeAsset,
+    return (
+      basisTradeAssets.find(
+        (asset) =>
+          asset.perpAsset.name === activeAsset ||
+          asset.spotAsset.name === activeAsset,
+      ) ?? basisTradeAssets.find((asset) => asset.perpAsset.name === 'BTC') //fallback to BTC if no matching basis trade asset is found
     )
   }, [activeAsset, basisTradeAssetKeys, basisTradeAssets])
 

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/available-to-trade.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/available-to-trade.tsx
@@ -5,10 +5,21 @@ import { StatItem, TableButton } from '../_common'
 import { PerpSpotTransferDialog } from '../account-management'
 import { SwapStablesDialog } from '../account-management/swap-stables-dialog'
 import { useAssetState } from './asset-state-provider'
+import {
+  BasisTradePerpAvailability,
+  BasisTradeSpotAvailability,
+} from './basis-trade-spot-availability'
 
 export const AvailableToTrade = () => {
   const {
-    state: { tradeSide, availableToLong, availableToShort, asset, markPrice },
+    state: {
+      tradeSide,
+      tradeType,
+      availableToLong,
+      availableToShort,
+      asset,
+      markPrice,
+    },
   } = useAssetState()
   const { baseSymbol, quoteSymbol } = useSymbolSplit({ asset })
   const [open, setOpen] = useState(false)
@@ -47,6 +58,15 @@ export const AvailableToTrade = () => {
   const buttonText = useMemo(() => {
     return `${tradeSide === 'long' ? availToLong : availToShort} ${quoteSymbol}`
   }, [tradeSide, availToLong, availToShort, quoteSymbol])
+
+  if (tradeType === 'basis trade') {
+    return (
+      <>
+        <BasisTradePerpAvailability />
+        <BasisTradeSpotAvailability />
+      </>
+    )
+  }
 
   if (asset?.marketType === 'spot') {
     return (

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/basis-trade-spot-availability.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/basis-trade-spot-availability.tsx
@@ -1,15 +1,15 @@
 'use client'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import {
   type BalanceItemType,
-  currencyFormatter,
   perpsNumberFormatter,
   useBalances,
   useSymbolSplit,
   useUserAccountValues,
 } from 'src/lib/perps'
 import { useUserState } from '~evm/perps/user-provider'
-import { StatItem } from '../_common'
+import { StatItem, TableButton } from '../_common'
+import { SwapStablesDialog } from '../account-management/swap-stables-dialog'
 import type { BasisTradeAsset } from '../asset-selector'
 import { useAssetState } from './asset-state-provider'
 
@@ -101,21 +101,45 @@ export const BasisTradePerpAvailability = () => {
   const { quoteSymbol } = useSymbolSplit({
     asset: basisTradeAsset?.perpAsset,
   })
+  const [open, setOpen] = useState(false)
 
   if (!basisTradeAsset) return null
 
   const availablePerp =
     tradeSide === 'long' ? availableToShort : availableToLong
 
+  const buttonText = `${perpsNumberFormatter({
+    value: availablePerp,
+    minFraxDigits: 2,
+    maxFraxDigits: 2,
+  })} ${quoteSymbol}`
+
   return (
-    <StatItem
-      title="Available Perp"
-      value={`${perpsNumberFormatter({
-        value: availablePerp,
-        minFraxDigits: 2,
-        maxFraxDigits: 2,
-      })} ${quoteSymbol}`}
-    />
+    <>
+      <StatItem
+        title="Available Perp Trade"
+        value={
+          basisTradeAsset?.perpAsset?.dex !== '' && quoteSymbol !== 'USDC' ? (
+            <TableButton onClick={() => setOpen(true)}>
+              {buttonText}
+            </TableButton>
+          ) : (
+            <>{buttonText}</>
+          )
+        }
+      />
+      {open ? (
+        <SwapStablesDialog
+          trigger={<div />}
+          nonSelectableSwapData={{
+            assetSymbolToSend: 'USDC',
+            assetSymbolToBuy: quoteSymbol,
+          }}
+          isOpen={open}
+          onOpenChange={setOpen}
+        />
+      ) : null}
+    </>
   )
 }
 
@@ -123,28 +147,32 @@ export const BasisTradeSpotAvailability = () => {
   const {
     state: { basisTradeAsset, tradeSide },
   } = useAssetState()
-  const { spotBaseBalance, spotBaseSymbol, spotEquity } =
+  const { spotBaseBalance, spotBaseSymbol, spotQuoteBalance, spotQuoteSymbol } =
     useBasisTradeAccountBalances({ basisTradeAsset })
 
   if (!basisTradeAsset) return null
 
   const availableSpot =
     tradeSide === 'long'
-      ? spotEquity.toString()
-      : spotBaseBalance?.availableBalance
+      ? (spotQuoteBalance?.availableBalance ?? '0')
+      : (spotBaseBalance?.availableBalance ?? '0')
 
   return (
     <StatItem
-      title="Available Spot"
+      title="Available Spot Trade"
       value={
         availableSpot
           ? tradeSide === 'long'
-            ? currencyFormatter.format(Number(availableSpot))
+            ? `${perpsNumberFormatter({
+                value: availableSpot,
+                minFraxDigits: 2,
+                maxFraxDigits: 2,
+              })} ${spotQuoteSymbol}`
             : `${perpsNumberFormatter({
                 value: availableSpot,
                 maxFraxDigits: basisTradeAsset.spotAsset.formatParseDecimals,
               })} ${spotBaseSymbol}`
-          : 'N/A'
+          : '0'
       }
     />
   )

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/basis-trade-spot-availability.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/basis-trade-spot-availability.tsx
@@ -1,0 +1,181 @@
+'use client'
+import { useMemo } from 'react'
+import {
+  type BalanceItemType,
+  currencyFormatter,
+  perpsNumberFormatter,
+  useBalances,
+  useSymbolSplit,
+  useUserAccountValues,
+} from 'src/lib/perps'
+import { useUserState } from '~evm/perps/user-provider'
+import { StatItem } from '../_common'
+import type { BasisTradeAsset } from '../asset-selector'
+import { useAssetState } from './asset-state-provider'
+
+export function useBasisTradeAccountBalances({
+  basisTradeAsset,
+}: {
+  basisTradeAsset: BasisTradeAsset | undefined
+}) {
+  const { data: balances, isLoading: isBalancesLoading } = useBalances()
+  const { spotEquity, isLoading: isAccountValuesLoading } =
+    useUserAccountValues()
+  const {
+    state: {
+      allDexClearinghouseStateQuery: {
+        data: allDexClearinghouseState,
+        isLoading: isAllDexClearinghouseStateLoading,
+      },
+    },
+  } = useUserState()
+  const { baseSymbol: spotBaseSymbol, quoteSymbol: spotQuoteSymbol } =
+    useSymbolSplit({
+      asset: basisTradeAsset?.spotAsset,
+    })
+  const { quoteSymbol: perpQuoteSymbol } = useSymbolSplit({
+    asset: basisTradeAsset?.perpAsset,
+  })
+
+  const spotBaseBalance = useMemo(() => {
+    if (!basisTradeAsset) return undefined
+
+    return getBasisTradeSpotTokenBalance({
+      balances,
+      tokenIndex: basisTradeAsset.spotAsset.tokens?.[0]?.index,
+      symbol: spotBaseSymbol,
+    })
+  }, [balances, basisTradeAsset, spotBaseSymbol])
+
+  const spotQuoteBalance = useMemo(() => {
+    if (!basisTradeAsset) return undefined
+
+    return getBasisTradeSpotTokenBalance({
+      balances,
+      tokenIndex: basisTradeAsset.spotAsset.tokens?.[1]?.index,
+      symbol: spotQuoteSymbol,
+    })
+  }, [balances, basisTradeAsset, spotQuoteSymbol])
+
+  const perpsBalance = useMemo(() => {
+    if (!basisTradeAsset || !allDexClearinghouseState) return undefined
+
+    const clearinghouseState =
+      allDexClearinghouseState.clearinghouseStates.find(
+        ([dex]) => dex === basisTradeAsset.perpAsset.dex,
+      )?.[1]
+
+    if (!clearinghouseState) return undefined
+
+    const unrealizedPnl = clearinghouseState.assetPositions.reduce(
+      (acc, assetPosition) =>
+        acc + Number(assetPosition.position.unrealizedPnl ?? 0),
+      0,
+    )
+
+    return (
+      Number(clearinghouseState.marginSummary?.accountValue ?? 0) -
+      unrealizedPnl
+    )
+  }, [allDexClearinghouseState, basisTradeAsset])
+
+  return {
+    isLoading:
+      isBalancesLoading ||
+      isAccountValuesLoading ||
+      isAllDexClearinghouseStateLoading,
+    perpsBalance,
+    perpQuoteSymbol,
+    spotBaseBalance,
+    spotBaseSymbol,
+    spotEquity,
+    spotQuoteBalance,
+    spotQuoteSymbol,
+  }
+}
+
+export const BasisTradePerpAvailability = () => {
+  const {
+    state: { availableToLong, availableToShort, basisTradeAsset, tradeSide },
+  } = useAssetState()
+  const { quoteSymbol } = useSymbolSplit({
+    asset: basisTradeAsset?.perpAsset,
+  })
+
+  if (!basisTradeAsset) return null
+
+  const availablePerp =
+    tradeSide === 'long' ? availableToShort : availableToLong
+
+  return (
+    <StatItem
+      title="Available Perp"
+      value={`${perpsNumberFormatter({
+        value: availablePerp,
+        minFraxDigits: 2,
+        maxFraxDigits: 2,
+      })} ${quoteSymbol}`}
+    />
+  )
+}
+
+export const BasisTradeSpotAvailability = () => {
+  const {
+    state: { basisTradeAsset, tradeSide },
+  } = useAssetState()
+  const { spotBaseBalance, spotBaseSymbol, spotEquity } =
+    useBasisTradeAccountBalances({ basisTradeAsset })
+
+  if (!basisTradeAsset) return null
+
+  const availableSpot =
+    tradeSide === 'long'
+      ? spotEquity.toString()
+      : spotBaseBalance?.availableBalance
+
+  return (
+    <StatItem
+      title="Available Spot"
+      value={
+        availableSpot
+          ? tradeSide === 'long'
+            ? currencyFormatter.format(Number(availableSpot))
+            : `${perpsNumberFormatter({
+                value: availableSpot,
+                maxFraxDigits: basisTradeAsset.spotAsset.formatParseDecimals,
+              })} ${spotBaseSymbol}`
+          : 'N/A'
+      }
+    />
+  )
+}
+
+function getBasisTradeSpotTokenBalance({
+  balances,
+  tokenIndex,
+  symbol,
+}: {
+  balances: BalanceItemType[]
+  tokenIndex: number | undefined
+  symbol: string
+}): BalanceItemType | undefined {
+  return (
+    balances.find(
+      (balance) =>
+        tokenIndex !== undefined &&
+        isSpotLikeBalance(balance) &&
+        balance.token?.index === tokenIndex,
+    ) ??
+    balances.find(
+      (balance) =>
+        isSpotLikeBalance(balance) &&
+        (balance.coin === symbol ||
+          balance.coin.startsWith(`${symbol} `) ||
+          balance.coin.startsWith(`${symbol} (`)),
+    )
+  )
+}
+
+function isSpotLikeBalance(balance: BalanceItemType): boolean {
+  return balance.marketType === 'spot' || balance.marketType === 'unified'
+}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/asset-display.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/asset-display.tsx
@@ -19,6 +19,7 @@ export const AssetDisplay = () => {
         <_Display
           tradeSide={tradeSide}
           asset={basisTradeAsset?.spotAsset}
+          assetForIcon={basisTradeAsset?.perpAsset}
           currentLeverageForAsset={currentLeverageForAsset}
         />
         <_Display
@@ -42,10 +43,12 @@ export const AssetDisplay = () => {
 const _Display = ({
   tradeSide,
   asset,
+  assetForIcon,
   currentLeverageForAsset,
 }: {
   tradeSide: TradeSideType
   asset: PerpOrSpotAsset | undefined
+  assetForIcon?: PerpOrSpotAsset
   currentLeverageForAsset: number | undefined
 }) => {
   return (
@@ -53,7 +56,7 @@ const _Display = ({
       <Circles tradeSide={tradeSide} />
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
         <div className="relative border rounded-full border-perps-muted-50">
-          <AssetIcon asset={asset} size="xl" />
+          <AssetIcon asset={assetForIcon || asset} size="xl" />
           <div
             className="absolute left-1/2 -translate-x-1/2 -bottom-2.5 rounded-full text-white text-xs px-2 py-px backdrop-blur-[1px] font-semibold"
             style={{

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/asset-display.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/asset-display.tsx
@@ -1,10 +1,53 @@
+import type { PerpOrSpotAsset } from 'src/lib/perps'
 import { AssetIcon } from '../../_common'
 import { type TradeSideType, useAssetState } from '../asset-state-provider'
 
 export const AssetDisplay = () => {
   const {
-    state: { tradeSide, asset, currentLeverageForAsset },
+    state: {
+      tradeSide,
+      asset,
+      currentLeverageForAsset,
+      basisTradeAsset,
+      tradeType,
+    },
   } = useAssetState()
+
+  if (tradeType === 'basis trade') {
+    return (
+      <div className="flex flex-row gap-4">
+        <_Display
+          tradeSide={tradeSide}
+          asset={basisTradeAsset?.spotAsset}
+          currentLeverageForAsset={currentLeverageForAsset}
+        />
+        <_Display
+          tradeSide={tradeSide === 'long' ? 'short' : 'long'}
+          asset={basisTradeAsset?.perpAsset}
+          currentLeverageForAsset={currentLeverageForAsset}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <_Display
+      tradeSide={tradeSide}
+      asset={asset}
+      currentLeverageForAsset={currentLeverageForAsset}
+    />
+  )
+}
+
+const _Display = ({
+  tradeSide,
+  asset,
+  currentLeverageForAsset,
+}: {
+  tradeSide: TradeSideType
+  asset: PerpOrSpotAsset | undefined
+  currentLeverageForAsset: number | undefined
+}) => {
   return (
     <div className="relative">
       <Circles tradeSide={tradeSide} />

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/confirm-dialog-trigger.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/confirm-dialog-trigger.tsx
@@ -2,12 +2,20 @@ import { Button, DialogTrigger } from '@sushiswap/ui'
 import { Checker } from 'src/lib/wagmi/systems/Checker'
 import { useUserSettingsState } from '../../account-management'
 import { PerpsChecker } from '../../perps-checker'
+import { useAssetState } from '../asset-state-provider'
 import { PlaceOrderButton } from './place-order-button'
 
 export const ConfirmDialogTrigger = () => {
   const {
     state: { quickConfirmPositionEnabled },
   } = useUserSettingsState()
+  const {
+    state: { tradeType },
+  } = useAssetState()
+  const AmountChecker =
+    tradeType === 'basis trade'
+      ? PerpsChecker.BasisTradeAmount
+      : PerpsChecker.OrderAmount
 
   return (
     <Checker.Connect size="sm" namespace="evm" variant="perps-default">
@@ -21,7 +29,7 @@ export const ConfirmDialogTrigger = () => {
                     size="sm"
                     variant="perps-default"
                   >
-                    <PerpsChecker.OrderAmount size="sm" variant="perps-default">
+                    <AmountChecker size="sm" variant="perps-default">
                       <PerpsChecker.TakeStopTrigger
                         size="sm"
                         variant="perps-default"
@@ -45,7 +53,7 @@ export const ConfirmDialogTrigger = () => {
                           )}
                         </PerpsChecker.TwapSuborder>
                       </PerpsChecker.TakeStopTrigger>
-                    </PerpsChecker.OrderAmount>
+                    </AmountChecker>
                   </PerpsChecker.TwapRunningTime>
                 </PerpsChecker.HyperReferral>
               </PerpsChecker.BuilderFee>

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/confirm-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/confirm-dialog.tsx
@@ -14,7 +14,7 @@ import {
   useScaleOrders,
   useSymbolSplit,
 } from 'src/lib/perps'
-import { CheckboxSetting, StatItem } from '../../_common'
+import { AssetIcon, CheckboxSetting, StatItem } from '../../_common'
 import { useUserSettingsState } from '../../account-management'
 import { useAssetState } from '../asset-state-provider'
 import {
@@ -67,7 +67,9 @@ export const ConfirmDialog = () => {
               <AssetDisplay />
             </div>
             <div className="flex flex-col gap-2">
-              {tradeType === 'TWAP' ? (
+              {tradeType === 'basis trade' ? (
+                <_BasisTradeOrderStats />
+              ) : tradeType === 'TWAP' ? (
                 <_TwapOrderStats />
               ) : tradeType === 'scale' ? (
                 <_ScaleOrderStats />
@@ -142,6 +144,51 @@ const _RegularOrderStats = () => {
           </div>
         }
       />
+    </>
+  )
+}
+
+const _BasisTradeOrderStats = () => {
+  const {
+    state: { basisTradeAsset, basisTradeSize, tradeSide },
+  } = useAssetState()
+  const { baseSymbol: spotBaseSymbol } = useSymbolSplit({
+    asset: basisTradeAsset?.spotAsset,
+  })
+  const { baseSymbol: perpBaseSymbol } = useSymbolSplit({
+    asset: basisTradeAsset?.perpAsset,
+  })
+
+  if (!basisTradeAsset) return null
+
+  return (
+    <>
+      <StatItem
+        title="Spot Action"
+        value={
+          <div className={getTextColorClass(tradeSide === 'long' ? 1 : -1)}>
+            {tradeSide === 'long' ? 'Buy' : 'Sell'}
+          </div>
+        }
+      />
+      <StatItem
+        title="Spot Size"
+        value={`${basisTradeSize.spot.base || '0'} ${spotBaseSymbol}`}
+      />
+      <StatItem
+        title="Perp Action"
+        value={
+          <div className={getTextColorClass(tradeSide === 'long' ? -1 : 1)}>
+            {tradeSide === 'long' ? 'Short' : 'Long'}
+          </div>
+        }
+      />
+      <StatItem
+        title="Perp Size"
+        value={`${basisTradeSize.perp.base || '0'} ${perpBaseSymbol}`}
+      />
+      <StatItem title="Price" value="Market" />
+      <StatItem title="Time in Force" value="FrontendMarket" />
     </>
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/place-order-button.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/place-order-button.tsx
@@ -4,6 +4,7 @@ import {
   BUILDER_FEE_PERPS,
   BUILDER_FEE_SPOT,
   type OrderData,
+  type PerpOrSpotAsset,
   type TwapOrder,
   formatPrice,
   formatSize,
@@ -44,8 +45,16 @@ export const PlaceOrderButton = ({ onMutate }: { onMutate?: () => void }) => {
     } else {
       if (!orderData || orderData.orders.length === 0) return
       try {
-        // console.log('Executing orders with data:', orderData)
-        await executeOrdersAsync({ orderData })
+        if (tradeType === 'basis trade') {
+          const singleLegOrders = getBasisTradeSingleLegOrderData(orderData)
+
+          for (const singleLegOrderData of singleLegOrders) {
+            await executeOrdersAsync({ orderData: singleLegOrderData })
+          }
+        } else {
+          // console.log('Executing orders with data:', orderData)
+          await executeOrdersAsync({ orderData })
+        }
         onMutate?.()
       } catch (error) {
         console.log(error)
@@ -64,11 +73,14 @@ export const PlaceOrderButton = ({ onMutate }: { onMutate?: () => void }) => {
     if (quickConfirmPositionEnabled && !onMutate) {
       return 'Place Order'
     }
+    if (tradeType === 'basis trade') {
+      return tradeSide === 'long' ? 'Buy / Short' : 'Sell / Long'
+    }
     if (asset?.marketType === 'spot') {
       return tradeSide === 'long' ? 'Buy' : 'Sell'
     }
     return tradeSide === 'long' ? 'Buy / Long' : 'Sell / Short'
-  }, [quickConfirmPositionEnabled, onMutate, tradeSide, asset])
+  }, [quickConfirmPositionEnabled, onMutate, tradeType, tradeSide, asset])
 
   return (
     <Button
@@ -80,6 +92,20 @@ export const PlaceOrderButton = ({ onMutate }: { onMutate?: () => void }) => {
       {buttonText}
     </Button>
   )
+}
+
+function getBasisTradeSingleLegOrderData(orderData: OrderData): OrderData[] {
+  return orderData.orders.map((order) => ({
+    orders: [order],
+    grouping: 'na' as const,
+    builder: {
+      // https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids#perps
+      builderFee:
+        Number(order.asset) >= 10_000 && Number(order.asset) < 100_000
+          ? BUILDER_FEE_SPOT
+          : BUILDER_FEE_PERPS,
+    },
+  }))
 }
 
 const _useTwapOrderData = () => {
@@ -133,9 +159,21 @@ const _useOrderData = () => {
       limitPrice,
       timeInForce,
       triggerPrice,
+      basisTradeAsset,
+      basisTradeSize,
     },
   } = useAssetState()
   const marketPrice = _useMarketPrice()
+  const basisSpotMarketPrice = _useMarketPriceForAsset({
+    assetString: basisTradeAsset?.spotAsset.name,
+    asset: basisTradeAsset?.spotAsset,
+    tradeSide: tradeSide === 'long' ? 'long' : 'short',
+  })
+  const basisPerpMarketPrice = _useMarketPriceForAsset({
+    assetString: basisTradeAsset?.perpAsset.name,
+    asset: basisTradeAsset?.perpAsset,
+    tradeSide: tradeSide === 'long' ? 'short' : 'long',
+  })
   const { tpOrder, slOrder } = _useTpSlOrder()
   const builderFee = _useBuilderFee()
   const { data: scaleOrderData } = useScaleOrders()
@@ -192,6 +230,55 @@ const _useOrderData = () => {
           ],
           grouping:
             tpOrder || slOrder ? ('normalTpsl' as const) : ('na' as const),
+          builder: {
+            builderFee: builderFee,
+          },
+        }
+      }
+      case 'basis trade': {
+        if (
+          !basisTradeAsset ||
+          !basisSpotMarketPrice ||
+          !basisPerpMarketPrice
+        ) {
+          return undefined
+        }
+
+        const spotSize = formatSize(
+          basisTradeSize.spot.base,
+          basisTradeAsset.spotAsset.decimals,
+        )
+        const perpSize = formatSize(
+          basisTradeSize.perp.base,
+          basisTradeAsset.perpAsset.decimals,
+        )
+
+        return {
+          orders: [
+            {
+              asset: basisTradeAsset.spotAsset.name,
+              side:
+                tradeSide === 'long' ? ('long' as const) : ('short' as const),
+              price: basisSpotMarketPrice,
+              size: spotSize,
+              reduceOnly: false,
+              orderType: {
+                limit: { timeInForce: 'FrontendMarket' as const },
+              },
+            },
+            {
+              asset: basisTradeAsset.perpAsset.name,
+              side:
+                tradeSide === 'long' ? ('short' as const) : ('long' as const),
+              price: basisPerpMarketPrice,
+              size: perpSize,
+              reduceOnly: false,
+              orderType: {
+                limit: { timeInForce: 'FrontendMarket' as const },
+              },
+            },
+          ],
+          grouping: 'na' as const,
           builder: {
             builderFee: builderFee,
           },
@@ -368,51 +455,91 @@ const _useOrderData = () => {
     builderFee,
     triggerPrice,
     scaleOrderData,
+    basisTradeAsset,
+    basisTradeSize,
+    basisSpotMarketPrice,
+    basisPerpMarketPrice,
   ])
 }
 
 const _useBuilderFee = () => {
   const {
-    state: { asset },
+    state: { asset, tradeType },
   } = useAssetState()
 
   return useMemo(() => {
+    if (tradeType === 'basis trade') return BUILDER_FEE_PERPS
     if (!asset) return BUILDER_FEE_PERPS
     return asset?.marketType === 'perp' ? BUILDER_FEE_PERPS : BUILDER_FEE_SPOT
-  }, [asset])
+  }, [asset, tradeType])
 }
 
 const _useMarketPrice = () => {
   const {
     state: { activeAsset, asset, tradeSide },
   } = useAssetState()
-  const { midPrice } = useMidPrice({
+  return _useMarketPriceForAsset({
     assetString: activeAsset,
+    asset,
+    tradeSide,
+  })
+}
+
+const _useMarketPriceForAsset = ({
+  assetString,
+  asset,
+  tradeSide,
+}: {
+  assetString: string | undefined
+  asset: PerpOrSpotAsset | undefined
+  tradeSide: 'long' | 'short'
+}) => {
+  const { midPrice } = useMidPrice({
+    assetString,
   })
   const {
     state: { marketOrderSlippage },
   } = useUserSettingsState()
 
   return useMemo(() => {
-    if (!midPrice || !asset) return undefined
-    const _midPrice = parseUnits(midPrice ?? '0', asset?.formatParseDecimals)
-    // console.log(asset, midPrice, _midPrice)
-    const slippage =
-      tradeSide === 'long'
-        ? Number(marketOrderSlippage) + 10_000
-        : 10_000 - Number(marketOrderSlippage)
-    const adjustedPrice = (_midPrice * BigInt(slippage)) / BigInt(10_000) // 8% lower for buy orders
-
-    try {
-      return formatPrice(
-        formatUnits(adjustedPrice, asset?.formatParseDecimals),
-        asset?.decimals,
-        asset?.marketType,
-      )
-    } catch {
-      return undefined
-    }
+    return getMarketPrice({
+      midPrice,
+      marketOrderSlippage,
+      asset,
+      tradeSide,
+    })
   }, [midPrice, marketOrderSlippage, asset, tradeSide])
+}
+
+function getMarketPrice({
+  midPrice,
+  marketOrderSlippage,
+  asset,
+  tradeSide,
+}: {
+  midPrice: string | null
+  marketOrderSlippage: number
+  asset: PerpOrSpotAsset | undefined
+  tradeSide: 'long' | 'short'
+}): string | undefined {
+  if (!midPrice || !asset) return undefined
+
+  const parsedMidPrice = parseUnits(midPrice, asset.formatParseDecimals)
+  const slippage =
+    tradeSide === 'long'
+      ? Number(marketOrderSlippage) + 10_000
+      : 10_000 - Number(marketOrderSlippage)
+  const adjustedPrice = (parsedMidPrice * BigInt(slippage)) / BigInt(10_000)
+
+  try {
+    return formatPrice(
+      formatUnits(adjustedPrice, asset.formatParseDecimals),
+      asset.decimals,
+      asset.marketType,
+    )
+  } catch {
+    return undefined
+  }
 }
 
 const _useTpSlOrder = () => {

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/place-order-button.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/confirm-dialog/place-order-button.tsx
@@ -95,15 +95,12 @@ export const PlaceOrderButton = ({ onMutate }: { onMutate?: () => void }) => {
 }
 
 function getBasisTradeSingleLegOrderData(orderData: OrderData): OrderData[] {
-  return orderData.orders.map((order) => ({
+  return orderData.orders.map((order, index) => ({
     orders: [order],
     grouping: 'na' as const,
     builder: {
-      // https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids#perps
-      builderFee:
-        Number(order.asset) >= 10_000 && Number(order.asset) < 100_000
-          ? BUILDER_FEE_SPOT
-          : BUILDER_FEE_PERPS,
+      // spot at index 0, perp at index 1
+      builderFee: index === 0 ? BUILDER_FEE_SPOT : BUILDER_FEE_PERPS,
     },
   }))
 }

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/current-position.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/current-position.tsx
@@ -11,7 +11,7 @@ import { useAssetState } from './asset-state-provider'
 
 export const CurrentPosition = () => {
   const {
-    state: { activeAsset, asset },
+    state: { activeAsset, asset, tradeType },
   } = useAssetState()
   const { data } = useUserPositions(activeAsset)
   const { baseSymbol } = useSymbolSplit({ asset })
@@ -28,7 +28,11 @@ export const CurrentPosition = () => {
 
   return (
     <StatItem
-      title="Current Position"
+      title={
+        tradeType === 'basis trade'
+          ? 'Current Perp Position'
+          : 'Current Position'
+      }
       value={
         <div
           className={classNames(

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/index.ts
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/index.ts
@@ -1,2 +1,3 @@
 export * from './trade-widget'
 export * from './asset-state-provider'
+export * from './basis-trade-spot-availability'

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
@@ -7,23 +7,86 @@ import {
   HoverCardTrigger,
   classNames,
 } from '@sushiswap/ui'
-import { useCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   type PerpOrSpotAsset,
   getSizeAndPercentageFromInput,
+  getSizeAndPercentageFromPercentageInput,
 } from 'src/lib/perps'
-import { AssetIcon, SizeInput } from '../../_common'
+import { AssetIcon, PercentageSlider, SizeInput } from '../../_common'
 import {
   type BasisTradeSizeKey,
   type BasisTradeSizeSide,
   useAssetState,
 } from '../asset-state-provider'
+import { useBasisTradeAccountBalances } from '../basis-trade-spot-availability'
+
+type BasisTradePercentage = Record<BasisTradeSizeKey, number>
 
 export const BasisTradeOrderForm = () => {
   const {
-    state: { basisTradeAsset, basisTradeSize, basisTradeSizeSide, tradeSide },
+    state: {
+      basisTradeAsset,
+      basisTradeSize,
+      basisTradeSizeSide,
+      maxTradeSizeLong,
+      maxTradeSizeShort,
+      tradeSide,
+    },
     mutate: { setBasisTradeSize, setBasisTradeSizeSide },
   } = useAssetState()
+  const { spotBaseBalance, spotQuoteBalance } = useBasisTradeAccountBalances({
+    basisTradeAsset,
+  })
+  const [basisTradePercentage, setBasisTradePercentage] =
+    useState<BasisTradePercentage>({
+      spot: 0,
+      perp: 0,
+    })
+
+  const spotMaxSize = useMemo(() => {
+    if (!basisTradeAsset) return '0'
+
+    if (tradeSide === 'short') {
+      return spotBaseBalance?.availableBalance ?? '0'
+    }
+
+    const price =
+      basisTradeAsset.spotAsset.markPrice ||
+      basisTradeAsset.spotAsset.midPrice ||
+      basisTradeAsset.spotAsset.lastPrice ||
+      '0'
+    const quoteBalance = Number(spotQuoteBalance?.availableBalance ?? 0)
+    const spotPrice = Number(price)
+
+    if (
+      !Number.isFinite(quoteBalance) ||
+      !Number.isFinite(spotPrice) ||
+      spotPrice <= 0
+    ) {
+      return '0'
+    }
+
+    return (quoteBalance / spotPrice).toString()
+  }, [
+    basisTradeAsset,
+    spotBaseBalance?.availableBalance,
+    spotQuoteBalance?.availableBalance,
+    tradeSide,
+  ])
+
+  const perpMaxSize =
+    tradeSide === 'long' ? maxTradeSizeShort : maxTradeSizeLong
+
+  const handlePercentageChange = useCallback(
+    (leg: BasisTradeSizeKey, percentage: number) => {
+      setBasisTradePercentage((prev) => ({
+        ...prev,
+        [leg]: percentage,
+      }))
+    },
+    [],
+  )
 
   if (!basisTradeAsset) {
     return (
@@ -36,10 +99,6 @@ export const BasisTradeOrderForm = () => {
   return (
     <div className="flex flex-col gap-2">
       <BasisTradeInfo />
-      <div className="flex items-center justify-between text-xs text-perps-muted-50">
-        <span>Order</span>
-        <span className="text-perps-muted-70">Market</span>
-      </div>
       <BasisTradeLeg
         leg="spot"
         asset={basisTradeAsset.spotAsset}
@@ -47,8 +106,15 @@ export const BasisTradeOrderForm = () => {
         actionType={tradeSide === 'long' ? 'long' : 'short'}
         size={basisTradeSize.spot}
         sizeSide={basisTradeSizeSide.spot}
+        maxSize={spotMaxSize}
+        percentage={
+          basisTradeSize.spot.base || basisTradeSize.spot.quote
+            ? basisTradePercentage.spot
+            : 0
+        }
         onSizeChange={setBasisTradeSize}
         onSizeSideChange={setBasisTradeSizeSide}
+        onPercentageChange={handlePercentageChange}
       />
       <BasisTradeLeg
         leg="perp"
@@ -57,8 +123,15 @@ export const BasisTradeOrderForm = () => {
         actionType={tradeSide === 'long' ? 'short' : 'long'}
         size={basisTradeSize.perp}
         sizeSide={basisTradeSizeSide.perp}
+        maxSize={perpMaxSize}
+        percentage={
+          basisTradeSize.perp.base || basisTradeSize.perp.quote
+            ? basisTradePercentage.perp
+            : 0
+        }
         onSizeChange={setBasisTradeSize}
         onSizeSideChange={setBasisTradeSizeSide}
+        onPercentageChange={handlePercentageChange}
       />
     </div>
   )
@@ -84,7 +157,8 @@ const BasisTradeInfo = () => {
         <p>
           A basis trade pairs a spot trade with the opposite perp trade on the
           same asset, aiming to capture the spread or funding difference while
-          reducing directional exposure.
+          reducing directional exposure. It is recommended that users enable
+          Unified Account Mode in settings for a better experience.
         </p>
       </HoverCardContent>
     </HoverCard>
@@ -98,8 +172,11 @@ const BasisTradeLeg = ({
   actionType,
   size,
   sizeSide,
+  maxSize,
+  percentage,
   onSizeChange,
   onSizeSideChange,
+  onPercentageChange,
 }: {
   leg: BasisTradeSizeKey
   asset: PerpOrSpotAsset
@@ -107,6 +184,8 @@ const BasisTradeLeg = ({
   actionType: 'long' | 'short'
   size: { base: string; quote: string }
   sizeSide: BasisTradeSizeSide[BasisTradeSizeKey]
+  maxSize: string
+  percentage: number
   onSizeChange: (
     leg: BasisTradeSizeKey,
     size: { base: string; quote: string },
@@ -115,19 +194,22 @@ const BasisTradeLeg = ({
     leg: BasisTradeSizeKey,
     sizeSide: BasisTradeSizeSide[BasisTradeSizeKey],
   ) => void
+  onPercentageChange: (leg: BasisTradeSizeKey, percentage: number) => void
 }) => {
   const handleSetSize = useCallback(
     (value: string) => {
       const price = asset.markPrice || asset.midPrice || asset.lastPrice || '0'
 
       try {
-        const { baseSize, quoteSize } = getSizeAndPercentageFromInput({
-          inputValue: value,
-          sizeSide,
-          maxSize: '0',
-          priceUsd: price,
-          decimals: asset.formatParseDecimals,
-        })
+        const { baseSize, quoteSize, percentage } =
+          getSizeAndPercentageFromInput({
+            inputValue: value,
+            sizeSide,
+            maxSize,
+            priceUsd: price,
+            decimals: asset.formatParseDecimals,
+          })
+        onPercentageChange(leg, percentage)
 
         onSizeChange(leg, {
           base: sizeSide === 'base' ? value : baseSize,
@@ -141,7 +223,31 @@ const BasisTradeLeg = ({
         })
       }
     },
-    [asset, leg, onSizeChange, sizeSide],
+    [asset, leg, maxSize, onPercentageChange, onSizeChange, sizeSide],
+  )
+
+  const handleSetPercentage = useCallback(
+    (value: number) => {
+      const price = asset.markPrice || asset.midPrice || asset.lastPrice || '0'
+
+      try {
+        const { baseSize, quoteSize, percentage } =
+          getSizeAndPercentageFromPercentageInput({
+            percentageInput: value,
+            maxSize,
+            priceUsd: price,
+            decimals: asset.formatParseDecimals,
+          })
+
+        onSizeChange(leg, { base: baseSize, quote: quoteSize })
+        onPercentageChange(leg, percentage)
+      } catch (error) {
+        console.error('Error formatting basis trade size:', error)
+        onSizeChange(leg, { base: '0', quote: '0' })
+        onPercentageChange(leg, value)
+      }
+    },
+    [asset, leg, maxSize, onPercentageChange, onSizeChange],
   )
 
   const handleSetSizeSide = useCallback(
@@ -183,6 +289,11 @@ const BasisTradeLeg = ({
         value={size}
         onChange={handleSetSize}
         className="!py-0 text-sm !px-2"
+      />
+      <PercentageSlider
+        value={percentage}
+        onChange={handleSetPercentage}
+        variant={actionType}
       />
     </div>
   )

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
@@ -89,11 +89,7 @@ export const BasisTradeOrderForm = () => {
   )
 
   if (!basisTradeAsset) {
-    return (
-      <div className="text-xs text-perps-muted-50">
-        Select a basis trade asset to configure both legs.
-      </div>
-    )
+    return null
   }
 
   return (

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
@@ -1,0 +1,189 @@
+'use client'
+import { InformationCircleIcon } from '@heroicons/react/24/outline'
+import {
+  Chip,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+  classNames,
+} from '@sushiswap/ui'
+import { useCallback } from 'react'
+import {
+  type PerpOrSpotAsset,
+  getSizeAndPercentageFromInput,
+} from 'src/lib/perps'
+import { AssetIcon, SizeInput } from '../../_common'
+import {
+  type BasisTradeSizeKey,
+  type BasisTradeSizeSide,
+  useAssetState,
+} from '../asset-state-provider'
+
+export const BasisTradeOrderForm = () => {
+  const {
+    state: { basisTradeAsset, basisTradeSize, basisTradeSizeSide, tradeSide },
+    mutate: { setBasisTradeSize, setBasisTradeSizeSide },
+  } = useAssetState()
+
+  if (!basisTradeAsset) {
+    return (
+      <div className="text-xs text-perps-muted-50">
+        Select a basis trade asset to configure both legs.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <BasisTradeInfo />
+      <div className="flex items-center justify-between text-xs text-perps-muted-50">
+        <span>Order</span>
+        <span className="text-perps-muted-70">Market</span>
+      </div>
+      <BasisTradeLeg
+        leg="spot"
+        asset={basisTradeAsset.spotAsset}
+        action={tradeSide === 'long' ? 'Buy Spot' : 'Sell Spot'}
+        actionType={tradeSide === 'long' ? 'long' : 'short'}
+        size={basisTradeSize.spot}
+        sizeSide={basisTradeSizeSide.spot}
+        onSizeChange={setBasisTradeSize}
+        onSizeSideChange={setBasisTradeSizeSide}
+      />
+      <BasisTradeLeg
+        leg="perp"
+        asset={basisTradeAsset.perpAsset}
+        action={tradeSide === 'long' ? 'Short Perp' : 'Long Perp'}
+        actionType={tradeSide === 'long' ? 'short' : 'long'}
+        size={basisTradeSize.perp}
+        sizeSide={basisTradeSizeSide.perp}
+        onSizeChange={setBasisTradeSize}
+        onSizeSideChange={setBasisTradeSizeSide}
+      />
+    </div>
+  )
+}
+
+const BasisTradeInfo = () => {
+  return (
+    <HoverCard openDelay={0} closeDelay={0}>
+      <HoverCardTrigger asChild tabIndex={0}>
+        <button
+          type="button"
+          className="flex items-center gap-1 text-left text-xs text-perps-muted-50 underline decoration-dotted"
+        >
+          <InformationCircleIcon width={14} height={14} />
+          What is a basis trade?
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        forceMount
+        side="bottom"
+        className="!px-3 !bg-black/10 !py-2 max-w-[320px] whitespace-normal text-left text-xs"
+      >
+        <p>
+          A basis trade pairs a spot trade with the opposite perp trade on the
+          same asset, aiming to capture the spread or funding difference while
+          reducing directional exposure.
+        </p>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+const BasisTradeLeg = ({
+  leg,
+  asset,
+  action,
+  actionType,
+  size,
+  sizeSide,
+  onSizeChange,
+  onSizeSideChange,
+}: {
+  leg: BasisTradeSizeKey
+  asset: PerpOrSpotAsset
+  action: string
+  actionType: 'long' | 'short'
+  size: { base: string; quote: string }
+  sizeSide: BasisTradeSizeSide[BasisTradeSizeKey]
+  onSizeChange: (
+    leg: BasisTradeSizeKey,
+    size: { base: string; quote: string },
+  ) => void
+  onSizeSideChange: (
+    leg: BasisTradeSizeKey,
+    sizeSide: BasisTradeSizeSide[BasisTradeSizeKey],
+  ) => void
+}) => {
+  const handleSetSize = useCallback(
+    (value: string) => {
+      const price = asset.markPrice || asset.midPrice || asset.lastPrice || '0'
+
+      try {
+        const { baseSize, quoteSize } = getSizeAndPercentageFromInput({
+          inputValue: value,
+          sizeSide,
+          maxSize: '0',
+          priceUsd: price,
+          decimals: asset.formatParseDecimals,
+        })
+
+        onSizeChange(leg, {
+          base: sizeSide === 'base' ? value : baseSize,
+          quote: sizeSide === 'quote' ? value : quoteSize,
+        })
+      } catch (error) {
+        console.error('Error formatting basis trade size:', error)
+        onSizeChange(leg, {
+          base: sizeSide === 'base' ? value : '0',
+          quote: sizeSide === 'quote' ? value : '0',
+        })
+      }
+    },
+    [asset, leg, onSizeChange, sizeSide],
+  )
+
+  const handleSetSizeSide = useCallback(
+    (_sizeSide: BasisTradeSizeSide[BasisTradeSizeKey]) => {
+      onSizeSideChange(leg, _sizeSide)
+    },
+    [leg, onSizeSideChange],
+  )
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between text-xs">
+        <div className="flex items-center gap-1.5 text-perps-muted-70">
+          <AssetIcon asset={asset} size="sm" />
+          <span>{asset.symbol}</span>
+          <Chip variant="perps-blue" className="!px-1 !font-medium">
+            {asset.marketType === 'perp'
+              ? `${asset.maxLeverage ?? 1}x`
+              : 'SPOT'}
+          </Chip>
+          {asset.dex ? (
+            <Chip variant="perps-blue" className="!px-1 !py-0 rounded-md">
+              {asset.dex}
+            </Chip>
+          ) : null}
+        </div>
+        <span
+          className={classNames(
+            actionType === 'long' ? 'text-perps-green' : 'text-perps-red',
+          )}
+        >
+          {action}
+        </span>
+      </div>
+      <SizeInput
+        asset={asset}
+        sizeSide={sizeSide}
+        setSizeSide={handleSetSizeSide}
+        value={size}
+        onChange={handleSetSize}
+        className="!py-0 text-sm !px-2"
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
@@ -7,14 +7,20 @@ import {
   HoverCardTrigger,
   classNames,
 } from '@sushiswap/ui'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import {
   type PerpOrSpotAsset,
   getSizeAndPercentageFromInput,
   getSizeAndPercentageFromPercentageInput,
 } from 'src/lib/perps'
-import { AssetIcon, PercentageSlider, SizeInput } from '../../_common'
 import {
+  AssetIcon,
+  PercentageSlider,
+  SizeInput,
+  SwitchSetting,
+} from '../../_common'
+import {
+  type BasisTradeSize,
   type BasisTradeSizeKey,
   type BasisTradeSizeSide,
   useAssetState,
@@ -22,6 +28,21 @@ import {
 import { useBasisTradeAccountBalances } from '../basis-trade-spot-availability'
 
 type BasisTradePercentage = Record<BasisTradeSizeKey, number>
+type BasisTradeSizeValue = BasisTradeSize[BasisTradeSizeKey]
+
+function getOppositeBasisTradeLeg(leg: BasisTradeSizeKey): BasisTradeSizeKey {
+  return leg === 'spot' ? 'perp' : 'spot'
+}
+
+function hasBasisTradeSize(size: BasisTradeSizeValue): boolean {
+  const baseSize = Number(size.base)
+  const quoteSize = Number(size.quote)
+
+  return (
+    (Number.isFinite(baseSize) && baseSize > 0) ||
+    (Number.isFinite(quoteSize) && quoteSize > 0)
+  )
+}
 
 export const BasisTradeOrderForm = () => {
   const {
@@ -43,6 +64,8 @@ export const BasisTradeOrderForm = () => {
       spot: 0,
       perp: 0,
     })
+  const [linkInputSizes, setLinkInputSizes] = useState(true)
+  const lastEditedBasisTradeLeg = useRef<BasisTradeSizeKey>('spot')
 
   const spotMaxSize = useMemo(() => {
     if (!basisTradeAsset) return '0'
@@ -88,6 +111,92 @@ export const BasisTradeOrderForm = () => {
     [],
   )
 
+  const syncLinkedBasisTradeLeg = useCallback(
+    (
+      leg: BasisTradeSizeKey,
+      size: BasisTradeSizeValue,
+      sizeSide: BasisTradeSizeSide[BasisTradeSizeKey],
+    ) => {
+      if (!basisTradeAsset) return
+
+      const linkedLeg = getOppositeBasisTradeLeg(leg)
+      const linkedAsset =
+        linkedLeg === 'spot'
+          ? basisTradeAsset.spotAsset
+          : basisTradeAsset.perpAsset
+      const linkedMaxSize = linkedLeg === 'spot' ? spotMaxSize : perpMaxSize
+
+      if (size[sizeSide] === '') {
+        setBasisTradeSize(linkedLeg, { base: '', quote: '' })
+        setBasisTradePercentage((prev) => ({ ...prev, [linkedLeg]: 0 }))
+        return
+      }
+
+      const price =
+        linkedAsset.markPrice ||
+        linkedAsset.midPrice ||
+        linkedAsset.lastPrice ||
+        '0'
+
+      try {
+        const { baseSize, quoteSize, percentage } =
+          getSizeAndPercentageFromInput({
+            inputValue: size.base,
+            sizeSide: 'base',
+            maxSize: linkedMaxSize,
+            priceUsd: price,
+            decimals: linkedAsset.formatParseDecimals,
+          })
+
+        setBasisTradeSize(linkedLeg, { base: baseSize, quote: quoteSize })
+        setBasisTradePercentage((prev) => ({
+          ...prev,
+          [linkedLeg]: percentage,
+        }))
+      } catch (error) {
+        console.error('Error formatting linked basis trade size:', error)
+        setBasisTradeSize(linkedLeg, { base: size.base, quote: '0' })
+        setBasisTradePercentage((prev) => ({ ...prev, [linkedLeg]: 0 }))
+      }
+    },
+    [basisTradeAsset, perpMaxSize, setBasisTradeSize, spotMaxSize],
+  )
+
+  const handleSizeChange = useCallback(
+    (leg: BasisTradeSizeKey, size: BasisTradeSizeValue) => {
+      lastEditedBasisTradeLeg.current = leg
+      setBasisTradeSize(leg, size)
+
+      if (linkInputSizes) {
+        syncLinkedBasisTradeLeg(leg, size, basisTradeSizeSide[leg])
+      }
+    },
+    [
+      basisTradeSizeSide,
+      linkInputSizes,
+      setBasisTradeSize,
+      syncLinkedBasisTradeLeg,
+    ],
+  )
+
+  const handleLinkInputSizesChange = useCallback(
+    (value: boolean) => {
+      setLinkInputSizes(value)
+
+      if (!value) return
+
+      const lastEditedLeg = lastEditedBasisTradeLeg.current
+      const leg = hasBasisTradeSize(basisTradeSize[lastEditedLeg])
+        ? lastEditedLeg
+        : hasBasisTradeSize(basisTradeSize.spot)
+          ? 'spot'
+          : 'perp'
+
+      syncLinkedBasisTradeLeg(leg, basisTradeSize[leg], basisTradeSizeSide[leg])
+    },
+    [basisTradeSize, basisTradeSizeSide, syncLinkedBasisTradeLeg],
+  )
+
   if (!basisTradeAsset) {
     return null
   }
@@ -95,6 +204,7 @@ export const BasisTradeOrderForm = () => {
   return (
     <div className="flex flex-col gap-2">
       <BasisTradeInfo />
+
       <BasisTradeLeg
         leg="spot"
         asset={basisTradeAsset.spotAsset}
@@ -110,7 +220,7 @@ export const BasisTradeOrderForm = () => {
             ? basisTradePercentage.spot
             : 0
         }
-        onSizeChange={setBasisTradeSize}
+        onSizeChange={handleSizeChange}
         onSizeSideChange={setBasisTradeSizeSide}
         onPercentageChange={handlePercentageChange}
       />
@@ -127,10 +237,31 @@ export const BasisTradeOrderForm = () => {
             ? basisTradePercentage.perp
             : 0
         }
-        onSizeChange={setBasisTradeSize}
+        onSizeChange={handleSizeChange}
         onSizeSideChange={setBasisTradeSizeSide}
         onPercentageChange={handlePercentageChange}
       />
+      <HoverCard>
+        <HoverCardTrigger tabIndex={0}>
+          <SwitchSetting
+            label="Link Sizes"
+            value={linkInputSizes}
+            onChange={handleLinkInputSizesChange}
+          />
+        </HoverCardTrigger>
+        <HoverCardContent
+          forceMount
+          side="top"
+          className="!px-3 !bg-black/10 !py-2 max-w-[320px] whitespace-normal text-left text-xs"
+        >
+          <p>
+            When enabled, the spot and perp trade sizes will be linked. Changing
+            one will automatically update the other to maintain the same
+            notional value. When disabled, you can set the spot and perp trade
+            sizes independently.
+          </p>
+        </HoverCardContent>
+      </HoverCard>
     </div>
   )
 }
@@ -182,20 +313,20 @@ const BasisTradeLeg = ({
   assetForIcon?: PerpOrSpotAsset
   action: string
   actionType: 'long' | 'short'
-  size: { base: string; quote: string }
+  size: BasisTradeSizeValue
   sizeSide: BasisTradeSizeSide[BasisTradeSizeKey]
   maxSize: string
   percentage: number
-  onSizeChange: (
-    leg: BasisTradeSizeKey,
-    size: { base: string; quote: string },
-  ) => void
+  onSizeChange: (leg: BasisTradeSizeKey, size: BasisTradeSizeValue) => void
   onSizeSideChange: (
     leg: BasisTradeSizeKey,
     sizeSide: BasisTradeSizeSide[BasisTradeSizeKey],
   ) => void
   onPercentageChange: (leg: BasisTradeSizeKey, percentage: number) => void
 }) => {
+  const {
+    state: { currentLeverageForAsset },
+  } = useAssetState()
   const handleSetSize = useCallback(
     (value: string) => {
       const price = asset.markPrice || asset.midPrice || asset.lastPrice || '0'
@@ -265,7 +396,7 @@ const BasisTradeLeg = ({
           <span>{asset.symbol}</span>
           <Chip variant="perps-blue" className="!px-1 !font-medium">
             {asset.marketType === 'perp'
-              ? `${asset.maxLeverage ?? 1}x`
+              ? `${currentLeverageForAsset ?? 1}x`
               : 'SPOT'}
           </Chip>
           {asset.dex ? (

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/basis-trade-order-form.tsx
@@ -102,6 +102,8 @@ export const BasisTradeOrderForm = () => {
       <BasisTradeLeg
         leg="spot"
         asset={basisTradeAsset.spotAsset}
+        //not a lot of spot tokens have icons, so we use the perp asset for the icon instead
+        assetForIcon={basisTradeAsset.perpAsset}
         action={tradeSide === 'long' ? 'Buy Spot' : 'Sell Spot'}
         actionType={tradeSide === 'long' ? 'long' : 'short'}
         size={basisTradeSize.spot}
@@ -168,6 +170,7 @@ const BasisTradeInfo = () => {
 const BasisTradeLeg = ({
   leg,
   asset,
+  assetForIcon,
   action,
   actionType,
   size,
@@ -180,6 +183,7 @@ const BasisTradeLeg = ({
 }: {
   leg: BasisTradeSizeKey
   asset: PerpOrSpotAsset
+  assetForIcon?: PerpOrSpotAsset
   action: string
   actionType: 'long' | 'short'
   size: { base: string; quote: string }
@@ -261,7 +265,7 @@ const BasisTradeLeg = ({
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between text-xs">
         <div className="flex items-center gap-1.5 text-perps-muted-70">
-          <AssetIcon asset={asset} size="sm" />
+          <AssetIcon asset={assetForIcon || asset} size="sm" />
           <span>{asset.symbol}</span>
           <Chip variant="perps-blue" className="!px-1 !font-medium">
             {asset.marketType === 'perp'

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/order-forms.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-forms/order-forms.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useAssetState } from '../asset-state-provider'
+import { BasisTradeOrderForm } from './basis-trade-order-form'
 import { LimitOrderForm } from './limit-order-form'
 import { MarketOrderForm } from './market-order-form'
 import { ScaleOrderForm } from './scale-order-form'
@@ -17,6 +18,8 @@ export const OrderForms = () => {
         return <MarketOrderForm />
       case 'limit':
         return <LimitOrderForm />
+      case 'basis trade':
+        return <BasisTradeOrderForm />
       case 'scale':
         return <ScaleOrderForm />
       case 'stop limit':

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-stats/order-stats.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/order-stats/order-stats.tsx
@@ -1,3 +1,5 @@
+import { perpsNumberFormatter, useSymbolSplit } from 'src/lib/perps'
+import { StatItem } from '../../_common'
 import { useAssetState } from '../asset-state-provider'
 import { FeeStat } from './fee-stat'
 import { LiquidationStat } from './liquidation-stat'
@@ -16,6 +18,10 @@ export const OrderStats = () => {
     return <TwapStats />
   }
 
+  if (tradeType === 'basis trade') {
+    return <BasisTradeStats />
+  }
+
   return (
     <div className="flex flex-col gap-2">
       {tradeType === 'scale' ? (
@@ -29,4 +35,56 @@ export const OrderStats = () => {
       <FeeStat />
     </div>
   )
+}
+
+const BasisTradeStats = () => {
+  const {
+    state: { basisTradeAsset, basisTradeSize, tradeSide },
+  } = useAssetState()
+  const { quoteSymbol: spotQuoteSymbol } = useSymbolSplit({
+    asset: basisTradeAsset?.spotAsset,
+  })
+  const { quoteSymbol: perpQuoteSymbol } = useSymbolSplit({
+    asset: basisTradeAsset?.perpAsset,
+  })
+
+  if (!basisTradeAsset) return null
+
+  return (
+    <div className="flex flex-col gap-2">
+      <StatItem
+        title="Spot Leg"
+        value={`${tradeSide === 'long' ? 'Buy' : 'Sell'} ${basisTradeAsset.spotAsset.symbol}`}
+      />
+      <StatItem
+        title="Perp Leg"
+        value={`${tradeSide === 'long' ? 'Short' : 'Long'} ${basisTradeAsset.perpAsset.symbol}`}
+      />
+      <StatItem
+        title="Spot Value"
+        value={formatBasisTradeValue(
+          basisTradeSize.spot.quote,
+          spotQuoteSymbol,
+        )}
+      />
+      <StatItem
+        title="Perp Value"
+        value={formatBasisTradeValue(
+          basisTradeSize.perp.quote,
+          perpQuoteSymbol,
+        )}
+      />
+      <StatItem title="Order Type" value="Market" />
+    </div>
+  )
+}
+
+function formatBasisTradeValue(value: string, quoteSymbol: string): string {
+  if (Number(value) === 0) return 'N/A'
+
+  return `${perpsNumberFormatter({
+    value,
+    minFraxDigits: 2,
+    maxFraxDigits: 2,
+  })} ${quoteSymbol}`
 }

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/trade-side-select.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/trade-side-select.tsx
@@ -4,9 +4,18 @@ import { useAssetState } from './asset-state-provider'
 
 export const TradeSideSelect = () => {
   const {
-    state: { tradeSide, asset },
+    state: { tradeSide, asset, tradeType },
     mutate: { setTradeSide },
   } = useAssetState()
+
+  const longLabel =
+    tradeType === 'basis trade'
+      ? 'Buy / Short'
+      : `Buy${asset?.marketType === 'perp' ? ' / Long' : ''}`
+  const shortLabel =
+    tradeType === 'basis trade'
+      ? 'Sell / Long'
+      : `Sell${asset?.marketType === 'perp' ? ' / Short' : ''}`
 
   return (
     <PerpsCard className="flex items-center w-full">
@@ -20,7 +29,7 @@ export const TradeSideSelect = () => {
         fullWidth
         onClick={() => setTradeSide('long')}
       >
-        Buy{asset?.marketType === 'perp' ? ' / Long' : ''}
+        {longLabel}
       </Button>
       <Button
         size="sm"
@@ -32,7 +41,7 @@ export const TradeSideSelect = () => {
         fullWidth
         onClick={() => setTradeSide('short')}
       >
-        Sell{asset?.marketType === 'perp' ? ' / Short' : ''}
+        {shortLabel}
       </Button>
     </PerpsCard>
   )

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/trade-type-select.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/trade-type-select.tsx
@@ -13,14 +13,25 @@ import {
 import { DownTriangleIcon } from '@sushiswap/ui/icons/DownTriangleIcon'
 import { useMemo } from 'react'
 import { PerpsCard } from '../_common/perps-card'
-import {
-  TRADE_TYPES,
-  type TradeType,
-  useAssetState,
-} from './asset-state-provider'
+import { type TradeType, useAssetState } from './asset-state-provider'
 
-const REGULAR_TRADE_TYPES = TRADE_TYPES.slice(0, 2)
-const PRO_TRADE_TYPES = TRADE_TYPES.slice(2)
+const REGULAR_TRADE_TYPES = [
+  'market',
+  'limit',
+] as const satisfies readonly TradeType[]
+const PRO_TRADE_TYPES = [
+  'basis trade',
+  'scale',
+  'stop limit',
+  'stop market',
+  'take limit',
+  'take market',
+  'TWAP',
+] as const satisfies readonly TradeType[]
+const SPOT_PRO_TRADE_TYPES = [
+  'scale',
+  'TWAP',
+] as const satisfies readonly TradeType[]
 
 export const TradeTypeSelect = () => {
   const {
@@ -35,13 +46,13 @@ export const TradeTypeSelect = () => {
 
   const proTradeType = useMemo(() => {
     if (assetType === 'spot') {
-      return ['scale', 'TWAP']
+      return SPOT_PRO_TRADE_TYPES
     }
-    return TRADE_TYPES.slice(2)
+    return PRO_TRADE_TYPES
   }, [assetType])
 
   const isProTrade = useMemo(() => {
-    return PRO_TRADE_TYPES.includes(tradeType)
+    return (PRO_TRADE_TYPES as readonly TradeType[]).includes(tradeType)
   }, [tradeType])
 
   return (

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/trade-type-select.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-widget/trade-type-select.tsx
@@ -29,6 +29,7 @@ const PRO_TRADE_TYPES = [
   'TWAP',
 ] as const satisfies readonly TradeType[]
 const SPOT_PRO_TRADE_TYPES = [
+  'basis trade',
   'scale',
   'TWAP',
 ] as const satisfies readonly TradeType[]

--- a/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-header.tsx
+++ b/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-header.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ArrowLeftIcon } from '@heroicons/react-v1/solid'
 import {
   ArrowLeftOnRectangleIcon,
   ChevronDownIcon,
@@ -70,7 +71,7 @@ export const PortfolioHeader = () => {
 const ConnectedWalletInfo = ({
   wallet,
 }: { wallet: WalletConnection | undefined }) => {
-  const { setView } = useSidebar()
+  const { setView, close } = useSidebar()
 
   const { data: ensName, isLoading: isENSNameLoading } = useEnsName({
     chainId: EvmChainId.ETHEREUM,
@@ -94,7 +95,14 @@ const ConnectedWalletInfo = ({
 
   return (
     <div className="flex justify-between w-full">
-      <div className="flex gap-2.5">
+      <div className="flex gap-2.5 items-center">
+        <IconButton
+          size="xs"
+          onClick={close}
+          icon={ArrowLeftIcon}
+          className="block sm:hidden"
+          name="Back"
+        />
         <div className="shrink-0">
           {wallet ? (
             <Badge

--- a/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-tokens/index.tsx
+++ b/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-tokens/index.tsx
@@ -16,7 +16,7 @@ export const PortfolioTokens = () => {
         className="w-full space-y-4 h-full"
       >
         <div className="flex px-5 gap-x-2">
-          <TabsList className="w-full h-8">
+          <TabsList className="w-full h-8 !rounded-[10px] !px-px">
             {TABS.map((_tab) => (
               <TabsTrigger
                 key={_tab}

--- a/apps/web/src/lib/perps/exchange/use-execute-orders.ts
+++ b/apps/web/src/lib/perps/exchange/use-execute-orders.ts
@@ -113,7 +113,6 @@ export const useExecuteOrders = () => {
           ...(c.clientOrderId ? { c: c.clientOrderId } : {}),
         } satisfies OrderParameters['orders'][number]
       })
-      // console.log(orders)
       const _orderData: OrderParameters = {
         orders,
         ...(IS_PERPS_TESTNET || activeAccount?.type === 'vault'
@@ -126,7 +125,6 @@ export const useExecuteOrders = () => {
             }),
         ...(orderData.grouping ? { grouping: orderData.grouping } : {}),
       }
-      console.log(_orderData)
       return order(
         { wallet: agentAccount, transport: hlHttpTransport },
         _orderData,

--- a/apps/web/src/lib/perps/exchange/use-execute-orders.ts
+++ b/apps/web/src/lib/perps/exchange/use-execute-orders.ts
@@ -126,6 +126,7 @@ export const useExecuteOrders = () => {
             }),
         ...(orderData.grouping ? { grouping: orderData.grouping } : {}),
       }
+      console.log(_orderData)
       return order(
         { wallet: agentAccount, transport: hlHttpTransport },
         _orderData,


### PR DESCRIPTION
- Basis trade feat: Allows users to pair a spot trade with the opposite perp trade on the same asset, aiming to capture the spread or funding difference while directional exposure
- Fixes pnl card text gradient for better browser compatibility 
- Back button in portfolio sidebar header for better mobile UX