### PR TITLE
feat(web): include permissionless tokens in token search

### DIFF
--- a/apps/web/src/lib/wagmi/components/token-selector/hooks/use-search-tokens.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/hooks/use-search-tokens.ts
@@ -10,6 +10,14 @@ import {
   createTokenListToken,
 } from './token-list-token'
 
+type TokenSearchApprovalStatus = 'APPROVED' | 'PERMISSIONLESS'
+
+export function getTokenListApprovalStatuses(
+  search?: string,
+): TokenSearchApprovalStatus[] | undefined {
+  return search ? ['APPROVED', 'PERMISSIONLESS'] : undefined
+}
+
 type UseSearchTokens<TChainId extends TokenListChainId> = {
   chainId: TChainId | undefined
   search?: string
@@ -41,11 +49,18 @@ export function useSearchTokens<TChainId extends TokenListChainId>({
       .filter((t) => t.chainId === chainId)
       .map((t) => t.address)
   }, [_customTokens, chainId, includeCustomTokens])
+  const approvalStatuses = getTokenListApprovalStatuses(search)
 
   const query = useInfiniteQuery({
     queryKey: [
       'data-api-token-list',
-      { chainId, symbol: search, pageSize: pagination.pageSize, customTokens },
+      {
+        chainId,
+        symbol: search,
+        pageSize: pagination.pageSize,
+        customTokens,
+        approvalStatuses,
+      },
     ],
     queryFn: async ({ pageParam }) => {
       if (!chainId) throw new Error('chainId is required')
@@ -56,6 +71,7 @@ export function useSearchTokens<TChainId extends TokenListChainId>({
         skip: pageParam * pagination.pageSize,
         search,
         customTokens,
+        approvalStatuses,
       })
       return result
     },

--- a/packages/graph-client/src/subgraphs/data-api/queries/token-list/token-list.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/token-list/token-list.ts
@@ -10,8 +10,8 @@ import { SUSHI_REQUEST_HEADERS } from '../../request-headers.js'
 
 export const TokenListQuery = graphql(
   `
-  query TokenList($chainId: TokenListChainId!, $first: Int = 50,  $skip: Int, $search: String, $customTokens: [ContractAddress!]) {
-    tokenList(chainId: $chainId, first: $first, skip: $skip, search: $search, customTokens: $customTokens) {
+  query TokenList($chainId: TokenListChainId!, $first: Int = 50,  $skip: Int, $search: String, $customTokens: [ContractAddress!], $approvalStatuses: [TokenApprovalStatus!]) {
+    tokenList(chainId: $chainId, first: $first, skip: $skip, search: $search, customTokens: $customTokens, approvalStatuses: $approvalStatuses) {
       address
       symbol
       name

--- a/packages/graph-client/src/subgraphs/data-api/schema.graphql
+++ b/packages/graph-client/src/subgraphs/data-api/schema.graphql
@@ -56,7 +56,7 @@ type Query {
   vaults(chainId: SmartPoolChainId!, poolAddress: Bytes!): [Vault!]!
   sushiBarStats: SushiBarStats!
   sushiBarHistory: SushiBarHistory!
-  tokenList(chainId: TokenListChainId!, first: Int = 50, skip: Int, search: String, customTokens: [ContractAddress!]): [TokenListEntry!]!
+  tokenList(chainId: TokenListChainId!, first: Int = 50, skip: Int, search: String, customTokens: [ContractAddress!], approvalStatuses: [TokenApprovalStatus!] = [APPROVED]): [TokenListEntry!]!
   tokenListBalances(chainId: TokenListChainId!, account: Address!, includeNative: Boolean = true, customTokens: [ContractAddress!]): [TokenListWithBalanceEntry!]!
   tokenAnalysis(chainId: Int!, address: Bytes!): TokenAnalysis!
   pendingTokens: [PendingToken!]!
@@ -843,6 +843,13 @@ type SushiBarHistory {
 type StellarTokenMetadata {
   issuer: StellarAccountAddress
   domain: String
+}
+
+enum TokenApprovalStatus {
+  UNKNOWN
+  APPROVED
+  PERMISSIONLESS
+  DISAPPROVED
 }
 
 type TokenListEntry {


### PR DESCRIPTION
## Summary

- add token approval status filtering to the graph-client token list query
- search approved and permissionless tokens for non-empty token selector searches
- preserve the approved-only API default for the unsearched general list

## Testing

- pnpm --filter @sushiswap/graph-client check
- pnpm lint