### PR TITLE
fix(web): prevent token security dialog crashes

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/lifi/token-not-found-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/lifi/token-not-found-dialog.tsx
@@ -159,8 +159,8 @@ export function CrossChainSwapTokenNotFoundDialog<
       open={Boolean(token0NotInList || token1NotInList)}
       onOpenChange={(open) => !open && reset()}
     >
-      <DialogContent className="!max-h-screen overflow-y-auto">
-        <DialogHeader className="!text-left !space-y-3">
+      <DialogContent className="!flex max-h-[calc(100dvh-16px)] flex-col overflow-hidden md:max-h-[80vh]">
+        <DialogHeader className="!text-left !space-y-3 shrink-0">
           <DialogTitle>
             <div
               className={classNames(
@@ -199,193 +199,195 @@ export function CrossChainSwapTokenNotFoundDialog<
             </span>
           )}
         </DialogHeader>
-        <div className="flex flex-col gap-4">
-          {token0 && token0NotInList && token0?.type === 'native' && (
-            <List>
-              {token1NotInList ? <List.Label>Token 1</List.Label> : null}
-              <List.Control>
-                <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
-                  Could not retrieve token info for{' '}
-                  <a
-                    target="_blank"
-                    href={getChainById(token0.chainId)?.getTokenUrl(
-                      token0.wrap().address,
-                    )}
-                    className="text-blue font-medium"
-                    rel="noreferrer"
-                  >
-                    {shortenAddress(token0.wrap().address)}
-                  </a>{' '}
-                  are you sure this token is on{' '}
-                  {getChainById(token0.chainId)?.name}?
-                </p>
-              </List.Control>
-            </List>
-          )}
-          {token0NotInList && token0?.type === 'token' && (
-            <>
+        <div className="min-h-0 overflow-y-auto">
+          <div className="flex flex-col gap-4">
+            {token0 && token0NotInList && token0?.type === 'native' && (
               <List>
                 {token1NotInList ? <List.Label>Token 1</List.Label> : null}
-                <List.Control className="!p-4">
-                  <div className="flex justify-between items-center">
-                    <div className="flex items-center gap-4">
-                      <Badge
-                        position="bottom-right"
-                        badgeContent={
-                          <div className="bg-white rounded-full dark:bg-slate-800">
-                            <NetworkIcon
-                              width={20}
-                              height={20}
-                              chainId={token0.chainId}
-                            />
-                          </div>
-                        }
-                      >
-                        <div className="w-10 h-10">
-                          <UnknownTokenIcon width={40} height={40} />
-                        </div>
-                      </Badge>
-                      <div className="flex flex-col">
-                        <span className="text-2xl font-medium">
-                          {token0.symbol ?? '-'}
-                        </span>
-                        <span className="font-medium text-muted-foreground">
-                          {token0.name ?? '-'}
-                        </span>
-                      </div>
-                    </div>
-                    <LinkExternal
+                <List.Control>
+                  <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
+                    Could not retrieve token info for{' '}
+                    <a
                       target="_blank"
                       href={getChainById(token0.chainId)?.getTokenUrl(
-                        token0.address,
+                        token0.wrap().address,
                       )}
-                      className="font-medium"
+                      className="text-blue font-medium"
+                      rel="noreferrer"
                     >
-                      {shortenAddress(token0.address)}{' '}
-                    </LinkExternal>
-                  </div>
+                      {shortenAddress(token0.wrap().address)}
+                    </a>{' '}
+                    are you sure this token is on{' '}
+                    {getChainById(token0.chainId)?.name}?
+                  </p>
                 </List.Control>
               </List>
-              {isTokenSecurityChainId(token0.chainId) && (
-                <List className="!pt-0 max-h-64">
-                  <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
-                    <div className="flex items-center">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Token Security Scan
-                      </span>
+            )}
+            {token0NotInList && token0?.type === 'token' && (
+              <>
+                <List>
+                  {token1NotInList ? <List.Label>Token 1</List.Label> : null}
+                  <List.Control className="!p-4">
+                    <div className="flex justify-between items-center">
+                      <div className="flex items-center gap-4">
+                        <Badge
+                          position="bottom-right"
+                          badgeContent={
+                            <div className="bg-white rounded-full dark:bg-slate-800">
+                              <NetworkIcon
+                                width={20}
+                                height={20}
+                                chainId={token0.chainId}
+                              />
+                            </div>
+                          }
+                        >
+                          <div className="w-10 h-10">
+                            <UnknownTokenIcon width={40} height={40} />
+                          </div>
+                        </Badge>
+                        <div className="flex flex-col">
+                          <span className="text-2xl font-medium">
+                            {token0.symbol ?? '-'}
+                          </span>
+                          <span className="font-medium text-muted-foreground">
+                            {token0.name ?? '-'}
+                          </span>
+                        </div>
+                      </div>
+                      <LinkExternal
+                        target="_blank"
+                        href={getChainById(token0.chainId)?.getTokenUrl(
+                          token0.address,
+                        )}
+                        className="font-medium"
+                      >
+                        {shortenAddress(token0.address)}{' '}
+                      </LinkExternal>
                     </div>
-                    {token0SecurityState === 'unavailable' ? (
-                      <span className="text-sm text-muted-foreground">
-                        Security providers did not return results for this
-                        token.
-                      </span>
-                    ) : (
-                      <TokenSecurityView
-                        token={token0}
-                        tokenSecurity={token0SecurityResponse}
-                        isTokenSecurityLoading={
-                          token0SecurityState === 'scanning'
-                        }
-                      />
-                    )}
                   </List.Control>
                 </List>
-              )}
-            </>
-          )}
-          {token1 && token1NotInList && token1.type === 'native' && (
-            <List>
-              {token0NotInList ? <List.Label>Token 2</List.Label> : null}
-              <List.Control>
-                <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
-                  Could not retrieve token info for{' '}
-                  <a
-                    target="_blank"
-                    href={getChainById(token1.chainId)?.getTokenUrl(
-                      token1.wrap().address,
-                    )}
-                    className="text-blue font-medium"
-                    rel="noreferrer"
-                  >
-                    {shortenAddress(token1.wrap().address)}
-                  </a>{' '}
-                  are you sure this token is on{' '}
-                  {getChainById(token1.chainId)?.name}?
-                </p>
-              </List.Control>
-            </List>
-          )}
-          {token1NotInList && token1?.type === 'token' && (
-            <>
-              <List>
-                {token0NotInList ? <List.Label>Token 2</List.Label> : null}
-                <List.Control className="!p-4">
-                  <div className="flex justify-between items-center">
-                    <div className="flex items-center gap-4">
-                      <Badge
-                        position="bottom-right"
-                        badgeContent={
-                          <div className="bg-white rounded-full dark:bg-slate-800">
-                            <NetworkIcon
-                              width={20}
-                              height={20}
-                              chainId={token1.chainId}
-                            />
-                          </div>
-                        }
-                      >
-                        <div className="w-10 h-10">
-                          <UnknownTokenIcon width={40} height={40} />
-                        </div>
-                      </Badge>
-                      <div className="flex flex-col">
-                        <span className="text-2xl font-medium">
-                          {token1.symbol ?? '-'}
-                        </span>
-                        <span className="font-medium text-muted-foreground">
-                          {token1.name ?? '-'}
+                {isTokenSecurityChainId(token0.chainId) && (
+                  <List className="!pt-0 overflow-hidden">
+                    <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
+                      <div className="flex items-center">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          Token Security Scan
                         </span>
                       </div>
-                    </div>
-                    <LinkExternal
+                      {token0SecurityState === 'unavailable' ? (
+                        <span className="text-sm text-muted-foreground">
+                          Security providers did not return results for this
+                          token.
+                        </span>
+                      ) : (
+                        <TokenSecurityView
+                          token={token0}
+                          tokenSecurity={token0SecurityResponse}
+                          isTokenSecurityLoading={
+                            token0SecurityState === 'scanning'
+                          }
+                        />
+                      )}
+                    </List.Control>
+                  </List>
+                )}
+              </>
+            )}
+            {token1 && token1NotInList && token1.type === 'native' && (
+              <List>
+                {token0NotInList ? <List.Label>Token 2</List.Label> : null}
+                <List.Control>
+                  <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
+                    Could not retrieve token info for{' '}
+                    <a
                       target="_blank"
                       href={getChainById(token1.chainId)?.getTokenUrl(
-                        token1.address,
+                        token1.wrap().address,
                       )}
-                      className="font-medium"
+                      className="text-blue font-medium"
+                      rel="noreferrer"
                     >
-                      {shortenAddress(token1.address)}{' '}
-                    </LinkExternal>
-                  </div>
+                      {shortenAddress(token1.wrap().address)}
+                    </a>{' '}
+                    are you sure this token is on{' '}
+                    {getChainById(token1.chainId)?.name}?
+                  </p>
                 </List.Control>
               </List>
-              {isTokenSecurityChainId(token1.chainId) && (
-                <List className="!pt-0 max-h-64">
-                  <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
-                    <div className="flex items-center">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Token Security Scan
-                      </span>
+            )}
+            {token1NotInList && token1?.type === 'token' && (
+              <>
+                <List>
+                  {token0NotInList ? <List.Label>Token 2</List.Label> : null}
+                  <List.Control className="!p-4">
+                    <div className="flex justify-between items-center">
+                      <div className="flex items-center gap-4">
+                        <Badge
+                          position="bottom-right"
+                          badgeContent={
+                            <div className="bg-white rounded-full dark:bg-slate-800">
+                              <NetworkIcon
+                                width={20}
+                                height={20}
+                                chainId={token1.chainId}
+                              />
+                            </div>
+                          }
+                        >
+                          <div className="w-10 h-10">
+                            <UnknownTokenIcon width={40} height={40} />
+                          </div>
+                        </Badge>
+                        <div className="flex flex-col">
+                          <span className="text-2xl font-medium">
+                            {token1.symbol ?? '-'}
+                          </span>
+                          <span className="font-medium text-muted-foreground">
+                            {token1.name ?? '-'}
+                          </span>
+                        </div>
+                      </div>
+                      <LinkExternal
+                        target="_blank"
+                        href={getChainById(token1.chainId)?.getTokenUrl(
+                          token1.address,
+                        )}
+                        className="font-medium"
+                      >
+                        {shortenAddress(token1.address)}{' '}
+                      </LinkExternal>
                     </div>
-                    {token1SecurityState === 'unavailable' ? (
-                      <span className="text-sm text-muted-foreground">
-                        Security providers did not return results for this
-                        token.
-                      </span>
-                    ) : (
-                      <TokenSecurityView
-                        token={token1}
-                        tokenSecurity={token1SecurityResponse}
-                        isTokenSecurityLoading={
-                          token1SecurityState === 'scanning'
-                        }
-                      />
-                    )}
                   </List.Control>
                 </List>
-              )}
-            </>
-          )}
+                {isTokenSecurityChainId(token1.chainId) && (
+                  <List className="!pt-0 overflow-hidden">
+                    <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
+                      <div className="flex items-center">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          Token Security Scan
+                        </span>
+                      </div>
+                      {token1SecurityState === 'unavailable' ? (
+                        <span className="text-sm text-muted-foreground">
+                          Security providers did not return results for this
+                          token.
+                        </span>
+                      ) : (
+                        <TokenSecurityView
+                          token={token1}
+                          tokenSecurity={token1SecurityResponse}
+                          isTokenSecurityLoading={
+                            token1SecurityState === 'scanning'
+                          }
+                        />
+                      )}
+                    </List.Control>
+                  </List>
+                )}
+              </>
+            )}
+          </div>
         </div>
         <Message
           size="sm"
