### PR TITLE
fix(web): correct unified perps portfolio value

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/perps/portfolio/_ui/portfolio-stats/portfolio-stats.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/portfolio/_ui/portfolio-stats/portfolio-stats.tsx
@@ -99,6 +99,7 @@ export const PortfolioStats = () => {
   const {
     spotEquity,
     perpsEquity,
+    portfolioValue,
     isLoading: isLoadingAccountValues,
     error: accountValuesError,
   } = useUserAccountValues()
@@ -270,9 +271,7 @@ export const PortfolioStats = () => {
                   </HoverCardContent>
                 </HoverCard>
               }
-              value={currencyFormatter.format(
-                Number(perpsEquity || 0) + Number(spotEquity || 0),
-              )}
+              value={currencyFormatter.format(portfolioValue)}
             />
           ) : (
             <>

--- a/apps/web/src/lib/perps/user/get-portfolio-value.ts
+++ b/apps/web/src/lib/perps/user/get-portfolio-value.ts
@@ -1,0 +1,13 @@
+interface GetPortfolioValueArgs {
+  isUnifiedAccount: boolean
+  perpsEquity: number
+  spotEquity: number
+}
+
+export function getPortfolioValue({
+  isUnifiedAccount,
+  perpsEquity,
+  spotEquity,
+}: GetPortfolioValueArgs): number {
+  return isUnifiedAccount ? spotEquity : perpsEquity + spotEquity
+}

--- a/apps/web/src/lib/perps/user/use-user-account-values.ts
+++ b/apps/web/src/lib/perps/user/use-user-account-values.ts
@@ -3,6 +3,7 @@ import { useAssetListState } from '~evm/perps/_ui/asset-selector'
 import { useActiveAccountState } from '~evm/perps/active-account-provider'
 import { useUserState } from '~evm/perps/user-provider'
 import { getCollateralTokenForDex, useAllPerpMetas } from '../info'
+import { getPortfolioValue } from './get-portfolio-value'
 
 export const useUserAccountValues = () => {
   const {
@@ -15,6 +16,11 @@ export const useUserAccountValues = () => {
         data: spotState,
         isLoading: isLoadingSpotState,
         error: errorSpotState,
+      },
+      webData3Query: {
+        data: webData3,
+        isLoading: isLoadingWebData3,
+        error: errorWebData3,
       },
       allDexClearinghouseStateQuery: {
         data: allDexClearinghouseState,
@@ -42,6 +48,7 @@ export const useUserAccountValues = () => {
     if (!address) return false
     return (
       isLoadingSpotState ||
+      isLoadingWebData3 ||
       allDexLoading ||
       assetListLoading ||
       isLoadingAllPerpMetas
@@ -49,6 +56,7 @@ export const useUserAccountValues = () => {
   }, [
     address,
     isLoadingSpotState,
+    isLoadingWebData3,
     allDexLoading,
     assetListLoading,
     isLoadingAllPerpMetas,
@@ -56,16 +64,27 @@ export const useUserAccountValues = () => {
 
   const error = useMemo(() => {
     if (!address) return null
-    return errorSpotState || allDexError || assetListError || errorAllPerpMetas
-  }, [address, errorSpotState, allDexError, assetListError, errorAllPerpMetas])
+    return (
+      errorSpotState ||
+      errorWebData3 ||
+      allDexError ||
+      assetListError ||
+      errorAllPerpMetas
+    )
+  }, [
+    address,
+    errorSpotState,
+    errorWebData3,
+    allDexError,
+    assetListError,
+    errorAllPerpMetas,
+  ])
 
   const spotEquity = useMemo(() => {
     if (!spotState?.spotState?.balances || !assetList) return 0
     return (
       spotState.spotState.balances.reduce((acc, asset) => {
-        const hold = Number(asset?.hold) ?? 0
-        const total = Number(asset?.total) ?? 0
-        const balance = total - hold
+        const balance = Number(asset?.total) ?? 0
         if (asset.coin === 'USDC') {
           return acc + balance
         }
@@ -164,8 +183,12 @@ export const useUserAccountValues = () => {
   }, [allDexClearinghouseState])
 
   const portfolioValue = useMemo(() => {
-    return perpsEquity + spotEquity
-  }, [perpsEquity, spotEquity])
+    return getPortfolioValue({
+      isUnifiedAccount: webData3?.userState?.abstraction === 'unifiedAccount',
+      perpsEquity,
+      spotEquity,
+    })
+  }, [perpsEquity, spotEquity, webData3?.userState?.abstraction])
 
   const clearhouseStateTotal = useMemo(() => {
     if (!spotState?.spotState?.balances || !assetList || !allPerpMetas) {
@@ -178,9 +201,7 @@ export const useUserAccountValues = () => {
 
     return (
       spotState.spotState.balances.reduce((acc, asset) => {
-        const hold = Number(asset?.hold) ?? 0
-        const total = Number(asset?.total) ?? 0
-        const balance = total - hold
+        const balance = Number(asset?.total) ?? 0
         if (asset.coin === 'USDC') {
           return acc + balance
         }


### PR DESCRIPTION
## Summary

- use the unified spot-state total directly for unified-account portfolio value
- include held balances in account equity and collateral totals
- reuse the shared portfolio-value calculation in portfolio stats

## Root cause

After the webData2 removal, the UI combined the unified spotState balance with individual perp clearinghouse equity. Hyperliquid already includes perp equity in the unified spot balance, so this double-counted part of the account and reported roughly $6,600 instead of $4,918 for 0x399A8F9bfc85e62d4dc0E306e93B6eEd1b7BC357.

## Testing

- pnpm format
- pnpm lint