### PR TITLE
fix(graph-client): preserve GraphQL nullability

### DIFF
--- a/apps/web/src/app/(cms)/academy/[article-slug]/page.tsx
+++ b/apps/web/src/app/(cms)/academy/[article-slug]/page.tsx
@@ -48,13 +48,13 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     openGraph: {
       type: 'article',
       ...media,
-      publishedTime: article.publishedAt,
-      modifiedTime: article.updatedAt,
+      publishedTime: article.publishedAt ?? undefined,
+      modifiedTime: article.updatedAt ?? undefined,
       authors: article.authors.map((author) => author.name),
       tags: [...article.topics, ...article.products]
         .flat()
         .reduce<string[]>((acc, el) => {
-          acc.push(el.name)
+          if (el.name) acc.push(el.name)
           return acc
         }, []),
     },
@@ -85,6 +85,7 @@ export default async function Page(props: Props) {
     })
 
     article = (await articleP).articles[0]
+    if (!article.ghostSlug) return notFound()
     body = await getGhostBody(article.ghostSlug).then(({ html }) => html)
     moreArticles = (await moreArticlesP).articles
   } catch {
@@ -102,8 +103,8 @@ export default async function Page(props: Props) {
       email,
       url: `https://twitter.com/${handle}`,
     })),
-    datePublished: article.publishedAt,
-    dateModified: article.updatedAt,
+    datePublished: article.publishedAt ?? undefined,
+    dateModified: article.updatedAt ?? undefined,
     image: {
       '@type': 'ImageObject',
       url: article.cover.url,

--- a/apps/web/src/app/(cms)/academy/components/difficulty-filter-bar/difficulty-filter-bar-client.tsx
+++ b/apps/web/src/app/(cms)/academy/components/difficulty-filter-bar/difficulty-filter-bar-client.tsx
@@ -20,12 +20,16 @@ export function DifficultyFilterBarClient({
   const setFilters = useSetAcademySearch()
 
   // Only allow one difficulty to be selected at a time
-  const [value, setValue] = useState<string | undefined>(selectedDifficulty)
+  const [value, setValue] = useState<string | undefined>(
+    selectedDifficulty ?? undefined,
+  )
 
   const onSelect = useCallback(
     (difficulty: Difficulty) => {
       const newDifficulty =
-        difficulty.slug === value ? undefined : difficulty.slug
+        difficulty.slug && difficulty.slug !== value
+          ? difficulty.slug
+          : undefined
 
       setValue(newDifficulty)
 

--- a/apps/web/src/app/(cms)/academy/components/topic-product-bar/topic-product-bar-client.tsx
+++ b/apps/web/src/app/(cms)/academy/components/topic-product-bar/topic-product-bar-client.tsx
@@ -16,13 +16,15 @@ export function TopicProductBarClient({ categories }: TopicProductBarClient) {
   const { category: selectedCategory } = useAcademySearch()
   const setFilters = useSetAcademySearch()
 
-  const [value, setValue] = useState<string | undefined>(selectedCategory)
+  const [value, setValue] = useState<string | undefined>(
+    selectedCategory ?? undefined,
+  )
 
   const FilterButton = ({ category }: { category: Topic | Product }) => {
     const isSelected = value === category.slug
 
     const onClick = useCallback(() => {
-      const newCategory = isSelected ? undefined : category.slug
+      const newCategory = isSelected ? undefined : (category.slug ?? undefined)
 
       setValue(newCategory)
 

--- a/apps/web/src/app/(cms)/academy/explore/components/difficulty-filter-dropdown/difficulty-filter-dropdown-client.tsx
+++ b/apps/web/src/app/(cms)/academy/explore/components/difficulty-filter-dropdown/difficulty-filter-dropdown-client.tsx
@@ -29,7 +29,7 @@ export function DifficultyFilterDropdownClient({
     (slug: string | undefined) => {
       if (!slug) return undefined
 
-      return difficulties.find((d) => d.slug === slug)!.name
+      return difficulties.find((d) => d.slug === slug)?.name ?? undefined
     },
     [difficulties],
   )
@@ -38,7 +38,7 @@ export function DifficultyFilterDropdownClient({
     (name: string | undefined) => {
       if (!name) return undefined
 
-      return difficulties.find((d) => d.name === name)!.slug
+      return difficulties.find((d) => d.name === name)?.slug ?? undefined
     },
     [difficulties],
   )
@@ -76,16 +76,18 @@ export function DifficultyFilterDropdownClient({
           </span>
         </SelectTrigger>
         <SelectContent>
-          {difficulties.map((difficulty) => (
-            <SelectItem
-              key={difficulty.slug}
-              value={difficulty.name}
-              title={difficulty.name}
-              className="px-4 text-base"
-            >
-              {difficulty.name}
-            </SelectItem>
-          ))}
+          {difficulties.map((difficulty) =>
+            difficulty.name && difficulty.slug ? (
+              <SelectItem
+                key={difficulty.slug}
+                value={difficulty.name}
+                title={difficulty.name}
+                className="px-4 text-base"
+              >
+                {difficulty.name}
+              </SelectItem>
+            ) : null,
+          )}
         </SelectContent>
       </Select>
       <div

--- a/apps/web/src/app/(cms)/academy/explore/components/topic-product-sidebar/topic-product-sidebar-client-desktop.tsx
+++ b/apps/web/src/app/(cms)/academy/explore/components/topic-product-sidebar/topic-product-sidebar-client-desktop.tsx
@@ -14,12 +14,14 @@ export function TopicProductBarClientDesktop({
     ({
       category,
     }: { category: TopicProductBarClientGeneric['categories'][number] }) => {
-      const isSelected = selectedValue === category.slug
+      if (!category.slug) return null
+      const slug = category.slug
+      const isSelected = selectedValue === slug
 
       return (
         <div
-          onClick={() => setValue(category.slug)}
-          onKeyDown={() => setValue(category.slug)}
+          onClick={() => setValue(slug)}
+          onKeyDown={() => setValue(slug)}
           className={classNames(
             'text-sm w-full cursor-pointer rounded-xl hover:bg-blue hover:bg-opacity-70 px-4 py-2',
             isSelected && 'bg-blue bg-opacity-80',

--- a/apps/web/src/app/(cms)/academy/explore/components/topic-product-sidebar/topic-product-sidebar-client-mobile.tsx
+++ b/apps/web/src/app/(cms)/academy/explore/components/topic-product-sidebar/topic-product-sidebar-client-mobile.tsx
@@ -12,16 +12,19 @@ interface SidebarEntry {
 }
 
 function SidebarEntry({ category, setValue, selectedValue }: SidebarEntry) {
+  if (!category.slug) return null
+  const slug = category.slug
+
   return (
     <div
       className={classNames(
         'font-medium w-[160px] max-w-fit',
-        category.slug === selectedValue
+        slug === selectedValue
           ? 'dark:text-gray-100'
           : 'dark:text-gray-400 text-[#7F7F7F] dark:hover:text-gray-300',
       )}
-      onClick={() => setValue(category.slug)}
-      onKeyUp={() => setValue(category.slug)}
+      onClick={() => setValue(slug)}
+      onKeyUp={() => setValue(slug)}
     >
       {category.name}
     </div>

--- a/apps/web/src/app/(cms)/academy/explore/components/topic-product-sidebar/topic-product-sidebar-client.tsx
+++ b/apps/web/src/app/(cms)/academy/explore/components/topic-product-sidebar/topic-product-sidebar-client.tsx
@@ -26,7 +26,9 @@ export function TopicProductSidebarClient({
   const { category: selectedCategory } = useAcademySearch()
   const setFilters = useSetAcademySearch()
 
-  const [value, setValue] = useState<string | undefined>(selectedCategory)
+  const [value, setValue] = useState<string | undefined>(
+    selectedCategory ?? undefined,
+  )
 
   const onSelect = useCallback(
     (categorySlug: string) => {

--- a/apps/web/src/app/(cms)/academy/sitemap.ts
+++ b/apps/web/src/app/(cms)/academy/sitemap.ts
@@ -24,7 +24,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         (article) =>
           ({
             url: `https://www.sushi.com/academy/${article.slug}`,
-            lastModified: new Date(article.updatedAt),
+            ...(article.updatedAt
+              ? { lastModified: new Date(article.updatedAt) }
+              : {}),
             changeFrequency: 'weekly',
           }) as const,
       ),

--- a/apps/web/src/app/(cms)/blog/[article-slug]/page.tsx
+++ b/apps/web/src/app/(cms)/blog/[article-slug]/page.tsx
@@ -49,8 +49,8 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     openGraph: {
       type: 'article',
       ...media,
-      publishedTime: article.publishedAt,
-      modifiedTime: article.updatedAt,
+      publishedTime: article.publishedAt ?? undefined,
+      modifiedTime: article.updatedAt ?? undefined,
       authors: article.authors.map((author) => author.name),
       tags: article.categories.reduce<string[]>((acc, el) => {
         acc.push(el.name)
@@ -84,6 +84,7 @@ export default async function Page(props: Props) {
     })
 
     article = (await articleP).articles[0]
+    if (!article.ghostSlug) return notFound()
     body = await getGhostBody(article.ghostSlug).then(({ html }) => html)
     moreArticles = (await moreArticlesP).articles
   } catch {
@@ -101,8 +102,8 @@ export default async function Page(props: Props) {
       email,
       url: `https://twitter.com/${handle}`,
     })),
-    datePublished: article.publishedAt,
-    dateModified: article.updatedAt,
+    datePublished: article.publishedAt ?? undefined,
+    dateModified: article.updatedAt ?? undefined,
     image: {
       '@type': 'ImageObject',
       url: article.cover.url,

--- a/apps/web/src/app/(cms)/blog/sitemap.ts
+++ b/apps/web/src/app/(cms)/blog/sitemap.ts
@@ -19,7 +19,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         (article) =>
           ({
             url: `https://www.sushi.com/blog/${article.slug}`,
-            lastModified: new Date(article.updatedAt),
+            ...(article.updatedAt
+              ? { lastModified: new Date(article.updatedAt) }
+              : {}),
             changeFrequency: 'weekly',
           }) as const,
       ),

--- a/apps/web/src/app/(cms)/header.tsx
+++ b/apps/web/src/app/(cms)/header.tsx
@@ -52,13 +52,18 @@ export async function Header() {
     },
     {
       title: 'Learn',
-      items: difficulties?.map(({ shortDescription, slug }) => {
+      items: difficulties?.flatMap(({ shortDescription, slug }) => {
+        if (!shortDescription) return []
         const isTechnical = slug === 'technical'
-        return {
-          title: shortDescription,
-          href: isTechnical ? DOCS_URL : `/academy/explore?difficulty=${slug}`,
-          description: '',
-        }
+        return [
+          {
+            title: shortDescription,
+            href: isTechnical
+              ? DOCS_URL
+              : `/academy/explore?difficulty=${slug}`,
+            description: '',
+          },
+        ]
       }),
       show: 'desktop',
       type: NavigationElementType.Dropdown,

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/strapi-banner/strapi-banner-content.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/strapi-banner/strapi-banner-content.tsx
@@ -38,15 +38,13 @@ export function StrapiBannerContent({
     [banner, hiddenBannerIds],
   )
 
-  if (hiddenBannerIds.includes(banner.id)) {
-    return <></>
-  }
+  if (hiddenBannerIds.includes(banner.id) || !banner.image) return null
 
   const image = banner.image.attributes
 
   return (
     <a
-      href={banner.link}
+      href={banner.link ?? undefined}
       target="_blank"
       rel="noopener noreferrer"
       className="text-white"
@@ -66,8 +64,8 @@ export function StrapiBannerContent({
         <Image
           src={getOptimizedMedia({
             metadata: image.provider_metadata,
-            width: image.width,
-            height: image.height,
+            width: image.width ?? undefined,
+            height: image.height ?? undefined,
           })}
           alt={image.alternativeText || ''}
           layout="fill"

--- a/apps/web/src/app/(networks)/(evm)/perps/leaderboard/_ui/leaderboard-table.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/leaderboard/_ui/leaderboard-table.tsx
@@ -113,7 +113,8 @@ export const LeaderboardTable = () => {
 
   const userData = useMemo(() => {
     if (!_userData) return null
-    if (_userData.rank <= 3) return null
+    const rank = _userData.rank
+    if (rank === null || rank <= 3) return null
     const userInLeaderboard = leaderboardData?.find(
       (entry) =>
         entry.address.toLowerCase() === _userData.address.toLowerCase(),
@@ -122,7 +123,7 @@ export const LeaderboardTable = () => {
     if (userInLeaderboard) {
       return userInLeaderboard
     }
-    return _userData
+    return { ..._userData, rank }
   }, [_userData, leaderboardData])
 
   useEffect(() => {

--- a/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-history/portfolio-approve-transaction.tsx
+++ b/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-history/portfolio-approve-transaction.tsx
@@ -11,6 +11,8 @@ import { PortfolioInfoRow } from '../portfolio-info-row'
 export const PortfolioApproveTransaction: FC<{ tx: PortfolioTransaction }> = ({
   tx,
 }) => {
+  if (!tx.approve) return null
+
   return (
     <PortfolioInfoRow
       chainId={tx.chainId as EvmChainId}

--- a/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-history/portfolio-other-transaction.tsx
+++ b/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-history/portfolio-other-transaction.tsx
@@ -19,7 +19,7 @@ export const PortfolioOtherTransaction: FC<{ tx: PortfolioTransaction }> = ({
       )}
       externalLink
       icon={
-        tx.projectName.toLowerCase().includes('sushi') ? (
+        tx.projectName?.toLowerCase().includes('sushi') ? (
           <div className="p-1.5 bg-gradient-to-r from-[rgba(12,116,183,0.3)] to-[rgba(174,46,141,0.3)] rounded-full w-7 h-7">
             <SushiLiteIcon className="text-white" />
           </div>

--- a/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-positions/portfolio-v2-positions.tsx
+++ b/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-positions/portfolio-v2-positions.tsx
@@ -33,13 +33,13 @@ export const PortfolioV2Positions: FC<PortfolioV2PositionssProps> = ({
             <Currency.IconList iconWidth={24} iconHeight={24}>
               <img
                 className="rounded-full"
-                src={position.token0.logoUrl}
-                alt={position.token0.symbol}
+                src={position.token0.logoUrl ?? undefined}
+                alt={position.token0.symbol ?? undefined}
               />
               <img
                 className="rounded-full"
-                src={position.token1.logoUrl}
-                alt={position.token1.symbol}
+                src={position.token1.logoUrl ?? undefined}
+                alt={position.token1.symbol ?? undefined}
               />
             </Currency.IconList>
           }

--- a/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-positions/portfolio-v3-positions.tsx
+++ b/apps/web/src/app/(networks)/_ui/user-portfolio/portfolio-positions/portfolio-v3-positions.tsx
@@ -35,13 +35,13 @@ export const PortfolioV3Positions: FC<PortfolioV3PositionsProps> = ({
             <Currency.IconList iconWidth={24} iconHeight={24}>
               <img
                 className="rounded-full"
-                src={position.token0.logoUrl}
-                alt={position.token0.symbol}
+                src={position.token0.logoUrl ?? undefined}
+                alt={position.token0.symbol ?? undefined}
               />
               <img
                 className="rounded-full"
-                src={position.token1.logoUrl}
-                alt={position.token1.symbol}
+                src={position.token1.logoUrl ?? undefined}
+                alt={position.token1.symbol ?? undefined}
               />
             </Currency.IconList>
           }

--- a/apps/web/src/app/tokenlist-request/approved/page.tsx
+++ b/apps/web/src/app/tokenlist-request/approved/page.tsx
@@ -46,7 +46,7 @@ const COLUMNS: ColumnDef<ApprovedCommunityTokens[number], unknown>[] = [
         >
           <div className="h-8 w-8 rounded-full overflow-hidden border-2 ring-gray-50 dark:ring-slate-950">
             <img
-              src={props.row.original.logoUrl}
+              src={props.row.original.logoUrl ?? undefined}
               width={32}
               height={32}
               alt={props.row.original.symbol}

--- a/apps/web/src/app/tokenlist-request/pending/page.tsx
+++ b/apps/web/src/app/tokenlist-request/pending/page.tsx
@@ -39,9 +39,11 @@ import {
 import { NavigationItems } from '../navigation-items'
 
 const getTokenSecurity = (security: PendingTokens[number]['security']) => {
+  if (!security) return undefined
+
   const data = {
     is_buyable: {
-      goPlus: security.isBuyable,
+      goPlus: security.isBuyable ?? undefined,
     },
     is_open_source: {
       goPlus: security.isOpenSource,
@@ -71,10 +73,10 @@ const getTokenSecurity = (security: PendingTokens[number]['security']) => {
       goPlus: security.gasAbuse,
     },
     buy_tax: {
-      goPlus: security.buyTax,
+      goPlus: security.buyTax ?? undefined,
     },
     sell_tax: {
-      goPlus: security.sellTax,
+      goPlus: security.sellTax ?? undefined,
     },
     is_sell_limit: {
       goPlus: security.cannotSellAll,
@@ -114,8 +116,8 @@ const getTokenSecurity = (security: PendingTokens[number]['security']) => {
   return {
     data,
     isAvailable: true,
-    isHoneypot: data?.is_honeypot?.goPlus,
-    isFoT: data?.buy_tax?.goPlus || data?.sell_tax?.goPlus,
+    isHoneypot: data.is_honeypot.goPlus,
+    isFoT: data.buy_tax.goPlus || data.sell_tax.goPlus || undefined,
     isRisky: Object.entries(data || {}).some(([_key, value]) => {
       const key = _key as keyof TokenSecurity
       if (

--- a/apps/web/src/lib/hooks/react-query/tokens/useTokenSecurity.ts
+++ b/apps/web/src/lib/hooks/react-query/tokens/useTokenSecurity.ts
@@ -310,39 +310,52 @@ const fetchDeFiResponse = async (currency: EvmToken) => {
 
   const json = (await response.json()) as TokenScannerResponse
 
-  const issues = [...json.coreIssues, ...json.generalIssues].reduce(
+  type IssueGroup = NonNullable<
+    NonNullable<TokenScannerResponse['generalIssues']>[number]
+  >
+
+  const issues = [
+    ...(json.coreIssues ?? []),
+    ...(json.generalIssues ?? []),
+  ].reduce(
     (accum, cur) => {
-      accum[cur.scwId] = cur
+      if (cur?.scwId) accum[cur.scwId] = cur
       return accum
     },
-    {} as Record<string, TokenScannerResponse['generalIssues'][number]>,
+    {} as Record<string, IssueGroup>,
   )
+
+  function hasIssue(id: DeFiScannerIssue): boolean | undefined {
+    const issueList = issues[id]?.issues
+    return issueList ? issueList.length > 0 : undefined
+  }
+
+  const hasVerifiedContractIssue = hasIssue(DeFiScannerIssue.VERIFIED_CONTRACT)
+  const hasTransferLimitIssue = hasIssue(DeFiScannerIssue.TRANSFER_LIMITS)
 
   return {
     is_open_source:
-      issues[DeFiScannerIssue.VERIFIED_CONTRACT].issues.length === 0,
-    is_proxy: issues[DeFiScannerIssue.UPGRADABLE_CONTRACT].issues.length > 0,
-    is_mintable: issues[DeFiScannerIssue.IS_MINTABLE].issues.length > 0,
-    can_take_back_ownership:
-      issues[DeFiScannerIssue.VULNERABLE_OWNERSHIP].issues.length > 0,
-    owner_change_balance:
-      issues[DeFiScannerIssue.HAS_BALANCE_CONTROLS].issues.length > 0,
-    hidden_owner: issues[DeFiScannerIssue.HIDDEN_OWNERSHIP].issues.length > 0,
-    selfdestruct: issues[DeFiScannerIssue.SELF_DESTRUCT].issues.length > 0,
-    external_call:
-      issues[DeFiScannerIssue.HAS_EXTERNAL_CALLS].issues.length > 0,
-    gas_abuse: issues[DeFiScannerIssue.GAS_ABUSE].issues.length > 0,
-    buy_tax: issues[DeFiScannerIssue.TRANSFER_FEES].issues.length > 0,
-    sell_tax: issues[DeFiScannerIssue.TRANSFER_FEES].issues.length > 0,
-    transfer_pausable:
-      issues[DeFiScannerIssue.TRANSFER_PAUSABLE].issues.length > 0,
-    is_blacklisted: issues[DeFiScannerIssue.HAS_BLACKLIST].issues.length > 0,
-    is_whitelisted: issues[DeFiScannerIssue.HAS_WHITELIST].issues.length > 0,
-    trading_cooldown:
-      issues[DeFiScannerIssue.TRANSFER_COOLDOWN].issues.length > 0,
-    is_airdrop_scam: issues[DeFiScannerIssue.AIRDROP].issues.length > 0,
-    is_buyable: issues[DeFiScannerIssue.TRANSFER_LIMITS].issues.length === 0,
-    is_sell_limit: issues[DeFiScannerIssue.TRANSFER_LIMITS].issues.length > 0,
+      hasVerifiedContractIssue === undefined
+        ? undefined
+        : !hasVerifiedContractIssue,
+    is_proxy: hasIssue(DeFiScannerIssue.UPGRADABLE_CONTRACT),
+    is_mintable: hasIssue(DeFiScannerIssue.IS_MINTABLE),
+    can_take_back_ownership: hasIssue(DeFiScannerIssue.VULNERABLE_OWNERSHIP),
+    owner_change_balance: hasIssue(DeFiScannerIssue.HAS_BALANCE_CONTROLS),
+    hidden_owner: hasIssue(DeFiScannerIssue.HIDDEN_OWNERSHIP),
+    selfdestruct: hasIssue(DeFiScannerIssue.SELF_DESTRUCT),
+    external_call: hasIssue(DeFiScannerIssue.HAS_EXTERNAL_CALLS),
+    gas_abuse: hasIssue(DeFiScannerIssue.GAS_ABUSE),
+    buy_tax: hasIssue(DeFiScannerIssue.TRANSFER_FEES) ?? false,
+    sell_tax: hasIssue(DeFiScannerIssue.TRANSFER_FEES) ?? false,
+    transfer_pausable: hasIssue(DeFiScannerIssue.TRANSFER_PAUSABLE),
+    is_blacklisted: hasIssue(DeFiScannerIssue.HAS_BLACKLIST),
+    is_whitelisted: hasIssue(DeFiScannerIssue.HAS_WHITELIST),
+    trading_cooldown: hasIssue(DeFiScannerIssue.TRANSFER_COOLDOWN),
+    is_airdrop_scam: hasIssue(DeFiScannerIssue.AIRDROP),
+    is_buyable:
+      hasTransferLimitIssue === undefined ? undefined : !hasTransferLimitIssue,
+    is_sell_limit: hasTransferLimitIssue,
     is_fake_token: undefined,
     slippage_modifiable: undefined,
     is_honeypot: undefined,

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@solana/addresses": "catalog:web3",
-    "gql.tada": "1.7.5",
+    "gql.tada": "1.11.3",
     "graphql": "16.6.0",
     "graphql-request": "7.1.0",
     "json-bigint": "1.0.0",
@@ -60,7 +60,7 @@
     "viem": "catalog:web3"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "1.12.3",
+    "@0no-co/graphqlsp": "1.17.3",
     "@tsconfig/node24": "catalog:tsconfig",
     "@tsconfig/strictest": "catalog:tsconfig",
     "@types/json-bigint": "1.0.4",

--- a/packages/graph-client/src/subgraphs/data-api/schema.graphql
+++ b/packages/graph-client/src/subgraphs/data-api/schema.graphql
@@ -561,7 +561,7 @@ type Bucket {
 type SushiDayBuckets {
   v2: [Bucket!]!
   v3: [Bucket!]!
-  blade: [Bucket!]
+  blade: [Bucket!]!
 }
 
 type BladePoolToken {
@@ -1072,7 +1072,7 @@ type V3PortfolioPosition {
   range: RangeStatus!
   token0: SimpleToken!
   token1: SimpleToken!
-  fees: [SimpleToken]!
+  fees: [SimpleToken!]!
   amountUSD: Float!
   updatedAt: Int
 }
@@ -1093,15 +1093,15 @@ type FuroPosition {
 
 type PortfolioPositions {
   totalUSD: Float!
-  v2Positions: [V2PortfolioPosition]!
-  v3Positions: [V3PortfolioPosition]!
+  v2Positions: [V2PortfolioPosition!]!
+  v3Positions: [V3PortfolioPosition!]!
 }
 
 type PortfolioClaimables {
   totalUSD: Float!
-  v2PositionClaimables: [V2PoolClaim]!
-  v3PositionClaimables: [V3PoolClaim]!
-  furoClaimables: [FuroClaim]!
+  v2PositionClaimables: [V2PoolClaim!]!
+  v3PositionClaimables: [V3PoolClaim!]!
+  furoClaimables: [FuroClaim!]!
 }
 
 type V2PoolClaim {
@@ -1167,8 +1167,8 @@ type PortfolioTransaction {
   projectName: String
   protocolLogo: String
   category: PortfolioTransactionCategory!
-  receives: [PortfolioTransactionToken]!
-  sends: [PortfolioTransactionToken]!
+  receives: [PortfolioTransactionToken!]!
+  sends: [PortfolioTransactionToken!]!
   approve: PortfolioTransactionToken
   gasFeeNative: Float!
   gasFeeUSD: Float!
@@ -1515,9 +1515,9 @@ type V2Swap {
 }
 
 type V2Transaction {
-  swaps: [V2Swap]
-  burns: [V2Burn]
-  mints: [V2Mint]
+  swaps: [V2Swap!]
+  burns: [V2Burn!]
+  mints: [V2Mint!]
   createdAtBlock: String!
   createdAtTimestamp: String!
   id: ID!
@@ -1574,8 +1574,8 @@ type V3Transaction {
   id: ID!
   blockNumber: String!
   timestamp: String!
-  collects: [V3Collect]
-  swaps: [V3Swap]
-  burns: [V3Burn]
-  mints: [V3Mint]
+  collects: [V3Collect!]
+  swaps: [V3Swap!]
+  burns: [V3Burn!]
+  mints: [V3Mint!]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,8 +778,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       gql.tada:
-        specifier: 1.7.5
-        version: 1.7.5(graphql@16.6.0)(svelte@4.2.17)(typescript@5.9.3)
+        specifier: 1.11.3
+        version: 1.11.3(graphql@16.6.0)(typescript@5.9.3)
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -797,8 +797,8 @@ importers:
         version: 2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11)
     devDependencies:
       '@0no-co/graphqlsp':
-        specifier: 1.12.3
-        version: 1.12.3(graphql@16.6.0)(typescript@5.9.3)
+        specifier: 1.17.3
+        version: 1.17.3(graphql@16.6.0)(typescript@5.9.3)
       '@tsconfig/node24':
         specifier: catalog:tsconfig
         version: 24.0.4
@@ -1247,16 +1247,16 @@ importers:
 
 packages:
 
-  '@0no-co/graphql.web@1.0.7':
-    resolution: {integrity: sha512-E3Qku4mTzdrlwVWGPxklDnME5ANrEGetvYw4i2GCRlppWXXE4QD66j7pwb8HelZwS6LnqEChhrSOGCXpbiu6MQ==}
+  '@0no-co/graphql.web@1.3.3':
+    resolution: {integrity: sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==}
     peerDependencies:
       graphql: 16.6.0
     peerDependenciesMeta:
       graphql:
         optional: true
 
-  '@0no-co/graphqlsp@1.12.3':
-    resolution: {integrity: sha512-U0hV/FmFgm2perV+mrXKe/7Z5F4/9rmOziHJYYQgKLwzUVuN5LQG0qs3cLBGxAqoosG0HfTi2cQkgMKY1CMbYQ==}
+  '@0no-co/graphqlsp@1.17.3':
+    resolution: {integrity: sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==}
     peerDependencies:
       graphql: 16.6.0
       typescript: 5.9.3
@@ -3176,14 +3176,22 @@ packages:
     peerDependencies:
       viem: 2.55.0
 
-  '@gql.tada/cli-utils@1.3.9':
-    resolution: {integrity: sha512-oRb7SG/+csx9CiypSJTI21KaLfulOUnhX1vxg4FXi2snub9XShkGR2XnnlJVTAOZXY9Vcxti1NutAElxdDkycA==}
+  '@gql.tada/cli-utils@1.9.3':
+    resolution: {integrity: sha512-P1TiXErpJwIi73sei5fzwGA/SOeCaIHFWFR4RdZPLwqxZzQN0T6MAUivzXBgKCORL67rvYnLaaPoWeqWq/61ug==}
     peerDependencies:
+      '@0no-co/graphqlsp': ^1.16.0
+      '@gql.tada/svelte-support': 1.0.3
+      '@gql.tada/vue-support': 1.0.3
       graphql: 16.6.0
       typescript: 5.9.3
+    peerDependenciesMeta:
+      '@gql.tada/svelte-support':
+        optional: true
+      '@gql.tada/vue-support':
+        optional: true
 
-  '@gql.tada/internal@1.0.0':
-    resolution: {integrity: sha512-B55aIYyZn5ewdgMqoJciPAwF5DKYX6HBabTU+ap/dpNH3EgJrLomc8Y8w+MCxCyOx+dXL9OduT6eWnVr7J7Eyg==}
+  '@gql.tada/internal@1.2.2':
+    resolution: {integrity: sha512-4lZcElPP6MC8Ct8KN70LR2WQsHjbAsyAmTGG09VsOPhx738UFIYaL0S1XiI2pqq2tj/sDs/y3b9jvKoWGL7iuQ==}
     peerDependencies:
       graphql: 16.6.0
       typescript: 5.9.3
@@ -8658,29 +8666,6 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
-  '@volar/language-core@2.2.5':
-    resolution: {integrity: sha512-2htyAuxRrAgETmFeUhT4XLELk3LiEcqoW/B8YUXMF6BrGWLMwIR09MFaZYvrA2UhbdAeSyeQ726HaWSWkexUcQ==}
-
-  '@volar/source-map@2.2.5':
-    resolution: {integrity: sha512-wrOEIiZNf4E+PWB0AxyM4tfhkfldPsb3bxg8N6FHrxJH2ohar7aGu48e98bp3pR9HUA7P/pR9VrLmkTrgCCnWQ==}
-
-  '@vue/compiler-core@3.4.27':
-    resolution: {integrity: sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==}
-
-  '@vue/compiler-dom@3.4.27':
-    resolution: {integrity: sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==}
-
-  '@vue/language-core@2.0.19':
-    resolution: {integrity: sha512-A9EGOnvb51jOvnCYoRLnMP+CcoPlbZVxI9gZXE/y2GksRWM6j/PrLEIC++pnosWTN08tFpJgxhSS//E9v/Sg+Q==}
-    peerDependencies:
-      typescript: 5.9.3
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@vue/shared@3.4.27':
-    resolution: {integrity: sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==}
-
   '@wagmi/connectors@6.2.0':
     resolution: {integrity: sha512-2NfkbqhNWdjfibb4abRMrn7u6rPjEGolMfApXss6HCDVt9AW2oVC6k8Q5FouzpJezElxLJSagWz9FW1zaRlanA==}
     peerDependencies:
@@ -9944,9 +9929,6 @@ packages:
     resolution: {integrity: sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==}
     engines: {node: '>= 0.8.0'}
 
-  computeds@0.0.1:
-    resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -10255,9 +10237,6 @@ packages:
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
-  de-indent@1.0.2:
-    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
-
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -10330,9 +10309,6 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
-
-  dedent-js@1.0.1:
-    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
 
   dedent@1.5.3:
     resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
@@ -11574,8 +11550,8 @@ packages:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
 
-  gql.tada@1.7.5:
-    resolution: {integrity: sha512-GepPTee+FWSVVZQ7GiJHzsGNo7gOb59kcn4mUPYLlkbpeJfOUwpuoB05ZNaXG0W4qZVPd1I7R2UgMHBjY1lGlQ==}
+  gql.tada@1.11.3:
+    resolution: {integrity: sha512-5JCI4j2f0nug8ILaCQys/yjOP78QqqjVUf47OQsME63rZfemsHT3e5vcfbHsnZiG6vxyqpKUJArtXEVwSefUhw==}
     hasBin: true
     peerDependencies:
       typescript: 5.9.3
@@ -11645,10 +11621,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -12717,9 +12689,6 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
-  lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
@@ -13193,9 +13162,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  muggle-string@0.4.1:
-    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
-
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
@@ -13291,9 +13257,6 @@ packages:
       next: '>= 6.0.0'
       react: '>= 16.0.0'
       react-dom: '>= 16.0.0'
-
-  no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
   nocache@3.0.4:
     resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
@@ -13654,12 +13617,6 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-
-  pascal-case@3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
-
-  path-browserify@1.0.1:
-    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -15204,12 +15161,6 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
-  svelte2tsx@0.7.8:
-    resolution: {integrity: sha512-ABK3RDFcy59AqAiU1N5Kxu1RnKrb1GDMrQjLgNgJfE8Q+coCKpjCAPtUVKQM2HnmuqeNWcT3NqfXbE+ZmN5Pow==}
-    peerDependencies:
-      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
-      typescript: 5.9.3
-
   svelte@4.2.17:
     resolution: {integrity: sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==}
     engines: {node: '>=16'}
@@ -15975,9 +15926,6 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
-  vue-template-compiler@2.7.16:
-    resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
-
   w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
@@ -16374,13 +16322,13 @@ packages:
 
 snapshots:
 
-  '@0no-co/graphql.web@1.0.7(graphql@16.6.0)':
+  '@0no-co/graphql.web@1.3.3(graphql@16.6.0)':
     optionalDependencies:
       graphql: 16.6.0
 
-  '@0no-co/graphqlsp@1.12.3(graphql@16.6.0)(typescript@5.9.3)':
+  '@0no-co/graphqlsp@1.17.3(graphql@16.6.0)(typescript@5.9.3)':
     dependencies:
-      '@gql.tada/internal': 1.0.0(graphql@16.6.0)(typescript@5.9.3)
+      '@gql.tada/internal': 1.2.2(graphql@16.6.0)(typescript@5.9.3)
       graphql: 16.6.0
       typescript: 5.9.3
 
@@ -18873,21 +18821,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@gql.tada/cli-utils@1.3.9(graphql@16.6.0)(svelte@4.2.17)(typescript@5.9.3)':
+  '@gql.tada/cli-utils@1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.6.0)(typescript@5.9.3))(graphql@16.6.0)(typescript@5.9.3)':
     dependencies:
-      '@0no-co/graphqlsp': 1.12.3(graphql@16.6.0)(typescript@5.9.3)
-      '@gql.tada/internal': 1.0.0(graphql@16.6.0)(typescript@5.9.3)
-      '@vue/compiler-dom': 3.4.27
-      '@vue/language-core': 2.0.19(typescript@5.9.3)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.6.0)(typescript@5.9.3)
+      '@gql.tada/internal': 1.2.2(graphql@16.6.0)(typescript@5.9.3)
       graphql: 16.6.0
-      svelte2tsx: 0.7.8(svelte@4.2.17)(typescript@5.9.3)
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - svelte
 
-  '@gql.tada/internal@1.0.0(graphql@16.6.0)(typescript@5.9.3)':
+  '@gql.tada/internal@1.2.2(graphql@16.6.0)(typescript@5.9.3)':
     dependencies:
-      '@0no-co/graphql.web': 1.0.7(graphql@16.6.0)
+      '@0no-co/graphql.web': 1.3.3(graphql@16.6.0)
       graphql: 16.6.0
       typescript: 5.9.3
 
@@ -26694,41 +26637,6 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@volar/language-core@2.2.5':
-    dependencies:
-      '@volar/source-map': 2.2.5
-
-  '@volar/source-map@2.2.5':
-    dependencies:
-      muggle-string: 0.4.1
-
-  '@vue/compiler-core@3.4.27':
-    dependencies:
-      '@babel/parser': 7.26.5
-      '@vue/shared': 3.4.27
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
-  '@vue/compiler-dom@3.4.27':
-    dependencies:
-      '@vue/compiler-core': 3.4.27
-      '@vue/shared': 3.4.27
-
-  '@vue/language-core@2.0.19(typescript@5.9.3)':
-    dependencies:
-      '@volar/language-core': 2.2.5
-      '@vue/compiler-dom': 3.4.27
-      '@vue/shared': 3.4.27
-      computeds: 0.0.1
-      minimatch: 9.0.5
-      path-browserify: 1.0.1
-      vue-template-compiler: 2.7.16
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@vue/shared@3.4.27': {}
-
   '@wagmi/connectors@6.2.0(94708c3b423c11ac0018c66907f7de6e)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.17)(bufferutil@4.0.8)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(immer@9.0.21)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(utf-8-validate@6.0.3)(zod@4.1.11)
@@ -28618,7 +28526,8 @@ snapshots:
     dependencies:
       deep-equal: 2.2.3
 
-  aria-query@5.3.2: {}
+  aria-query@5.3.2:
+    optional: true
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -29419,6 +29328,7 @@ snapshots:
       acorn: 8.17.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
+    optional: true
 
   collect-v8-coverage@1.0.2:
     optional: true
@@ -29500,8 +29410,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  computeds@0.0.1: {}
 
   concat-map@0.0.1: {}
 
@@ -29671,6 +29579,7 @@ snapshots:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
+    optional: true
 
   cssesc@3.0.0: {}
 
@@ -29901,8 +29810,6 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  de-indent@1.0.2: {}
-
   debounce@1.2.1: {}
 
   debug@2.6.9:
@@ -29942,8 +29849,6 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-
-  dedent-js@1.0.1: {}
 
   dedent@1.5.3(babel-plugin-macros@3.1.0):
     optionalDependencies:
@@ -30241,7 +30146,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.2.1
 
-  entities@4.5.0: {}
+  entities@4.5.0:
+    optional: true
 
   envinfo@7.14.0: {}
 
@@ -30597,7 +30503,7 @@ snapshots:
       eslint: 9.39.5(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.5(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.5(jiti@1.21.7))
       eslint-plugin-react: 7.37.4(eslint@9.39.5(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@1.21.7))
@@ -30658,13 +30564,13 @@ snapshots:
       debug: 4.4.0
       enhanced-resolve: 5.17.1
       eslint: 9.39.5(jiti@1.21.7)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.5(jiti@1.21.7))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.5(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -30703,7 +30609,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.5(jiti@1.21.7)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -30714,7 +30620,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.5(jiti@1.21.7)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -30760,7 +30666,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.5(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -30771,7 +30677,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.5(jiti@1.21.7))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7)))(eslint@9.39.5(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -31606,15 +31512,17 @@ snapshots:
       p-cancelable: 2.1.1
       responselike: 2.0.1
 
-  gql.tada@1.7.5(graphql@16.6.0)(svelte@4.2.17)(typescript@5.9.3):
+  gql.tada@1.11.3(graphql@16.6.0)(typescript@5.9.3):
     dependencies:
-      '@0no-co/graphql.web': 1.0.7(graphql@16.6.0)
-      '@gql.tada/cli-utils': 1.3.9(graphql@16.6.0)(svelte@4.2.17)(typescript@5.9.3)
-      '@gql.tada/internal': 1.0.0(graphql@16.6.0)(typescript@5.9.3)
+      '@0no-co/graphql.web': 1.3.3(graphql@16.6.0)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.6.0)(typescript@5.9.3)
+      '@gql.tada/cli-utils': 1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.6.0)(typescript@5.9.3))(graphql@16.6.0)(typescript@5.9.3)
+      '@gql.tada/internal': 1.2.2(graphql@16.6.0)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
       - graphql
-      - svelte
 
   graceful-fs@4.2.11: {}
 
@@ -31679,8 +31587,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  he@1.2.0: {}
 
   help-me@5.0.0: {}
 
@@ -32049,6 +31955,7 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
+    optional: true
 
   is-regex@1.2.1:
     dependencies:
@@ -32966,7 +32873,8 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  locate-character@3.0.0: {}
+  locate-character@3.0.0:
+    optional: true
 
   locate-path@3.0.0:
     dependencies:
@@ -33043,10 +32951,6 @@ snapshots:
       get-func-name: 2.0.2
 
   loupe@3.2.1: {}
-
-  lower-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
 
   lowercase-keys@2.0.0: {}
 
@@ -33285,7 +33189,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.0.30: {}
+  mdn-data@2.0.30:
+    optional: true
 
   memoize-one@5.2.1: {}
 
@@ -33867,8 +33772,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  muggle-string@0.4.1: {}
-
   multiformats@9.9.0: {}
 
   mustache@4.0.0: {}
@@ -33970,11 +33873,6 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.8.1
 
   nocache@3.0.4: {}
 
@@ -34389,13 +34287,6 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  pascal-case@3.1.2:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
-
-  path-browserify@1.0.1: {}
-
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -34439,6 +34330,7 @@ snapshots:
       '@types/estree': 1.0.6
       estree-walker: 3.0.3
       is-reference: 3.0.3
+    optional: true
 
   petra-plugin-wallet-adapter@0.4.5(@aptos-labs/ts-sdk@1.27.0)(aptos@1.21.0):
     dependencies:
@@ -36214,13 +36106,6 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  svelte2tsx@0.7.8(svelte@4.2.17)(typescript@5.9.3):
-    dependencies:
-      dedent-js: 1.0.1
-      pascal-case: 3.1.2
-      svelte: 4.2.17
-      typescript: 5.9.3
-
   svelte@4.2.17:
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -36237,6 +36122,7 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.17
       periscopic: 3.1.0
+    optional: true
 
   symbol-tree@3.2.4:
     optional: true
@@ -37031,11 +36917,6 @@ snapshots:
       - terser
 
   vlq@1.0.1: {}
-
-  vue-template-compiler@2.7.16:
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
 
   w3c-xmlserializer@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade gql.tada and GraphQLSP so turbo-generated document types preserve schema nullability
- handle nullable CMS, portfolio, leaderboard, and token-security fields at their existing consumers
- keep generated GraphQL types as the source of truth, without cache bypasses or duplicated local result types

## Validation

- pnpm format
- pnpm lint
- pnpm check (18/18 tasks)
- pnpm --filter web test:unit (174 passed, 1 skipped)