@@ -401,7 +403,8 @@ export function CrossChainSwapTokenNotFoundDialog<
                   ? 'Our security scan has identified risks associated with this token. Proceeding may result in the loss of your funds. Please exercise caution and review the details before continuing.'
                   : 'Anyone can create a token, including creating fake versions of existing tokens that claim to represent projects. If you purchase this token, you may not be able to sell it back.'}
         </Message>
-        <DialogFooter>
+
+        <DialogFooter className="shrink-0">
           {isHoneypot ? (
             <Button fullWidth size="xl" onClick={reset}>
               Close

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token-not-found-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token-not-found-dialog.tsx
@@ -134,8 +134,8 @@ export const SimpleSwapTokenNotFoundDialog = () => {
       open={Boolean(token0NotInList || token1NotInList)}
       onOpenChange={(open) => !open && reset()}
     >
-      <DialogContent className="!max-h-screen overflow-y-auto">
-        <DialogHeader className="!text-left !space-y-3">
+      <DialogContent className="!flex max-h-[calc(100dvh-16px)] flex-col overflow-hidden md:max-h-[80vh]">
+        <DialogHeader className="!text-left !space-y-3 shrink-0">
           <DialogTitle>
             <div
               className={classNames(
@@ -174,193 +174,195 @@ export const SimpleSwapTokenNotFoundDialog = () => {
             </span>
           )}
         </DialogHeader>
-        <div className="flex flex-col gap-4">
-          {token0 && token0NotInList && token0?.type === 'native' && (
-            <List>
-              {token1NotInList ? <List.Label>Token 1</List.Label> : null}
-              <List.Control>
-                <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
-                  Could not retrieve token info for{' '}
-                  <a
-                    target="_blank"
-                    href={getChainById(token0.chainId)?.getTokenUrl(
-                      token0.wrap().address,
-                    )}
-                    className="text-blue font-medium"
-                    rel="noreferrer"
-                  >
-                    {shortenAddress(token0.wrap().address)}
-                  </a>{' '}
-                  are you sure this token is on{' '}
-                  {getChainById(token0.chainId).name}?
-                </p>
-              </List.Control>
-            </List>
-          )}
-          {token0NotInList && token0?.type === 'token' && (
-            <>
+        <div className="min-h-0 overflow-y-auto">
+          <div className="flex flex-col gap-4">
+            {token0 && token0NotInList && token0?.type === 'native' && (
               <List>
                 {token1NotInList ? <List.Label>Token 1</List.Label> : null}
-                <List.Control className="!p-4">
-                  <div className="flex justify-between items-center">
-                    <div className="flex items-center gap-4">
-                      <Badge
-                        position="bottom-right"
-                        badgeContent={
-                          <div className="bg-white rounded-full dark:bg-slate-800">
-                            <NetworkIcon
-                              width={20}
-                              height={20}
-                              chainId={token0.chainId}
-                            />
-                          </div>
-                        }
-                      >
-                        <div className="w-10 h-10">
-                          <UnknownTokenIcon width={40} height={40} />
-                        </div>
-                      </Badge>
-                      <div className="flex flex-col">
-                        <span className="text-2xl font-medium">
-                          {token0.symbol ?? '-'}
-                        </span>
-                        <span className="font-medium text-muted-foreground">
-                          {token0.name ?? '-'}
-                        </span>
-                      </div>
-                    </div>
-                    <LinkExternal
+                <List.Control>
+                  <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
+                    Could not retrieve token info for{' '}
+                    <a
                       target="_blank"
                       href={getChainById(token0.chainId)?.getTokenUrl(
-                        token0.address,
+                        token0.wrap().address,
                       )}
-                      className="font-medium"
+                      className="text-blue font-medium"
+                      rel="noreferrer"
                     >
-                      {shortenAddress(token0.address)}{' '}
-                    </LinkExternal>
-                  </div>
+                      {shortenAddress(token0.wrap().address)}
+                    </a>{' '}
+                    are you sure this token is on{' '}
+                    {getChainById(token0.chainId).name}?
+                  </p>
                 </List.Control>
               </List>
-              {isTokenSecurityChainId(token0.chainId) && (
-                <List className="!pt-0 max-h-64">
-                  <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
-                    <div className="flex items-center">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Token Security Scan
-                      </span>
+            )}
+            {token0NotInList && token0?.type === 'token' && (
+              <>
+                <List>
+                  {token1NotInList ? <List.Label>Token 1</List.Label> : null}
+                  <List.Control className="!p-4">
+                    <div className="flex justify-between items-center">
+                      <div className="flex items-center gap-4">
+                        <Badge
+                          position="bottom-right"
+                          badgeContent={
+                            <div className="bg-white rounded-full dark:bg-slate-800">
+                              <NetworkIcon
+                                width={20}
+                                height={20}
+                                chainId={token0.chainId}
+                              />
+                            </div>
+                          }
+                        >
+                          <div className="w-10 h-10">
+                            <UnknownTokenIcon width={40} height={40} />
+                          </div>
+                        </Badge>
+                        <div className="flex flex-col">
+                          <span className="text-2xl font-medium">
+                            {token0.symbol ?? '-'}
+                          </span>
+                          <span className="font-medium text-muted-foreground">
+                            {token0.name ?? '-'}
+                          </span>
+                        </div>
+                      </div>
+                      <LinkExternal
+                        target="_blank"
+                        href={getChainById(token0.chainId)?.getTokenUrl(
+                          token0.address,
+                        )}
+                        className="font-medium"
+                      >
+                        {shortenAddress(token0.address)}{' '}
+                      </LinkExternal>
                     </div>
-                    {token0SecurityState === 'unavailable' ? (
-                      <span className="text-sm text-muted-foreground">
-                        Security providers did not return results for this
-                        token.
-                      </span>
-                    ) : (
-                      <TokenSecurityView
-                        token={token0}
-                        tokenSecurity={token0SecurityResponse}
-                        isTokenSecurityLoading={
-                          token0SecurityState === 'scanning'
-                        }
-                      />
-                    )}
                   </List.Control>
                 </List>
-              )}
-            </>
-          )}
-          {token1 && token1NotInList && token1.type === 'native' && (
-            <List>
-              {token0NotInList ? <List.Label>Token 2</List.Label> : null}
-              <List.Control>
-                <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
-                  Could not retrieve token info for{' '}
-                  <a
-                    target="_blank"
-                    href={getChainById(token1.chainId)?.getTokenUrl(
-                      token1.wrap().address,
-                    )}
-                    className="text-blue font-medium"
-                    rel="noreferrer"
-                  >
-                    {shortenAddress(token1.wrap().address)}
-                  </a>{' '}
-                  are you sure this token is on{' '}
-                  {getChainById(token1.chainId)?.name}?
-                </p>
-              </List.Control>
-            </List>
-          )}
-          {token1NotInList && token1?.type === 'token' && (
-            <>
-              <List>
-                {token0NotInList ? <List.Label>Token 2</List.Label> : null}
-                <List.Control className="!p-4">
-                  <div className="flex justify-between items-center">
-                    <div className="flex items-center gap-4">
-                      <Badge
-                        position="bottom-right"
-                        badgeContent={
-                          <div className="bg-white rounded-full dark:bg-slate-800">
-                            <NetworkIcon
-                              width={20}
-                              height={20}
-                              chainId={token1.chainId}
-                            />
-                          </div>
-                        }
-                      >
-                        <div className="w-10 h-10">
-                          <UnknownTokenIcon width={40} height={40} />
-                        </div>
-                      </Badge>
-                      <div className="flex flex-col">
-                        <span className="text-2xl font-medium">
-                          {token1.symbol ?? '-'}
-                        </span>
-                        <span className="font-medium text-muted-foreground">
-                          {token1.name ?? '-'}
+                {isTokenSecurityChainId(token0.chainId) && (
+                  <List className="!pt-0 overflow-hidden">
+                    <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
+                      <div className="flex items-center">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          Token Security Scan
                         </span>
                       </div>
-                    </div>
-                    <LinkExternal
+                      {token0SecurityState === 'unavailable' ? (
+                        <span className="text-sm text-muted-foreground">
+                          Security providers did not return results for this
+                          token.
+                        </span>
+                      ) : (
+                        <TokenSecurityView
+                          token={token0}
+                          tokenSecurity={token0SecurityResponse}
+                          isTokenSecurityLoading={
+                            token0SecurityState === 'scanning'
+                          }
+                        />
+                      )}
+                    </List.Control>
+                  </List>
+                )}
+              </>
+            )}
+            {token1 && token1NotInList && token1.type === 'native' && (
+              <List>
+                {token0NotInList ? <List.Label>Token 2</List.Label> : null}
+                <List.Control>
+                  <p className="p-3 text-sm text-gray-900 dark:text-slate-50">
+                    Could not retrieve token info for{' '}
+                    <a
                       target="_blank"
                       href={getChainById(token1.chainId)?.getTokenUrl(
-                        token1.address,
+                        token1.wrap().address,
                       )}
-                      className="font-medium"
+                      className="text-blue font-medium"
+                      rel="noreferrer"
                     >
-                      {shortenAddress(token1.address)}{' '}
-                    </LinkExternal>
-                  </div>
+                      {shortenAddress(token1.wrap().address)}
+                    </a>{' '}
+                    are you sure this token is on{' '}
+                    {getChainById(token1.chainId)?.name}?
+                  </p>
                 </List.Control>
               </List>
-              {isTokenSecurityChainId(token1.chainId) && (
-                <List className="!pt-0 max-h-64">
-                  <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
-                    <div className="flex items-center">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Token Security Scan
-                      </span>
+            )}
+            {token1NotInList && token1?.type === 'token' && (
+              <>
+                <List>
+                  {token0NotInList ? <List.Label>Token 2</List.Label> : null}
+                  <List.Control className="!p-4">
+                    <div className="flex justify-between items-center">
+                      <div className="flex items-center gap-4">
+                        <Badge
+                          position="bottom-right"
+                          badgeContent={
+                            <div className="bg-white rounded-full dark:bg-slate-800">
+                              <NetworkIcon
+                                width={20}
+                                height={20}
+                                chainId={token1.chainId}
+                              />
+                            </div>
+                          }
+                        >
+                          <div className="w-10 h-10">
+                            <UnknownTokenIcon width={40} height={40} />
+                          </div>
+                        </Badge>
+                        <div className="flex flex-col">
+                          <span className="text-2xl font-medium">
+                            {token1.symbol ?? '-'}
+                          </span>
+                          <span className="font-medium text-muted-foreground">
+                            {token1.name ?? '-'}
+                          </span>
+                        </div>
+                      </div>
+                      <LinkExternal
+                        target="_blank"
+                        href={getChainById(token1.chainId)?.getTokenUrl(
+                          token1.address,
+                        )}
+                        className="font-medium"
+                      >
+                        {shortenAddress(token1.address)}{' '}
+                      </LinkExternal>
                     </div>
-                    {token1SecurityState === 'unavailable' ? (
-                      <span className="text-sm text-muted-foreground">
-                        Security providers did not return results for this
-                        token.
-                      </span>
-                    ) : (
-                      <TokenSecurityView
-                        token={token1}
-                        tokenSecurity={token1SecurityResponse}
-                        isTokenSecurityLoading={
-                          token1SecurityState === 'scanning'
-                        }
-                      />
-                    )}
                   </List.Control>
                 </List>
-              )}
-            </>
-          )}
+                {isTokenSecurityChainId(token1.chainId) && (
+                  <List className="!pt-0 overflow-hidden">
+                    <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
+                      <div className="flex items-center">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          Token Security Scan
+                        </span>
+                      </div>
+                      {token1SecurityState === 'unavailable' ? (
+                        <span className="text-sm text-muted-foreground">
+                          Security providers did not return results for this
+                          token.
+                        </span>
+                      ) : (
+                        <TokenSecurityView
+                          token={token1}
+                          tokenSecurity={token1SecurityResponse}
+                          isTokenSecurityLoading={
+                            token1SecurityState === 'scanning'
+                          }
+                        />
+                      )}
+                    </List.Control>
+                  </List>
+                )}
+              </>
+            )}
+          </div>
         </div>
         <Message
           size="sm"
@@ -376,6 +378,7 @@ export const SimpleSwapTokenNotFoundDialog = () => {
                   ? 'Our security scan has identified risks associated with this token. Proceeding may result in the loss of your funds. Please exercise caution and review the details before continuing.'
                   : 'Anyone can create a token, including creating fake versions of existing tokens that claim to represent projects. If you purchase this token, you may not be able to sell it back.'}
         </Message>
+
         <DialogFooter>
           {isHoneypot ? (
             <Button fullWidth size="xl" onClick={reset}>

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -13,6 +13,8 @@ import {
   type TransportItem,
 } from '@grafana/faro-web-sdk'
 
+const isFaroEnabled = false
+
 const faroConfig = {
   url: 'https://faro.analytics-fe.sushi.com/collect',
   samplingRate: 1,
@@ -32,7 +34,12 @@ const ignoreUrls = [
 
 const ignoreLogStacks: RegExp[] = [/-extension:\/\//]
 
-if (!faro.api && !process.env.CI && process.env.NODE_ENV !== 'development') {
+if (
+  isFaroEnabled &&
+  !faro.api &&
+  !process.env.CI &&
+  process.env.NODE_ENV !== 'development'
+) {
   try {
     initializeFaro({
       app: {

--- a/apps/web/src/lib/hooks/react-query/tokens/useTokenSecurity.ts
+++ b/apps/web/src/lib/hooks/react-query/tokens/useTokenSecurity.ts
@@ -193,6 +193,10 @@ export const isTokenSecurityIssue = {
   (value: TokenSecurity[keyof TokenSecurity]) => boolean
 >
 
+export function isTokenSecurityKey(key: string): key is keyof TokenSecurity {
+  return Object.hasOwn(isTokenSecurityIssue, key)
+}
+
 export const TokenSecurityMessage: Record<keyof TokenSecurity, string> = {
   //Contract Security
   is_open_source:
@@ -330,8 +334,6 @@ const fetchDeFiResponse = async (currency: EvmToken) => {
     gas_abuse: issues[DeFiScannerIssue.GAS_ABUSE].issues.length > 0,
     buy_tax: issues[DeFiScannerIssue.TRANSFER_FEES].issues.length > 0,
     sell_tax: issues[DeFiScannerIssue.TRANSFER_FEES].issues.length > 0,
-    cannot_buy: issues[DeFiScannerIssue.TRANSFER_LIMITS].issues.length > 0,
-    cannot_sell_all: issues[DeFiScannerIssue.TRANSFER_LIMITS].issues.length > 0,
     transfer_pausable:
       issues[DeFiScannerIssue.TRANSFER_PAUSABLE].issues.length > 0,
     is_blacklisted: issues[DeFiScannerIssue.HAS_BLACKLIST].issues.length > 0,
@@ -346,7 +348,7 @@ const fetchDeFiResponse = async (currency: EvmToken) => {
     is_honeypot: undefined,
     is_anti_whale: undefined,
     trust_list: undefined,
-  } as TokenSecurity
+  } satisfies TokenSecurity
 }
 
 const fetchTokenSecurityQueryFn = async (
@@ -380,18 +382,15 @@ const fetchTokenSecurityQueryFn = async (
       ? deFiResponseResult.value
       : undefined
 
-  const responseKeys = new Set([
-    ...Object.keys(goPlusResponse ?? {}),
-    ...Object.keys(deFiResponse ?? {}),
+  const responseKeys = new Set<keyof TokenSecurity>([
+    ...Object.keys(goPlusResponse ?? {}).filter(isTokenSecurityKey),
+    ...Object.keys(deFiResponse ?? {}).filter(isTokenSecurityKey),
   ])
   const data = Array.from(responseKeys).reduce(
     (acc, key) => {
-      type SecurityKey = keyof TokenSecurity
-      const field = key as SecurityKey
-
-      acc[field] = {
-        goPlus: goPlusResponse?.[field],
-        deFi: deFiResponse?.[field],
+      acc[key] = {
+        goPlus: goPlusResponse?.[key],
+        deFi: deFiResponse?.[key],
       }
       return acc
     },
@@ -408,11 +407,10 @@ const fetchTokenSecurityQueryFn = async (
       data?.sell_tax?.goPlus ||
       data?.buy_tax?.deFi,
     isRisky: Object.entries(data || {}).some(([_key, value]) => {
-      const key = _key as keyof TokenSecurity
       if (
-        key in isTokenSecurityIssue &&
-        (isTokenSecurityIssue[key](value.deFi) ||
-          isTokenSecurityIssue[key](value.goPlus))
+        isTokenSecurityKey(_key) &&
+        (isTokenSecurityIssue[_key](value.deFi) ||
+          isTokenSecurityIssue[_key](value.goPlus))
       ) {
         return true
       }

--- a/apps/web/src/lib/wagmi/components/token-security-rows.test.ts
+++ b/apps/web/src/lib/wagmi/components/token-security-rows.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { getTokenSecurityRows } from './token-security-rows'
+
+const isIssueByKey = {
+  is_honeypot: (value: boolean | undefined) => value === true,
+  is_open_source: (value: boolean | undefined) => value === false,
+}
+
+describe('getTokenSecurityRows', () => {
+  it('ignores unsupported scanner fields instead of rendering them', () => {
+    const data = {
+      cannot_buy: { deFi: true },
+      cannot_sell_all: { deFi: true },
+      is_honeypot: { goPlus: true },
+      is_open_source: { goPlus: true },
+    }
+
+    expect(getTokenSecurityRows(data, isIssueByKey)).toEqual({
+      rows: [
+        { key: 'is_honeypot', isIssue: true },
+        { key: 'is_open_source', isIssue: false },
+      ],
+      issueCount: 1,
+    })
+  })
+})

--- a/apps/web/src/lib/wagmi/components/token-security-rows.ts
+++ b/apps/web/src/lib/wagmi/components/token-security-rows.ts
@@ -1,0 +1,58 @@
+interface TokenSecurityValue {
+  deFi?: boolean
+  goPlus?: boolean
+}
+
+interface TokenSecurityRows<Key extends string> {
+  rows: { key: Key; isIssue: boolean }[]
+  issueCount: number
+}
+
+function isKeyOf<Key extends string>(
+  record: Record<Key, unknown>,
+  key: string,
+): key is Key {
+  return Object.hasOwn(record, key)
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | undefined {
+  return value === undefined || typeof value === 'boolean'
+}
+
+function isTokenSecurityValue(value: unknown): value is TokenSecurityValue {
+  if (!value || typeof value !== 'object') return false
+
+  return (
+    isOptionalBoolean(Reflect.get(value, 'deFi')) &&
+    isOptionalBoolean(Reflect.get(value, 'goPlus'))
+  )
+}
+
+export function getTokenSecurityRows<Key extends string>(
+  data: object | undefined,
+  isIssueByKey: Record<
+    Key,
+    (value: TokenSecurityValue[keyof TokenSecurityValue]) => boolean
+  >,
+): TokenSecurityRows<Key> {
+  const issues: Key[] = []
+  const nonIssues: Key[] = []
+
+  for (const [key, value] of Object.entries(data || {})) {
+    if (!isKeyOf(isIssueByKey, key) || !isTokenSecurityValue(value)) continue
+
+    if (isIssueByKey[key](value.deFi) || isIssueByKey[key](value.goPlus)) {
+      issues.push(key)
+    } else {
+      nonIssues.push(key)
+    }
+  }
+
+  return {
+    rows: [
+      ...issues.map((key) => ({ key, isIssue: true })),
+      ...nonIssues.map((key) => ({ key, isIssue: false })),
+    ],
+    issueCount: issues.length,
+  }
+}

--- a/apps/web/src/lib/wagmi/components/token-security-view.tsx
+++ b/apps/web/src/lib/wagmi/components/token-security-view.tsx
@@ -15,6 +15,7 @@ import {
 } from 'src/lib/hooks/react-query'
 import type { EvmToken } from 'sushi/evm'
 import type { SvmToken } from 'sushi/svm'
+import { getTokenSecurityRows } from './token-security-rows'
 
 export const TokenSecurityView = ({
   token,
@@ -25,30 +26,10 @@ export const TokenSecurityView = ({
   tokenSecurity: TokenSecurityResponse | undefined
   isTokenSecurityLoading: boolean
 }) => {
-  const { rows, issueCount } = useMemo(() => {
-    const issues: (keyof TokenSecurity)[] = []
-    const nonIssues: (keyof TokenSecurity)[] = []
-
-    for (const [_key, value] of Object.entries(tokenSecurity?.data || {})) {
-      const key = _key as keyof TokenSecurity
-      if (
-        key in isTokenSecurityIssue &&
-        (isTokenSecurityIssue[key](value.deFi) ||
-          isTokenSecurityIssue[key](value.goPlus))
-      ) {
-        issues.push(key)
-      } else {
-        nonIssues.push(key)
-      }
-    }
-    return {
-      rows: [
-        ...issues.map((key) => ({ key, isIssue: true })),
-        ...nonIssues.map((key) => ({ key, isIssue: false })),
-      ],
-      issueCount: issues.length,
-    }
-  }, [tokenSecurity])
+  const { rows, issueCount } = useMemo(
+    () => getTokenSecurityRows(tokenSecurity?.data, isTokenSecurityIssue),
+    [tokenSecurity],
+  )
 
   return (
     <div className="w-full overflow-x-auto">

--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/common/token-selector-import-row.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/common/token-selector-import-row.tsx
@@ -107,8 +107,8 @@ export function TokenSelectorImportRow<TChainId extends TokenSelectorChainId>({
           </div>
         </div>
       </div>
-      <DialogContent className="!flex flex-col max-h-[80vh]" hideClose>
-        <DialogHeader className="!text-left !space-y-3">
+      <DialogContent className="!flex max-h-[calc(100dvh-16px)] flex-col overflow-hidden md:max-h-[80vh]">
+        <DialogHeader className="!text-left !space-y-3 shrink-0">
           <DialogTitle>
             <div
               className={classNames(
@@ -147,70 +147,74 @@ export function TokenSelectorImportRow<TChainId extends TokenSelectorChainId>({
             </span>
           )}
         </DialogHeader>
-        <List>
-          <List.Control className="!p-4">
-            <div className="flex justify-between items-center">
-              <div className="flex items-center gap-4">
-                <Badge
-                  position="bottom-right"
-                  badgeContent={
-                    <div className="bg-white rounded-full dark:bg-slate-800">
-                      <NetworkIcon
-                        width={20}
-                        height={20}
-                        chainId={currency.chainId}
-                      />
+        <div className="min-h-0 overflow-y-auto">
+          <div className="flex flex-col gap-4">
+            <List>
+              <List.Control className="!p-4">
+                <div className="flex justify-between items-center">
+                  <div className="flex items-center gap-4">
+                    <Badge
+                      position="bottom-right"
+                      badgeContent={
+                        <div className="bg-white rounded-full dark:bg-slate-800">
+                          <NetworkIcon
+                            width={20}
+                            height={20}
+                            chainId={currency.chainId}
+                          />
+                        </div>
+                      }
+                    >
+                      <div className="w-10 h-10">
+                        <UnknownTokenIcon width={40} height={40} />
+                      </div>
+                    </Badge>
+                    <div className="flex flex-col">
+                      <span className="text-2xl font-medium">
+                        {currency.symbol ?? '-'}
+                      </span>
+                      <span className="font-medium text-muted-foreground">
+                        {currency.name ?? '-'}
+                      </span>
                     </div>
-                  }
-                >
-                  <div className="w-10 h-10">
-                    <UnknownTokenIcon width={40} height={40} />
                   </div>
-                </Badge>
-                <div className="flex flex-col">
-                  <span className="text-2xl font-medium">
-                    {currency.symbol ?? '-'}
-                  </span>
-                  <span className="font-medium text-muted-foreground">
-                    {currency.name ?? '-'}
-                  </span>
+                  <LinkExternal
+                    target="_blank"
+                    href={getChainById(currency.chainId).getTokenUrl(
+                      // Chain-specific address types collapse under the union here.
+                      currency.address as never,
+                    )}
+                    className="font-medium"
+                  >
+                    {shortenAddress(currency.address)}{' '}
+                  </LinkExternal>
                 </div>
-              </div>
-              <LinkExternal
-                target="_blank"
-                href={getChainById(currency.chainId).getTokenUrl(
-                  // Chain-specific address types collapse under the union here.
-                  currency.address as never,
-                )}
-                className="font-medium"
-              >
-                {shortenAddress(currency.address)}{' '}
-              </LinkExternal>
-            </div>
-          </List.Control>
-        </List>
-        {securityCurrency ? (
-          <List className="!pt-0 overflow-hidden">
-            <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
-              <div className="flex items-center">
-                <span className="text-sm font-medium text-muted-foreground">
-                  Token Security Scan
-                </span>
-              </div>
-              {tokenSecurityImportState === 'unavailable' ? (
-                <span className="text-sm text-muted-foreground">
-                  Security providers did not return results for this token.
-                </span>
-              ) : (
-                <TokenSecurityView
-                  token={securityCurrency}
-                  tokenSecurity={tokenSecurity}
-                  isTokenSecurityLoading={isTokenSecurityScanning}
-                />
-              )}
-            </List.Control>
-          </List>
-        ) : null}
+              </List.Control>
+            </List>
+            {securityCurrency ? (
+              <List className="!pt-0 overflow-hidden">
+                <List.Control className="!overflow-y-auto flex flex-col gap-3 p-4">
+                  <div className="flex items-center">
+                    <span className="text-sm font-medium text-muted-foreground">
+                      Token Security Scan
+                    </span>
+                  </div>
+                  {tokenSecurityImportState === 'unavailable' ? (
+                    <span className="text-sm text-muted-foreground">
+                      Security providers did not return results for this token.
+                    </span>
+                  ) : (
+                    <TokenSecurityView
+                      token={securityCurrency}
+                      tokenSecurity={tokenSecurity}
+                      isTokenSecurityLoading={isTokenSecurityScanning}
+                    />
+                  )}
+                </List.Control>
+              </List>
+            ) : null}
+          </div>
+        </div>
         <Message
           size="sm"
           variant={hasSecurityRisk ? 'destructive' : 'warning'}


### PR DESCRIPTION
## Summary

- discard unsupported De.Fi intermediate fields before building token security results
- validate token security rows before invoking issue predicates
- add regression coverage for cannot_buy and cannot_sell_all responses
- temporarily disable Faro initialization behind a local kill switch

## Root cause

The partial-provider merge included De.Fi intermediate cannot_buy and cannot_sell_all fields. The token security view placed unsupported fields in its non-issue rows and then called a missing issue predicate while rendering.

## Validation

- pnpm --filter web exec vitest --watch=false src/lib/wagmi/components/token-security-rows.test.ts
- pnpm format
- pnpm lint
- pnpm --filter web check (blocked locally only by five missing proprietary TradingView module declarations under the perps chart)