### PR TITLE
fix(web): correct app version checks

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/api/config/version/route.ts
+++ b/apps/web/src/app/(networks)/(evm)/api/config/version/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import * as z from 'zod'
 
+export const dynamic = 'force-dynamic'
+
 const schema = z.object({
   commit: z.string(),
 })
@@ -10,7 +12,7 @@ export async function GET() {
     schema.safeParse({ commit: process.env.VERCEL_GIT_COMMIT_SHA }),
     {
       headers: {
-        'Cache-Control': 'max-age=300',
+        'Cache-Control': 'no-store',
       },
     },
   )

--- a/apps/web/src/app/_common/app-version/use-app-version.ts
+++ b/apps/web/src/app/_common/app-version/use-app-version.ts
@@ -1,27 +1,24 @@
 import { useQuery } from '@tanstack/react-query'
 import ms from 'ms'
-import { useRef } from 'react'
+
+const clientCommit = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
 
 export const useAppVersion = () => {
-  const commitRef = useRef<string | null>(null)
-
   return useQuery({
     queryKey: ['app-version'],
     queryFn: async () => {
-      const resp = await fetch('/api/config/version')
+      const resp = await fetch('/api/config/version', { cache: 'no-store' })
       const { success, data } = await resp.json()
 
       if (!success || !data.commit)
         throw new Error('Failed to fetch /api/config/version')
 
-      if (commitRef.current === null) commitRef.current = data.commit
-
       return {
         server: data.commit,
-        client: commitRef.current as string,
+        client: clientCommit,
       }
     },
     refetchInterval: ms('5m'),
-    enabled: Boolean(process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA),
+    enabled: Boolean(clientCommit),
   })
 }


### PR DESCRIPTION
## Summary
- compare the server commit against the commit embedded in the running client bundle
- bypass browser caching when polling the version endpoint
- make the version route dynamic and return no-store cache headers

## Validation
- pnpm --filter web check
- targeted Biome check
- git diff --check