### PR TITLE
chore(design-sync): sync @sushiswap/ui to claude.ai/design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,248 @@
+# design-sync notes — @sushiswap/ui
+
+Repo-specific gotchas for future syncs. Append as you learn.
+
+## Install / build
+
+- **`pnpm install` fails without `TRADING_VIEW_GH_READ_TOKEN`.** The root `preinstall`
+  hook runs `scripts/require-trading-view-gh-read-token.js`, which hard-exits when that
+  env var is unset — the install never reaches dependency resolution. For sync purposes
+  use `pnpm install --frozen-lockfile --ignore-scripts`; it exits 0 and reports
+  `Already up to date` against the committed lockfile. (Never pipe the install through
+  `tail` — the pipe masks the exit code and the preinstall failure looks like success.)
+- Node/pnpm are pinned: `.nvmrc` = `lts/krypton` (node 24), `packageManager` = `pnpm@10.34.5`.
+- pnpm's isolated linker means **`react` is NOT at the repo-root `node_modules`**. Pass
+  `--node-modules packages/ui/node_modules` — `react`, `react-dom`, and `@types/react`
+  all resolve there.
+- DS build is plain `tsc` (`packages/ui/package.json`), emitting `dist/` next to `src/`.
+  Build with workspace deps: `pnpm -F "@sushiswap/ui..." build` (the trailing `...` is
+  required — `@sushiswap/ui` depends on the `@sushiswap/hooks`, `@sushiswap/telemetry`,
+  and `@sushiswap/tailwindcss-config` workspace packages).
+- The dist entry `packages/ui/dist/index.js` is a 227-byte barrel of `export *`
+  re-exports; that is correct, not a failed build.
+
+## Styling
+
+- `packages/ui/index.css` is **Tailwind source**, not compiled CSS (`@tailwind base;`
+  etc. plus `@layer base` token definitions). It is not usable as `cfg.cssEntry`.
+  The compiled CSS must come from the storybook build via the converter's
+  `[CSS_FROM_STORYBOOK]` scrape.
+- Fonts are npm packages shipping real woff2 files:
+  `@fontsource-variable/inter` and `@fontsource-variable/orbitron`, imported at the top
+  of `index.css`. Tokens `--font-sans` / `--font-orbitron` reference them.
+
+## Providers
+
+- `@sushiswap/ui` exports **`BaseProviders`**, which is what
+  `apps/storybook/.storybook/preview.tsx` wraps every story in
+  (`<BaseProviders forcedTheme={theme}>`). Theme comes from a storybook toolbar global,
+  default `light`. It is a `next-themes` `ThemeProvider` with `attribute="class"`,
+  `themes={['light','black','dark']}`, plus three portal divs
+  (`#network-check-portal`, `#popover-portal`, `#footer-portal`).
+- `cfg.provider` is set to `BaseProviders` with `forcedTheme: "light"` **explicitly**,
+  rather than relying on the auto-bundled `.storybook/preview` decorators. The decorator
+  bundle *cannot* work here: `preview.tsx` imports `@sushiswap/ui/index.css`, whose
+  fontsource `@import`s pull `.woff2` files, and the decorator bundler has no loader for
+  them (`! preview decorator bundle failed: No loader is configured for ".woff2" files`).
+  Setting `cfg.provider` skips decorator bundling entirely.
+
+## Root causes fixed on the first sync (2026-08-03)
+
+Three independent, all-components-down failures. All three are `[GENERAL]`.
+
+1. **`components: 0` / `exported PascalCase symbols: 0`** — `packages/ui/package.json`
+   declares its types entry *only* under `exports['.'].types`; it has no top-level
+   `types`/`typings`. The converter's `lib/dts.mjs` resolves the entry `.d.ts` from
+   `publishConfig.types || types || typings || 'index.d.ts'`, so it looked for
+   `packages/ui/index.d.ts`, didn't find it, never loaded the entry module, and found
+   zero exports — even though `findTypesRoot` correctly located the 357-file `dist/`
+   tree. No `cfg.*` knob covers this (`grep ASSUMPTION` confirms).
+   **Fix:** `.design-sync/overrides/dts.mjs` (declared in `cfg.libOverrides`) adds an
+   `exportsTypesEntry()` helper reading `exports['.'].types` and threads it into both
+   `findTypesRoot` and `projectFor`. Worth reporting upstream — an `exports`-only types
+   declaration is the modern norm.
+2. **`ReferenceError: process is not defined` at bundle load** — killed the entire
+   bundle before `window.SushiswapUi` was ever assigned, so *all* components vanished.
+   `@sushiswap/ui` is Next-coupled (`next/image`, `next/link`, `next/navigation`,
+   `next/script`, `next/dynamic` across avatar, link, table, navigation, data-table,
+   breadcrumb, currency/*), and `next/dist/client/image-component.js` reads
+   `process.env.__NEXT_IMAGE_OPTS` at module scope. The repo's storybook hides this with
+   `define: { 'process.env': {} }` in `.storybook/main.ts`; the shipped bundle gets no
+   such define, and the converter only defines `process.env.NODE_ENV`. There is no
+   `cfg.define`/`cfg.external` key, and `lib/bundle.mjs` is never-fork.
+   **Fix:** `.design-sync/ds-runtime-shim.mjs`, wired as the **first**
+   `cfg.extraEntries` item so it evaluates before the DS entry (the converter emits
+   extraEntries ahead of the main entry in `.bundle-entry.mjs`, and ESM evaluates in
+   declaration order). It defines a minimal `globalThis.process` without clobbering a
+   real one.
+3. **`[CSS_PLACEHOLDER]` / `[CSS_RUNTIME]` — no CSS at all.** `packages/ui/index.css` is
+   Tailwind *source*, unusable as `cfg.cssEntry`. The converter's storybook-CSS scrape
+   (`lib/css-fallback.mjs`) looks for the largest local `<link rel=stylesheet>` in
+   `sb-reference/iframe.html` — but **Storybook 8 + Vite injects its stylesheet from JS**
+   (`assets/iframe-*.js` references `assets/preview-*.css`), so there is no `<link>` to
+   find. The hashed artifact also can't be used as `cfg.cssEntry` directly: that field is
+   bounded to the package dir.
+   **Fix:** compile the DS's Tailwind CSS to a stable path under `packages/ui/dist/`
+   (gitignored) and point `cfg.cssEntry` at it. Two reproducible commands — **re-run both
+   whenever `packages/ui/src` or `index.css` changes**, before the converter:
+
+   ```sh
+   sed -e '/@fontsource-variable/d' -e 's#@import "\./#@import "../#' \
+     packages/ui/index.css > packages/ui/dist/.ds-input.css
+   (cd apps/storybook && npx tailwindcss -c ../../.design-sync/tailwind.config.mjs \
+      -i ../../packages/ui/dist/.ds-input.css -o ../../packages/ui/dist/design-sync.css)
+   ```
+
+   The `sed` strips the two `@fontsource-variable` imports (their `@font-face` `url()`s
+   are relative to the *fontsource* package, so they would dangle from `dist/`) and
+   rewrites `./date-picker.css` → `../date-picker.css` for the new depth. Fonts are wired
+   separately via `cfg.extraFonts` pointing at the two fontsource `index.css` files, which
+   is the converter's designed path.
+
+   **Use `.design-sync/tailwind.config.mjs`, NOT `apps/storybook/tailwind.config.js`.**
+   This is the subtlest trap in the whole sync and it fails *silently*: the storybook
+   config carries no `content` of its own and inherits the shared preset's **relative**
+   globs (`./components/**`, `../../packages/ui/src/**`). Run through the `tailwindcss`
+   CLI those globs match nothing — `DEBUG=tailwindcss:*` reports
+   `Potential classes: 1` — so the output still contains the preflight, `date-picker.css`
+   and the `@layer base` tokens (≈50 KB, looks plausible!) but **zero utilities**, and
+   every component ships unstyled while the build and validator both exit 0. Storybook's
+   own Vite/postcss pipeline resolves the same globs correctly, which is why the reference
+   render looks right and only the CLI path breaks. Absolute globs fix it: the same run
+   goes to 33.8k candidates and ≈139 KB.
+   `.design-sync/tailwind.config.mjs` derives absolute paths from `import.meta.url` (so
+   it is cwd- and clone-independent) and maps the shared preset's own content list through
+   `resolve(apps/storybook, glob)` — deliberately the **same** set the reference storybook
+   scans. It intentionally does *not* add `apps/storybook/stories/**`: the preset omits it,
+   so story-only classes are missing from the reference render too, and adding them would
+   let previews style things the oracle cannot — a self-inflicted fidelity mismatch.
+   It imports the preset by repo-relative path (`../config/tailwindcss/index.js`) because
+   `.design-sync/`'s only `node_modules` is the converter-deps symlink.
+   **Sanity check after any CSS recompile** — never trust the byte count alone:
+   `grep -c 'inline-flex' packages/ui/dist/design-sync.css` must be > 0.
+
+   Do not use `packages/ui/tailwind.js` either: it sets `prefix: 'ui-'`, but the
+   components emit *unprefixed* classes (`inline-flex gap-1`) and the storybook oracle
+   renders unprefixed. (`packages/ui/src` contains exactly one stray `ui-items`.)
+
+4. **Every one of the 66 stories reported `sb-error: no storybook root content`** on the
+   first `compare.mjs` run — i.e. the *reference* side, not the previews. The stories
+   render perfectly by hand (`#storybook-root` has 1152 bytes of HTML and innerText
+   "Button", zero page errors). The cause is a genuine interaction between this DS's
+   provider and the harness's readiness check: `compare.mjs` waits for
+   `:is(#storybook-root, #root) > :not(style,script,link,meta,template)` with playwright's
+   `waitForSelector`, whose default state is `visible`, and which resolves to the **first**
+   match. `BaseProviders` renders `<div id="network-check-portal" />` as its first child,
+   *before* `{children}` — an always-empty div with height 0, so the first match is never
+   visible and the wait times out for every story. (`state: 'attached'` matches
+   immediately; `state: 'visible'` does not — confirmed directly.)
+   **Fix:** `node .design-sync/patch-sb-reference.mjs`, which injects a `<style>` into
+   `.design-sync/sb-reference/iframe.html` making the three portal mounts
+   `position: absolute; width: 1px; height: 1px`. Layout-neutral — they contribute 0
+   height in flow today and paint nothing, and root height for
+   `primitives-button--default` is 40px both with and without the patch — so the oracle is
+   not distorted. `compare.mjs` is the fidelity oracle and must never be forked, which is
+   why this lives in the local reference artifact instead.
+   **`sb-reference/` is gitignored and regenerated, so this patch MUST be re-applied
+   after every reference rebuild.** Always run the two together:
+
+   ```sh
+   npx storybook build -c apps/storybook/.storybook -o "$(git rev-parse --show-toplevel)/.design-sync/sb-reference"
+   node .design-sync/patch-sb-reference.mjs
+   ```
+
+   The script is idempotent (second run prints "already patched"). Symptom if forgotten:
+   100% `sb-error` across all components — that is this, not broken stories.
+   Worth reporting upstream: the harness already excludes leading `style`/`script` nodes;
+   an empty leading layout div is the same class of problem.
+
+## Known render warns (triaged — an unrecorded warn is NEW, look at it)
+
+- **`[RENDER_THIN] components/primitives/Separator`** — legitimate. Separator *is* a 1px
+  hairline; the compare sheet shows it identical on both panels. Not a defect.
+- **`[TOKENS_MISSING]` — 4 vars, all expected:**
+  - `--radix-navigation-menu-viewport-height`, `--radix-navigation-menu-viewport-width`,
+    `--radix-accordion-content-height` — radix sets these at runtime via inline style.
+  - `--font-inter` — a genuine **upstream quirk**, not a sync problem, and worth fixing in
+    the repo one day. `config/tailwindcss/index.js` maps `fontFamily.sans` to
+    `var(--font-inter)`, but nothing in the design system ever defines that variable
+    (`packages/ui/index.css` defines `--font-sans` and `--font-orbitron`). Consequence: the
+    Tailwind `font-sans` **utility class** resolves to nothing. Text is still Inter because
+    `index.css` sets `html, body { font-family: var(--font-sans) }` — verified in a
+    rendered preview: computed font-family is `"Inter Variable", …` and
+    `document.fonts.check('16px "Inter Variable"')` is true. So fonts ship and render
+    correctly; only the explicit `font-sans` class is dead. `.design-sync/conventions.md`
+    warns the design agent off it.
+
+## Verification scope on the first sync (2026-08-03)
+
+All 33 storied components graded `match` on every story — 66 stories in the reference
+index, plus the 3 extra TextField stories the cap would have dropped.
+
+- **TextField was captured with `--max-stories 9`** (the default cap is 6 and
+  `[STORY_CAP]` flagged it). Its 9 stories are genuinely distinct variants
+  (Default/Numeric/Percent/Icon/Unit/Adornments/Description/Variants/Sizes). Keep passing
+  `--max-stories 9` for TextField, or the tail three ride on verified-by-upload without
+  ever having been graded individually.
+- **Interaction-driven stories render their closed state on BOTH panels** and are graded
+  `match` on that basis, which is faithful but means the product cards show a trigger
+  rather than an open overlay: Dialog (4 stories), Popover (2), Tooltip, Explainer. No
+  `cfg.overrides.*.skip` was needed and no `[PORTAL?]` fired, because nothing is ever open
+  in a static capture. If you later want open-overlay cards, that needs owned previews
+  forcing the open state — plus `cardMode: "single"`.
+- **Slider's reference panel is clipped, not different.** Storybook screenshots
+  `#storybook-root`, whose height collapses to the ~5px track, so the round thumb is cut
+  off vertically there while the preview captures the full page. Graded `match` on the
+  component; re-confirm from `raw/*__sb.png` if it ever looks suspicious.
+
+## Re-sync risks — what to watch
+
+- **Re-apply the sb-reference patch after every reference rebuild.**
+  `node .design-sync/patch-sb-reference.mjs`. Forgetting it presents as 100% `sb-error`.
+- **Re-compile the DS stylesheet whenever `packages/ui/src` or `index.css` changes** (the
+  two commands in the Styling section) — and then **verify utilities actually landed**:
+  `grep -c 'inline-flex' packages/ui/dist/design-sync.css` must be > 0. A CSS with tokens
+  but no utilities looks plausible at ~50 KB and ships every component unstyled while
+  build and validate both exit 0. Expect ~139 KB / ~1,280 rules.
+- **The shipped stylesheet is content-scanned, so it is NOT the full Tailwind universe.**
+  It carries what `packages/ui/src` uses (plus most common layout utilities), but arbitrary
+  utilities — especially responsive variants — can be missing (verified absent: `p-8`,
+  `gap-8`, `md:grid-cols-2`, `lg:px-8`; each breakpoint has only 1–2 media blocks). This
+  limits the layout glue the design agent can write, and `conventions.md` tells it so.
+  **Deliberately not "fixed" on this run:** adding a safelist would give previews classes
+  the reference storybook's own CSS lacks, breaking the lockstep the compare oracle depends
+  on and invalidating all 33 grades. Doing it properly means safelist + `--force` full
+  re-verify of every component in one run. Decide before broadening.
+- **`.design-sync/ds-story-globals.mjs` is a deliberately narrow allow-list.** It re-exports
+  exactly `Amount`, `ChainId`, `SUSHI`, `USDT` — the complete set of `sushi` imports across
+  `apps/storybook/stories/` and `apps/storybook/components/` as of this sync. A story that
+  starts importing anything else from `sushi` or `sushi/evm` gets `undefined` (because
+  `cfg.storyImports.shim` routes all `sushi` imports to the global). Symptom: a cell error
+  naming the missing symbol. Fix: add the export there.
+- **`.design-sync/ds-runtime-shim.mjs` covers what Next 16.2.9 touches at module scope**
+  (`process.env`, `platform`, `nextTick`). A Next major bump may read something new; the
+  symptom is the whole bundle dying at load with `window.SushiswapUi` undefined, which
+  makes *every* component vanish at once. Probe it by loading `_vendor/react.js`,
+  `_vendor/react-dom.js` and `_ds_bundle.js` in a page and checking
+  `Object.keys(window.SushiswapUi).length` (expect ~244).
+- **`.design-sync/overrides/dts.mjs` is a fork** — diff it against the bundled
+  `.ds-sync/lib/dts.mjs` on each re-sync and merge upstream changes. It can be deleted
+  outright the day `packages/ui/package.json` grows a top-level
+  `"types": "./dist/index.d.ts"`, which would be a good upstream fix.
+- **Fresh clone setup:** `pnpm install --frozen-lockfile --ignore-scripts`, the `.ds-sync`
+  dep install + `playwright@1.61.1`, the sb-reference build + patch, the CSS compile, and
+  `ln -sfn ../.ds-sync/node_modules .design-sync/node_modules` (the dts fork imports bare
+  `ts-morph`).
+- **Token images in Currency/Button/Card stories load from the network.** They resolved on
+  both panels this run (no `[ASSETS_BLOCKED]`), but a sandboxed shell would blank them on
+  both sides and grades would falsely pass.
+
+## Toolchain
+
+- Playwright: chromium build **1228** is what this machine has cached, which pins
+  **playwright 1.61.1** (1.62.x wants 1234 and would re-download ~170MB). If
+  `browserType.launch: Executable doesn't exist` appears, re-check the pin:
+  `node -e "console.log(require('.ds-sync/node_modules/playwright-core/browsers.json').browsers.find(b=>b.name==='chromium').revision)"`.
+- The `.design-sync/overrides/dts.mjs` fork imports bare `ts-morph`, so a fresh clone
+  needs `ln -sfn ../.ds-sync/node_modules .design-sync/node_modules` (gitignored link,
+  committed fork).

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -225,6 +225,15 @@ index, plus the 3 extra TextField stories the cap would have dropped.
   makes *every* component vanish at once. Probe it by loading `_vendor/react.js`,
   `_vendor/react-dom.js` and `_ds_bundle.js` in a page and checking
   `Object.keys(window.SushiswapUi).length` (expect ~244).
+- **`.design-sync/overrides` is in `biome.json`'s `files.ignore` — keep it there.**
+  Without it the repo's CI actively damages the fork: the `Lint` job runs
+  `biome check . --apply`, which cannot fix the 3 style violations it reports in the
+  vendored code (all are flagged "Unsafe fix", and `--apply` only applies safe ones), so
+  the job **fails**; and the `Format` job runs `biome format --write` and
+  **auto-commits the result**, which rewrote the file by 456/268 lines on the first PR.
+  That cosmetic rewrite is the real damage — it destroys the byte-level correspondence to
+  the bundled `lib/dts.mjs` that the diff-and-merge step below depends on. The four
+  design-sync `.mjs` files we authored ourselves are NOT ignored and lint clean.
 - **`.design-sync/overrides/dts.mjs` is a fork** — diff it against the bundled
   `.ds-sync/lib/dts.mjs` on each re-sync and merge upstream changes. It can be deleted
   outright the day `packages/ui/package.json` grows a top-level

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,35 @@
+{
+  "projectId": "f6c69bc8-5fa2-48c8-83b1-ba8192b43f13",
+  "shape": "storybook",
+  "pkg": "@sushiswap/ui",
+  "storybookConfigDir": "apps/storybook/.storybook",
+  "storybookStatic": ".design-sync/sb-reference",
+  "buildCmd": "pnpm -F \"@sushiswap/ui...\" build",
+  "readmeHeader": ".design-sync/conventions.md",
+  "cssEntry": "./dist/design-sync.css",
+  "extraEntries": [
+    "../../.design-sync/ds-runtime-shim.mjs",
+    "../../.design-sync/ds-story-globals.mjs"
+  ],
+  "storyImports": {
+    "shim": ["/node_modules/sushi/_esm/"]
+  },
+  "extraFonts": [
+    "./node_modules/@fontsource-variable/inter/index.css",
+    "./node_modules/@fontsource-variable/orbitron/index.css"
+  ],
+  "provider": {
+    "component": "BaseProviders",
+    "props": { "forcedTheme": "light" }
+  },
+  "titleMap": {
+    "CurrencyIcon": "Currency",
+    "External": "LinkExternal",
+    "Internal": "LinkInternal",
+    "Circle": "SkeletonCircle",
+    "Text": "SkeletonText"
+  },
+  "libOverrides": {
+    "dts.mjs": "@sushiswap/ui declares its .d.ts entry only under exports['.'].types (no top-level types/typings), which the bundled resolver doesn't read — without the fork every component drops out"
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,104 @@
+# Sushi UI — how to build with this library
+
+React + Tailwind. Components are imported from the bundle; you write layout glue with
+Tailwind utility classes. Every name below was verified against the compiled artifacts.
+
+## Wrapping and setup
+
+Wrap the app once in `BaseProviders`. It is a `next-themes` provider
+(`attribute="class"`, `themes={['light','black','dark']}`) plus three portal mount points
+(`#network-check-portal`, `#popover-portal`, `#footer-portal`).
+
+```jsx
+<BaseProviders forcedTheme="light">
+  <YourScreen />
+</BaseProviders>
+```
+
+Design tokens live in `:root` in the stylesheet, **not** in the provider, so components are
+correctly styled even without the wrapper. What you lose without it is theme switching and
+the portal mounts — wrap anyway, and pass `forcedTheme` to pin a theme.
+
+Themes are **classes on an ancestor**, applied by the provider: default light,
+`.dark`, and `.black`. `.paper` is a frosted-glass surface (backdrop blur/saturate).
+
+## The styling idiom
+
+Tailwind utilities, **unprefixed** (`inline-flex gap-2 px-4`). Ignore the `ui-` prefix in
+`packages/ui/tailwind.js` — the components emit unprefixed classes.
+
+Semantic colors are the important part of the vocabulary; each maps to a CSS variable that
+re-themes automatically under `.dark` / `.black`. Use these instead of raw palette values:
+
+| Family | Real class names |
+|---|---|
+| surfaces | `bg-background`, `bg-secondary`, `bg-muted`, `bg-accent` |
+| text | `text-muted-foreground`, `text-accent-foreground`, `text-white`, `text-blue` |
+| borders / rings | `border-accent`, `ring-blue` |
+| brand / status | `bg-blue`, `bg-red` (also `pink`, `green`, `yellow`, and the `perps-*` set) |
+| radii used by the DS | `rounded-lg`, `rounded-xl`, `rounded-2xl` |
+
+Underlying tokens, if you need `var()` directly: `--background`, `--background-color`,
+`--color`, `--secondary`, `--muted`, `--muted-foreground`, `--accent`,
+`--accent-foreground`, `--green`, `--red`, `--font-sans`, `--font-orbitron`.
+
+**Two traps, both verified:**
+
+1. **Never write `font-sans`.** The Tailwind preset maps `fontFamily.sans` to
+   `var(--font-inter)`, which this design system never defines — the class resolves to
+   nothing and text falls back to the browser default. Inter Variable is already applied
+   to `html, body` via `--font-sans`, so just inherit it. `font-orbitron` is likewise not
+   in the shipped stylesheet; use `style={{ fontFamily: 'var(--font-orbitron)' }}` for the
+   display face.
+2. **The stylesheet is content-scanned, so it is not the full Tailwind universe.** It
+   contains the utilities this component library itself uses (~1,280 rules), plus most
+   common layout ones. Verified present: `p-4`, `p-6`, `grid`, `grid-cols-2`,
+   `grid-cols-3`, `flex-col`, `gap-6`, `w-full`, `max-w-md`, `max-w-2xl`, `text-lg`,
+   `text-2xl`, `font-semibold`, `font-bold`, `shadow-lg`, `space-y-4`, `justify-between`,
+   `text-center`, `border`, `hidden`. Verified **absent**: `p-8`, `gap-8`,
+   `md:grid-cols-2`, `lg:px-8` — responsive variants in particular exist only where the DS
+   uses them. Prefer the classes above; if a layout needs something exotic or a
+   breakpoint variant, use an inline `style` rather than assuming the class resolves.
+
+## Where the truth lives
+
+- The bound `styles.css` and its `@import` closure is the authoritative stylesheet —
+  grep it before inventing a class name.
+- `components/<group>/<Name>/<Name>.prompt.md` — per-component usage notes.
+- `components/<group>/<Name>/<Name>.d.ts` — the real `<Name>Props` contract.
+
+## An idiomatic example
+
+Library components for the controls, DS utilities for your own layout:
+
+```jsx
+<BaseProviders forcedTheme="light">
+  <div className="w-full max-w-md flex flex-col gap-6 p-6">
+    <Card>
+      <CardHeader>
+        <CardTitle>Position</CardTitle>
+        <CardDescription>Review before confirming</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <List>
+          <List.Control>
+            <List.KeyValue title="Network">Ethereum</List.KeyValue>
+            <List.KeyValue title="Fee">0.05%</List.KeyValue>
+          </List.Control>
+        </List>
+      </CardContent>
+      <CardFooter>
+        <Button size="lg">Confirm</Button>
+      </CardFooter>
+    </Card>
+    <Message variant="warning" size="sm">Prices update every few seconds.</Message>
+  </div>
+</BaseProviders>
+```
+
+Two compound namespaces: `List` exposes `List.Item`, `List.MenuItem`, `List.Label`,
+`List.Control` and `List.KeyValue`; `Currency` exposes `Currency.Icon`,
+`Currency.IconList` and `Currency.List`.
+Note that currency-amount components (e.g. `CardCurrencyAmountItem`) require real `sushi`
+SDK objects (`new Amount(SUSHI[ChainId.ETHEREUM], 100)`); `Amount`, `ChainId`, `SUSHI` and
+`USDT` are exported on the bundle for that purpose.

--- a/.design-sync/ds-runtime-shim.mjs
+++ b/.design-sync/ds-runtime-shim.mjs
@@ -1,0 +1,34 @@
+// Bundled into _ds_bundle.js AHEAD of the @sushiswap/ui entry (the converter
+// emits cfg.extraEntries before the main entry in .bundle-entry.mjs, and ESM
+// evaluates in that order) via cfg.extraEntries.
+//
+// Why this exists: @sushiswap/ui is Next-coupled — next/image, next/link,
+// next/navigation and next/script are imported across avatar, link, table,
+// navigation, data-table and the currency components. Next's client modules
+// read process.env at MODULE SCOPE (e.g. next/dist/client/image-component.js
+// reads process.env.__NEXT_IMAGE_OPTS), so in a plain browser the very first
+// require of next/image throws `ReferenceError: process is not defined` while
+// the IIFE is still initialising. That aborts the whole bundle before it can
+// assign window.SushiswapUi, so EVERY component disappears — not just the
+// Next-dependent ones.
+//
+// The repo's own storybook papers over the same problem with
+// `define: { 'process.env': {} }` in .storybook/main.ts; claude.ai/design
+// consumes the compiled bundle directly, so the shim has to travel inside it.
+//
+// Deliberately minimal: define only what Next's module-scope reads touch, and
+// never clobber a real `process` if one exists.
+const g = globalThis
+
+if (!g.process) g.process = {}
+if (!g.process.env) g.process.env = {}
+if (typeof g.process.platform !== 'string') g.process.platform = 'browser'
+if (typeof g.process.nextTick !== 'function') {
+  g.process.nextTick = (fn, ...args) => {
+    Promise.resolve().then(() => fn(...args))
+  }
+}
+if (!g.process.version) g.process.version = ''
+if (!g.process.versions) g.process.versions = {}
+
+export {}

--- a/.design-sync/ds-story-globals.mjs
+++ b/.design-sync/ds-story-globals.mjs
@@ -1,0 +1,27 @@
+// Bundled into _ds_bundle.js via cfg.extraEntries, and paired with
+// cfg.storyImports.shim = ["/node_modules/sushi/_esm/"].
+//
+// The problem: previews compile the story module into their OWN esbuild bundle
+// while the components come from the already-built _ds_bundle.js. Any class
+// that crosses that boundary gets TWO identities. `packages/ui/dist/components/
+// card.js` does `import { unwrapToken } from 'sushi'`, and unwrapToken is a
+// chain of `currency instanceof EvmToken` checks — so a token built by the
+// story's copy of sushi fails every branch and throws
+// `Invariant failed: Unsupported currency type`, taking the whole Card preview
+// down (both of its stories construct `new Amount(SUSHI[ChainId.ETHEREUM], 100)`).
+// The repo's storybook never sees this because Vite gives it one module graph.
+//
+// The fix: re-export the handful of sushi symbols the stories actually use from
+// HERE. Because this module is bundled into the same IIFE as the DS entry,
+// esbuild dedupes it against card.js's own sushi import by absolute path, so
+// window.SushiswapUi.SUSHI and card.js's EvmToken come from one class. The
+// storyImports.shim pattern then routes the stories' `sushi` / `sushi/evm`
+// imports to the global instead of bundling a second copy.
+//
+// Deliberately narrow — the entire sushi SDK on the DS global would bloat the
+// bundle and pollute the namespace the design agent reads. This is the complete
+// set of sushi imports across apps/storybook/stories/ and apps/storybook/
+// components/ (verified by grep); a story that starts importing something else
+// from sushi will see it as `undefined` and needs its symbol added here.
+export { Amount, ChainId } from 'sushi'
+export { SUSHI, USDT } from 'sushi/evm'

--- a/.design-sync/overrides/dts.mjs
+++ b/.design-sync/overrides/dts.mjs
@@ -1,0 +1,557 @@
+// forked from design-sync lib/dts.mjs — @sushiswap/ui declares its .d.ts entry
+// only under exports['.'].types (no legacy top-level `types`/`typings`), which
+// the bundled resolver doesn't read; without this the entry .d.ts is never
+// loaded and every component drops out (components: 0).
+
+// .d.ts extraction via ts-morph (real TS checker). Resolves the apparent
+// structural type of each <Name>Props — unwraps Omit/Pick, follows extends
+// chains and intersections, resolves `(typeof X)[number]` / mapped types to
+// literal unions.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
+
+// The `exports` map is the modern (and often only) place a package declares its
+// types entry. Read the "." subpath's `types` condition, tolerating both the
+// nested-conditions form and the shorthand string form.
+function exportsTypesEntry(pkgJson) {
+  const dot = pkgJson.exports?.['.'];
+  if (!dot || typeof dot !== 'object') return undefined;
+  const t = dot.types ?? dot.import?.types ?? dot.default?.types;
+  return typeof t === 'string' ? t : undefined;
+}
+
+export function findTypesRoot(pkgDir, pkgJson) {
+  // Workspace/monorepo packages often point dev `types` at src/*.ts (no .d.ts
+  // tree there); publishConfig carries the published .d.ts entry — prefer it
+  // when it exists on disk.
+  const pubTypes = pkgJson.publishConfig?.types;
+  if (pubTypes && existsSync(join(pkgDir, pubTypes))) return dirname(join(pkgDir, pubTypes));
+  const t = pkgJson.types || pkgJson.typings || exportsTypesEntry(pkgJson);
+  if (t) return dirname(join(pkgDir, t));
+  const hasDts = (d) => { try { return readdirSync(d).some((f) => f.endsWith('.d.ts')); } catch { return false; } };
+  for (const c of ['build/ts', 'dist/types', 'types', 'lib', 'dist']) {
+    const p = join(pkgDir, c);
+    if (existsSync(p) && (c !== 'dist' || hasDts(p))) return p;
+  }
+  return pkgDir;
+}
+
+// *Props are prop interfaces; ALL-CAPS are object constants; *Manager /
+// *Placements / *Context are utility singletons; use* are hooks — none
+// renderable. (dts.nonComponents also catches React.Context by symbol kind;
+// the suffix check is belt-and-suspenders for DSes where that misses.)
+export const isComponentName = (n) => !n.endsWith('Props') && !/^[A-Z][A-Z0-9_]+$/.test(n)
+  && !/(?:Manager|Placements|Context)$/.test(n) && !/^use[A-Z]/.test(n);
+
+// Partition into roots and subcomponents. A name is a subcomponent ONLY when
+// another name is a PascalCase prefix of it AND the suffix is an actual
+// namespace member of that prefix per the `compounds` map (i.e. Table.Row
+// exists, so top-level TableRow is the same subpart). Name shape alone
+// can't distinguish TableRow (only renders inside Table) from ButtonGroup
+// (standalone) — the compounds membership is the reliable signal. For DSes
+// that export subparts top-level only (no `Table.Row` namespace), this
+// conservatively does nothing.
+export function partitionSubcomponents(names, compounds) {
+  const set = new Set(names);
+  const parentOf = new Map();
+  for (const n of names) {
+    const parts = n.match(/[A-Z][a-z0-9]*/g) ?? [];
+    // Try longest prefix first, keep trying shorter ones — `ListItemText`
+    // with compounds {List: ['ItemText']} must reach `List` even if
+    // `ListItem` is itself a top-level name.
+    for (let i = parts.length - 1; i >= 1; i--) {
+      const prefix = parts.slice(0, i).join('');
+      if (!set.has(prefix)) continue;
+      const suffix = parts.slice(i).join('');
+      if ((compounds?.get(prefix) ?? []).includes(suffix)) { parentOf.set(n, prefix); break; }
+    }
+  }
+  // Flatten transitively — TableRowCell → TableRow → Table becomes
+  // TableRowCell → Table, so the caller's per-root bucketing doesn't lose
+  // subs whose immediate parent is itself a sub. Terminates: each parent has
+  // strictly fewer PascalCase parts than its child.
+  for (const [n] of parentOf) {
+    let p = parentOf.get(n);
+    while (parentOf.has(p)) p = parentOf.get(p);
+    parentOf.set(n, p);
+  }
+  return { parentOf };
+}
+
+// One Project per package — loadDts/exportedNames share it.
+const projects = new Map();
+
+function projectFor(pkgDir, typesRoot) {
+  if (projects.has(pkgDir)) return projects.get(pkgDir);
+  // Derive node_modules for cross-package resolution (React, peer deps).
+  // Normalize separators — pkgDir may have backslashes on Windows.
+  const posix = pkgDir.split('\\').join('/');
+  const i = posix.lastIndexOf('/node_modules/');
+  let nodeModules = i >= 0 ? join(pkgDir.slice(0, i), 'node_modules') : join(pkgDir, '..');
+  // Workspace packages live outside node_modules — walk up to the hoisted
+  // root node_modules so @types/react resolves (otherwise React utility types
+  // collapse to `any` and inherited props drop out of the emitted bodies).
+  if (!existsSync(join(nodeModules, '@types', 'react'))) {
+    for (let d = pkgDir; ; d = dirname(d)) {
+      if (existsSync(join(d, 'node_modules', '@types', 'react'))) { nodeModules = join(d, 'node_modules'); break; }
+      if (dirname(d) === d) break;
+    }
+  }
+  const pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+  // Same publishConfig preference as findTypesRoot — keep the two in sync.
+  const pubEntry = pj.publishConfig?.types;
+  const entry = join(pkgDir, (pubEntry && existsSync(join(pkgDir, pubEntry)) ? pubEntry : null) || pj.types || pj.typings || exportsTypesEntry(pj) || 'index.d.ts');
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.ReactJSX,
+      skipLibCheck: true,
+      strict: false,
+    },
+  });
+  // Add the package's own .d.ts tree plus @types/react (otherwise
+  // `ComponentPropsWithoutRef<…>` is `any` and intersection types collapse).
+  const reactTypes = join(nodeModules, '@types', 'react', 'index.d.ts');
+  // The negation must be absolute-scoped to match the positive pattern —
+  // ts-morph's fast-glob ignores bare `!**/node_modules/**` otherwise.
+  const root = typesRoot ?? dirname(entry);
+  project.addSourceFilesAtPaths([`${root}/**/*.d.ts`, `!${root}/**/node_modules/**`]);
+  console.error(`  [DTS] parsed ${project.getSourceFiles().length} .d.ts files from ${root}`);
+  // ts-morph StandardizedFilePath is always forward-slash; normalize pkgDir
+  // once so fp.startsWith(pkgDir) in isOwnProp/propsBodyFor works on Windows.
+  // Trailing slash so a sibling node_modules package whose name is a prefix of
+  // this one (foo vs foo-icons) isn't mis-classified as in-package.
+  const pkgDirStd = pkgDir.split('\\').join('/').replace(/\/?$/, '/');
+  if (existsSync(reactTypes)) project.addSourceFileAtPath(reactTypes);
+  else console.error(
+    '\n[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
+    '[DTS_REACT] @types/react not found in node_modules. React utility types\n' +
+    '[DTS_REACT] (ComponentPropsWithoutRef, FC, …) will resolve to `any`, so\n' +
+    '[DTS_REACT] components whose props extend them will emit EMPTY bodies.\n' +
+    '[DTS_REACT] Fix: `npm i -D @types/react` then rebuild.\n' +
+    '[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n',
+  );
+  if (existsSync(entry)) project.addSourceFileAtPath(entry);
+  const ctx = { project, entry, pkgDir: pkgDirStd };
+  projects.set(pkgDir, ctx);
+  return ctx;
+}
+
+// Keep a prop unless its declaration lives in React/DOM types or a CSS-in-JS
+// style-system base (hundreds of token-typed style props from the component
+// library's styled-props layer). The small KEEP_PROP set passes regardless so
+// structural props survive when inherited from React. ts-morph's getFilePath()
+// returns StandardizedFilePath (forward-slash), so the substring checks are
+// cross-platform.
+const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/;
+// Style-system bases are detected by SHAPE, two-tier (canonical contract —
+// the call sites point here):
+// - EXTERNAL packages: >STYLE_SYSTEM_THRESHOLD CSS/token-named props,
+//   counted per package directory (the node_modules/<pkg>/ boundary), so a
+//   style system split across small per-category .d.ts files still crosses
+//   the bar in aggregate. Paths with no node_modules/ segment fall back to
+//   per-file counting at the in-package bar.
+// - IN-PACKAGE files: >IN_PACKAGE_FILE_THRESHOLD CSS-named props in ONE
+//   file. Hand-written API layers (tens of CSS-named props) are the DS's
+//   own API and are never filtered; only a generated style system crosses
+//   this bar. Left unfiltered, printing hundreds of token-typed unions per
+//   component costs minutes of build time and tens of GB of retained
+//   checker cache, and bloats every emitted .d.ts.
+// All props declared in a flagged file/package are filtered (KEEP_PROP
+// passes regardless). ASSUMPTION: when inherited shorthands are real API,
+// override per component with cfg.dtsPropsFor.<Name>.
+const CSS_PROP_NAME =
+  /^(m[tblrxy]?$|p[tblrxy]?$|margin|padding|bg|background|color|border|width|height|flex|grid|gap|font|text|display|position|top|left|right|bottom|z|opacity|overflow|shadow|rounded|space)/;
+const STYLE_SYSTEM_THRESHOLD = 15;
+const IN_PACKAGE_FILE_THRESHOLD = 100;
+// The package that owns a path: its deepest node_modules/<pkg>/ boundary
+// (trailing slash), or null for workspace paths. Identity comparison against
+// ownerOf(pkgDir) is the single in-package/external discriminator.
+function ownerOf(p) {
+  const m = /^(.*\/node_modules\/(?:@[^/]+\/)?[^/]+)\//.exec(p);
+  return m ? m[1] + '/' : null;
+}
+function detectStyleSystemDirs(props, pkgDir, declFile) {
+  const pkgOwner = ownerOf(pkgDir);
+  const cssByDir = new Map();
+  for (const p of props) {
+    if (!CSS_PROP_NAME.test(p.getName())) continue;
+    const d = p.getDeclarations()[0];
+    if (!d) continue;
+    const fp = d.getSourceFile().getFilePath();
+    // Key shape encodes the tier (see the canonical contract above
+    // CSS_PROP_NAME): external packages → node_modules/<pkg>/ prefix key
+    // (trailing slash); in-package declarations → exact FILE key. The
+    // DEEPEST node_modules boundary decides: a dep nested under the
+    // package's own node_modules (un-hoisted version conflict) is external.
+    // One principle, no orientation cases: a declaration is IN-PACKAGE iff
+    // the package that OWNS its file is the package being synced.
+    // ownerOf() = deepest node_modules package boundary, null for
+    // workspace paths. This derives every layout — nested dep under the
+    // package's own node_modules (different owner → external), dual-publish
+    // nested manifest (same owner → in-package even though pkgDir sits
+    // below the boundary), DS synced from inside a host package's
+    // node_modules (host files have a shallower owner → external).
+    // In-package files key per-FILE; external files key per owning package.
+    // Ownerless externals (sibling workspace packages) key per-file at the
+    // in-package bar — the documented out-of-scope fallback in the
+    // canonical block above.
+    const owner = ownerOf(fp);
+    const inPackage = owner === pkgOwner && (owner !== null || fp.startsWith(pkgDir));
+    const key = inPackage ? fp : (owner ?? fp);
+    // Never flag the file that declares the component's own Props: in a
+    // rolled-up single-file .d.ts the generated style layer co-lives with
+    // the API interfaces, and a per-FILE flag would drop the component's
+    // own props. Separate generated files still filter; rollups fall back
+    // to unfiltered (slow but correct). External dir keys are unaffected.
+    if (key === declFile) continue;
+    cssByDir.set(key, (cssByDir.get(key) ?? 0) + 1);
+  }
+  // Per-tier bars — rationale in the canonical block above CSS_PROP_NAME.
+  const keys = [];
+  for (const [k, n] of cssByDir) {
+    const bar = k.endsWith('/') ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    if (n > bar) keys.push(k);
+  }
+  return keys;
+}
+function isOwnProp(p, pkgDir, styleSystemDirs) {
+  const name = p.getName();
+  if (KEEP_PROP.test(name)) return true;
+  const d = p.getDeclarations()[0];
+  if (!d) return true;
+  const fp = d.getSourceFile().getFilePath();
+  // Same owner-identity discriminator as detectStyleSystemDirs, same order
+  // of authority: a flagged in-package FILE drops first (exact match); then
+  // owner-equality keeps the DS's own API — checked BEFORE dir keys because
+  // a flagged dir key can be an ANCESTOR of pkgDir (DS synced from inside a
+  // host package's node_modules) and must not swallow in-package files;
+  // then flagged external packages drop by prefix.
+  if (styleSystemDirs.some((k) => !k.endsWith('/') && fp === k)) return false;
+  const owner = ownerOf(fp);
+  if (owner === ownerOf(pkgDir) && (owner !== null || fp.startsWith(pkgDir))) return true;
+  if (styleSystemDirs.some((k) => k.endsWith('/') && fp.startsWith(k))) return false;
+  if (fp.includes('/@types/react/') || fp.includes('/typescript/lib/')) return false;
+  // DOM-noise name filters apply only to props inherited from other packages.
+  if (/^(on[A-Z]|aria-)/.test(name)) return false;
+  return true;
+}
+
+// Keep well-known aliases as-written instead of expanding to their full union.
+const KEEP_ALIAS = /^(ReactNode|ReactElement|CSSProperties|JSX\.Element|Key|Ref|RefObject)$/;
+
+function typeText(t, at) {
+  const alias = t.getAliasSymbol()?.getName();
+  if (alias && KEEP_ALIAS.test(alias)) return `React.${alias}`;
+  if (t.isBoolean()) return 'boolean';
+  let s;
+  if (t.isUnion()) {
+    // Render each member so ReactNode/boolean collapse while literal unions
+    // stay expanded; dedup, drop `undefined` (optionality is the `?`).
+    const parts = t.getUnionTypes().map((u) => typeText(u, at)).filter((p) => p !== 'undefined');
+    let uniq = [...new Set(parts)];
+    if (uniq.length === 2 && uniq.includes('true') && uniq.includes('false')) return 'boolean';
+    // Collapse the structural expansion of React.ReactNode (string | number |
+    // ReactElement<…> | Iterable<ReactNode> | ReactPortal | Promise<…>) back to
+    // the alias — when the alias symbol is lost, the expansion blows past the
+    // length cap below and would truncate into invalid TS.
+    if (uniq.includes('ReactPortal') && uniq.some((u) => u.startsWith('Iterable<ReactNode>'))) {
+      const RN_MEMBER = /^(string|number|bigint|boolean|ReactPortal|Iterable<ReactNode>.*|ReactElement<.*|Promise<.*)$/;
+      uniq = [...new Set([...uniq.filter((u) => !RN_MEMBER.test(u)), 'React.ReactNode'])];
+    }
+    // Function-type members are invalid un-parenthesized inside a union
+    // (`string | (x) => void` doesn't parse) — wrap them.
+    if (uniq.length > 1) uniq = uniq.map((u) => (u.includes('=>') ? `(${u})` : u));
+    // Cap very wide unions (icon-name sets can be 600+ members).
+    if (uniq.length > 24) uniq = [...uniq.slice(0, 16), `(string & {}) /* +${uniq.length - 16} more */`];
+    s = uniq.join(' | ').replace(/\bfalse \| true\b/, 'boolean');
+  } else {
+    s = t.getText(at, ts.TypeFormatFlags.NoTruncation).replace(/import\("[^"]*"\)\./g, '');
+  }
+  // Never hard-slice an over-long type — a cut generic/object literal is
+  // invalid TS and fails the validator's [DTS_PARSE] check (and the app's
+  // API-contract parse). Fall back to a safe wide type instead; the JSDoc
+  // line above the prop carries the human-readable detail.
+  return s.length > 240 ? 'unknown' : s;
+}
+
+// PascalCase value exports from the entry module. The checker knows value vs
+// type, so type-only exports never enter the set.
+export function exportedNames(pkgDir, pkgJson) {
+  const { project, entry } = projectFor(pkgDir, findTypesRoot(pkgDir, pkgJson));
+  const sf = project.getSourceFile(entry);
+  const names = new Set();
+  if (!sf) return names;
+  for (const [name, decls] of sf.getExportedDeclarations()) {
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    const hasValue = decls.some((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) ||
+      Node.isClassDeclaration(d) || Node.isSourceFile(d));
+    if (hasValue) names.add(name);
+  }
+  return names;
+}
+
+// Builds the context propsBodyFor/jsdocFor read from. `nonComponents` /
+// `compounds` are derived from the checker's symbol kinds.
+export function loadDts(typesRoot) {
+  // typesRoot is always under <nm>/<pkg>/… — walk up to the real package
+  // root: the nearest package.json with a `name` field, skipping stubs
+  // (`{"type":"module"}` in esm/ or dist/). dirname-fixed-point is the
+  // cross-platform root test (`/` vs `C:\`).
+  let walk = typesRoot;
+  for (; walk !== dirname(walk); walk = dirname(walk)) {
+    const pj = join(walk, 'package.json');
+    if (existsSync(pj)) {
+      try { if (JSON.parse(readFileSync(pj, 'utf8')).name) break; } catch {}
+    }
+  }
+  // projectFor normalizes pkgDir to forward-slashes (ts-morph's
+  // StandardizedFilePath) — use that for every fp.startsWith() downstream.
+  const { project, entry, pkgDir } = projectFor(walk, typesRoot);
+  const sf = project.getSourceFile(entry);
+  const nonComponents = new Set();
+  const compounds = new Map();
+  if (sf) for (const [name, decls] of sf.getExportedDeclarations()) {
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    // Declaration-merged names (`interface Button {}` + `const Button: …`)
+    // return both decls — prefer the value decl so the merge isn't
+    // misclassified as type-only by whichever the checker listed first.
+    const d = decls.find((x) =>
+      Node.isVariableDeclaration(x) || Node.isFunctionDeclaration(x) ||
+      Node.isClassDeclaration(x) || Node.isSourceFile(x)) ?? decls[0];
+    // Namespace export (`export * as X`) → compound with its own value members.
+    if (Node.isSourceFile(d)) {
+      const members = [...d.getExportedDeclarations().entries()]
+        .filter(([n, ds]) => /^[A-Z][a-z]/.test(n) && ds.some((x) => !Node.isInterfaceDeclaration(x) && !Node.isTypeAliasDeclaration(x)))
+        .map(([n]) => n);
+      if (members.length) compounds.set(name, members);
+      else nonComponents.add(name);
+      continue;
+    }
+    // Type-only / enum / Context / abstract-class are not components.
+    if (Node.isInterfaceDeclaration(d) || Node.isTypeAliasDeclaration(d) || Node.isEnumDeclaration(d)) {
+      nonComponents.add(name);
+      continue;
+    }
+    if (Node.isClassDeclaration(d) && d.isAbstract()) { nonComponents.add(name); continue; }
+    if (Node.isClassDeclaration(d)) continue;  // always renderable; compounds via statics aren't handled here
+    if (!Node.isVariableDeclaration(d) && !Node.isFunctionDeclaration(d)) continue;
+    // `const X: FC<…> & { Sub: … }` (possibly through an alias/Omit) —
+    // PascalCase callable properties declared in-package are compound members
+    // (React.Component lifecycle names have underscores / fail the full match).
+    const t = d.getType();
+    const members = [];
+    // PascalCase props can't be style-system CSS-shorthands, so the empty
+    // list is correct here — detectStyleSystemDirs would contribute nothing.
+    const noStyle = [];
+    for (const p of t.getProperties()) {
+      const pn = p.getName();
+      if (!/^[A-Z][a-zA-Z0-9]*$/.test(pn) || !isOwnProp(p, pkgDir, noStyle)) continue;
+      if (p.getTypeAtLocation(d).getCallSignatures().length) members.push(pn);
+    }
+    if (members.length) compounds.set(name, members);
+    // Only provably-not-renderable consts are filtered: a plain object/record
+    // type whose every property is a primitive (token/enum
+    // objects like Colors or Sizes). Anything with a call signature, construct signature, or a
+    // non-primitive property stays — class components and forwardRef wrappers
+    // without call sigs on the instance type must not be dropped here.
+    if (t.isObject() && !t.getCallSignatures().length && !t.getConstructSignatures().length && !members.length && !t.isAny()) {
+      const props = t.getProperties();
+      if (props.length && props.every((p) => {
+        const pt = p.getTypeAtLocation(d);
+        return pt.isString() || pt.isNumber() || pt.isStringLiteral() || pt.isNumberLiteral();
+      })) nonComponents.add(name);
+    }
+  }
+  return { project, entry, pkgDir, nonComponents, compounds };
+}
+
+// Returns { body, generics, extendsClause, prelude } for emit.mjs. Types are
+// fully resolved into `body`, so extendsClause/prelude stay empty.
+export function propsBodyFor(name, ctx) {
+  if (ctx.dtsPropsFor?.[name]) {
+    return { body: ctx.dtsPropsFor[name], generics: '', extendsClause: '', prelude: '' };
+  }
+  const { project, entry, pkgDir } = ctx;
+  // Find <Name>Props across the package's own files (not @types/react).
+  // Skip deprecated/legacy/experimental dirs so a stale copy doesn't shadow
+  // the live one.
+  let decl = null;
+  for (const sf of project.getSourceFiles()) {
+    const fp = sf.getFilePath();
+    if (!fp.startsWith(pkgDir)) continue;
+    if (/\/(deprecated|legacy|experimental)\//i.test(fp)) continue;
+    decl = sf.getInterface(`${name}Props`) ?? sf.getTypeAlias(`${name}Props`);
+    if (decl) break;
+  }
+  // Fallback: derive from the component symbol's first call signature.
+  // Prefer the value decl (declaration-merging — see loadDts).
+  if (!decl) {
+    const decls = project.getSourceFile(entry)?.getExportedDeclarations().get(name) ?? [];
+    const exp = decls.find((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+    if (!exp || Node.isSourceFile(exp)) return null;
+    const sig = exp.getType().getCallSignatures()[0];
+    const p0 = sig?.getParameters()[0];
+    if (!p0) return null;
+    return emitBody(p0.getTypeAtLocation(exp), exp, '', pkgDir);
+  }
+  const generics = decl.getTypeParameters?.().length
+    ? `<${decl.getTypeParameters().map((p) => p.getText()).join(', ')}>`
+    : '';
+  return emitBody(decl.getType(), decl, generics, pkgDir);
+}
+
+let loggedStyleSystemDirs;
+function emitBody(type, at, generics, pkgDir) {
+  const lines = [];
+  const props = type.getApparentType().getProperties();
+  // `at` is the component's own Props declaration site — its file is exempt
+  // from per-FILE flagging (see detectStyleSystemDirs).
+  const styleSystemDirs = detectStyleSystemDirs(props, pkgDir, at.getSourceFile().getFilePath());
+  // Surface a one-shot [DTS_STYLE_SYSTEM] line per flagged package so the
+  // self-heal loop routes to cfg.dtsPropsFor when the heuristic guesses
+  // wrong. ASSUMPTION: props from the named packages are token-typed
+  // style shorthands; override a component's contract with cfg.dtsPropsFor.
+  loggedStyleSystemDirs ??= new Set();
+  for (const dir of styleSystemDirs) {
+    if (loggedStyleSystemDirs.has(dir)) continue;
+    loggedStyleSystemDirs.add(dir);
+    const isDirKey = dir.endsWith('/');
+    const pkg = /\/node_modules\/((?:@[^/]+\/)?[^/]+)\/$/.exec(dir)?.[1]
+      ?? (dir.startsWith(pkgDir) ? dir.slice(pkgDir.length) : dir);
+    const bar = isDirKey ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    console.error(
+      `[DTS_STYLE_SYSTEM] filtering ${pkg} props (>${bar} CSS-shorthand-named props) — override a component with cfg.dtsPropsFor.<Name> if these are real API`,
+    );
+  }
+  for (const p of props) {
+    if (!isOwnProp(p, pkgDir, styleSystemDirs)) continue;
+    const optional = p.hasFlags(ts.SymbolFlags.Optional) ? '?' : '';
+    const pt = p.getTypeAtLocation(at);
+    let tt = typeText(pt, at);
+    // Structural hint when the type text hides the shape (aliased functions /
+    // arrays) — smartDefaultProps reads these to pick the right required-stub.
+    const members = pt.isUnion() ? pt.getUnionTypes() : [pt];
+    if (members.some((u) => u.getCallSignatures().length)) tt += ' /* @fn */';
+    // Tuples are not @arr — `[]` has the wrong length and `[0]` access crashes
+    // either way; optional tuples are safer left unset.
+    else if (members.some((u) => u.isArray())) tt += ' /* @arr */';
+    // Leading JSDoc on the prop declaration, if any.
+    const d = p.getDeclarations()[0];
+    const doc = d?.getJsDocs?.()?.[0]?.getDescription()?.trim();
+    if (doc) lines.push(`  /** ${doc.replace(/\s+/g, ' ').slice(0, 120)} */`);
+    const pn = p.getName();
+    // Hyphenated/index-signature names (`data-*`, `aria-*`) must be quoted.
+    const key = /^[a-zA-Z_$][\w$]*$/.test(pn) ? pn : JSON.stringify(pn);
+    lines.push(`  ${key}${optional}: ${tt};`);
+  }
+  if (!lines.length) return null;
+  return { body: lines.join('\n'), generics, extendsClause: '', prelude: '' };
+}
+
+// Scaffold-preview defaults from the resolved props body. Conservative: fill
+// only what's needed for a meaningful first render (children + variant axis +
+// visibility toggles + required arrays). Optional string/number/Date props are
+// left unset — filling them with placeholder values crashes more than it
+// helps.
+//
+// Void-element-ish components — a string `children` would throw at render.
+const VOID_LIKE = /^(Text|Number|Search|Password|File|Masked)?Input$|^(TextField|TextArea|Textarea|Img|Image|Avatar|Hr|Br|Spacer|Divider|Separator|Slider|Progress|ProgressBar)$/;
+// Ordered preference for the variant axis — earlier wins. `type` is last so
+// the HTML `type` attr ("button"|"submit"|"reset") doesn't beat `variant`.
+const VARIANT_RANK = ['variant', 'intent', 'kind', 'appearance', 'tone', 'status', 'size', 'color', 'type'];
+export function smartDefaultProps(name, pb) {
+  const body = pb?.body ?? '';
+  const props = {};
+  let variants = null;
+  // Matches the 2-space indent emitBody writes — keep the two in sync.
+  // `.+` (not `[^;]+`) so object-param types with inner semicolons still match.
+  for (const m of body.matchAll(/^ {2}([a-zA-Z_$][\w$]*)(\??)\s*:\s*(.+);$/gm)) {
+    const [, prop, q, t] = m;
+    if (prop in props) continue;
+    const req = !q;
+    // Union of string literals, optionally with a `string & {}` escape-hatch
+    // member (the "autocomplete these, accept any string" TS pattern).
+    if (/^(?:(?:"[^"]*"|\(?string\s*&\s*\{\}\)?)\s*\|?\s*)+$/.test(t)) {
+      const lits = [...t.matchAll(/"([^"]*)"/g)].map((l) => l[1]).filter(Boolean);
+      if (lits.length >= 2) {
+        const rank = VARIANT_RANK.indexOf(prop.toLowerCase());
+        // Displace on strictly better rank (prop names are unique, so no ties).
+        if (!variants || (rank >= 0 && (variants.rank < 0 || rank < variants.rank))) {
+          variants = { prop, values: lits.slice(0, 4), rank };
+        }
+        if (req) props[prop] = lits[0];
+        continue;
+      }
+    }
+    // Structural hints (/* @fn */, /* @arr */) from emitBody are authoritative
+    // over the text regexes — `(() => void)[]` has @arr, so the `=>` in the
+    // element type must not flip it to isFn. The text regexes cover
+    // cfg.dtsPropsFor overrides with no hints.
+    const hasFn = t.includes('/* @fn */'), hasArr = t.includes('/* @arr */');
+    const isFn = hasFn || (!hasArr && /=>|\)\s*:/.test(t));
+    const isArr = !isFn && (hasArr || /\[\]|Array</.test(t));
+    if (prop === 'children' && /React\.ReactNode|ReactElement/.test(t) && !isFn && !VOID_LIKE.test(name)) props.children = name;
+    // Visibility toggles — an overlay/dialog with open=false renders nothing.
+    else if (/^(open|isOpen|visible|show|defaultOpen|expanded|checked|active|selected)$/.test(prop) && t === 'boolean') props[prop] = true;
+    // Callable (required or optional) — optional stays unset (DSes guard
+    // optional callbacks); required gets a noop.
+    else if (isFn) { if (req) props[prop] = { $raw: '()=>null' }; }
+    // Arrays (required or optional). `[]` is crash-safe but renders nothing.
+    // Props that look like data/option lists get a small sample so the
+    // preview has visible rows; element shape is best-effort from the type
+    // text (string[] → strings; otherwise {id,label,value}).
+    else if (isArr) {
+      const isList = /^(items|options|tabs|rows|columns|data|actions|fields|links|steps|choices|values)$/i.test(prop);
+      const elT = t.replace(/\/\*.*?\*\//g, '').trim();
+      const elIsString = /^(?:readonly\s+)?string\[\]|^ReadonlyArray<string>|^Array<string>/.test(elT);
+      // Over-provision keys — extra ones are ignored, and this covers the
+      // common {id|key} + {label|text|name|title} + value conventions.
+      props[prop] = isList
+        ? elIsString
+          ? ['Item 1', 'Item 2', 'Item 3']
+          : [1, 2, 3].map((i) => {
+            const s = String(i), l = `Item ${i}`;
+            return { id: s, key: s, value: s, label: l, text: l, name: l, title: l };
+          })
+        : [];
+    }
+    // Optional everything-else stays unset — the component's own defaults are
+    // safer than a placeholder.
+    else if (!req) continue;
+    // Required props get a type-appropriate stub so the render doesn't crash
+    // on `undefined.…` / `undefined()`. `$raw` values are emitted verbatim by
+    // scaffoldPropsExpr (not JSON-stringified).
+    else if (/\bDate\b/.test(t)) props[prop] = { $raw: 'new Date()' };
+    else if (/ElementType|ComponentType|JSXElementConstructor/.test(t)) props[prop] = 'div';
+    else if (/React\.ReactNode|ReactElement/.test(t)) props[prop] = name;
+    else if (/^string\b/.test(t)) props[prop] = name;
+    else if (/^number\b/.test(t)) props[prop] = 0;
+    else if (/^boolean\b/.test(t)) props[prop] = false;
+    else if (/^\{/.test(t) || /Record<|Partial<|Pick<|Omit</.test(t)) props[prop] = {};
+    // Fallback: required prop of unrecognized shape — `{}` is the least likely
+    // to crash `.foo` access.
+    else props[prop] = {};
+  }
+  return { props, variants };
+}
+
+// One-line JSDoc from the component's own declaration.
+export function jsdocFor(name, ctx) {
+  const decls = ctx.project?.getSourceFile(ctx.entry)?.getExportedDeclarations().get(name) ?? [];
+  const exp = decls.find((d) =>
+    Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+  if (!exp || Node.isSourceFile(exp)) return '';
+  const doc = exp.getJsDocs?.()?.[0]?.getDescription()
+    ?? exp.getSymbol?.()?.compilerSymbol.getDocumentationComment?.(undefined)?.[0]?.text;
+  if (!doc) return '';
+  return doc.split('\n').find((l) => l.trim() && !l.trim().startsWith('@'))
+    ?.trim().replace(/\s+/g, ' ').replace(/[^\w\s.,()'/:+-]/g, '').slice(0, 140) ?? '';
+}

--- a/.design-sync/overrides/dts.mjs
+++ b/.design-sync/overrides/dts.mjs
@@ -8,52 +8,42 @@
 // chains and intersections, resolves `(typeof X)[number]` / mapped types to
 // literal unions.
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { Project, Node, ts } from 'ts-morph'
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
 
 // The `exports` map is the modern (and often only) place a package declares its
 // types entry. Read the "." subpath's `types` condition, tolerating both the
 // nested-conditions form and the shorthand string form.
 function exportsTypesEntry(pkgJson) {
-  const dot = pkgJson.exports?.['.']
-  if (!dot || typeof dot !== 'object') return undefined
-  const t = dot.types ?? dot.import?.types ?? dot.default?.types
-  return typeof t === 'string' ? t : undefined
+  const dot = pkgJson.exports?.['.'];
+  if (!dot || typeof dot !== 'object') return undefined;
+  const t = dot.types ?? dot.import?.types ?? dot.default?.types;
+  return typeof t === 'string' ? t : undefined;
 }
 
 export function findTypesRoot(pkgDir, pkgJson) {
   // Workspace/monorepo packages often point dev `types` at src/*.ts (no .d.ts
   // tree there); publishConfig carries the published .d.ts entry — prefer it
   // when it exists on disk.
-  const pubTypes = pkgJson.publishConfig?.types
-  if (pubTypes && existsSync(join(pkgDir, pubTypes)))
-    return dirname(join(pkgDir, pubTypes))
-  const t = pkgJson.types || pkgJson.typings || exportsTypesEntry(pkgJson)
-  if (t) return dirname(join(pkgDir, t))
-  const hasDts = (d) => {
-    try {
-      return readdirSync(d).some((f) => f.endsWith('.d.ts'))
-    } catch {
-      return false
-    }
-  }
+  const pubTypes = pkgJson.publishConfig?.types;
+  if (pubTypes && existsSync(join(pkgDir, pubTypes))) return dirname(join(pkgDir, pubTypes));
+  const t = pkgJson.types || pkgJson.typings || exportsTypesEntry(pkgJson);
+  if (t) return dirname(join(pkgDir, t));
+  const hasDts = (d) => { try { return readdirSync(d).some((f) => f.endsWith('.d.ts')); } catch { return false; } };
   for (const c of ['build/ts', 'dist/types', 'types', 'lib', 'dist']) {
-    const p = join(pkgDir, c)
-    if (existsSync(p) && (c !== 'dist' || hasDts(p))) return p
+    const p = join(pkgDir, c);
+    if (existsSync(p) && (c !== 'dist' || hasDts(p))) return p;
   }
-  return pkgDir
+  return pkgDir;
 }
 
 // *Props are prop interfaces; ALL-CAPS are object constants; *Manager /
 // *Placements / *Context are utility singletons; use* are hooks — none
 // renderable. (dts.nonComponents also catches React.Context by symbol kind;
 // the suffix check is belt-and-suspenders for DSes where that misses.)
-export const isComponentName = (n) =>
-  !n.endsWith('Props') &&
-  !/^[A-Z][A-Z0-9_]+$/.test(n) &&
-  !/(?:Manager|Placements|Context)$/.test(n) &&
-  !/^use[A-Z]/.test(n)
+export const isComponentName = (n) => !n.endsWith('Props') && !/^[A-Z][A-Z0-9_]+$/.test(n)
+  && !/(?:Manager|Placements|Context)$/.test(n) && !/^use[A-Z]/.test(n);
 
 // Partition into roots and subcomponents. A name is a subcomponent ONLY when
 // another name is a PascalCase prefix of it AND the suffix is an actual
@@ -64,21 +54,18 @@ export const isComponentName = (n) =>
 // that export subparts top-level only (no `Table.Row` namespace), this
 // conservatively does nothing.
 export function partitionSubcomponents(names, compounds) {
-  const set = new Set(names)
-  const parentOf = new Map()
+  const set = new Set(names);
+  const parentOf = new Map();
   for (const n of names) {
-    const parts = n.match(/[A-Z][a-z0-9]*/g) ?? []
+    const parts = n.match(/[A-Z][a-z0-9]*/g) ?? [];
     // Try longest prefix first, keep trying shorter ones — `ListItemText`
     // with compounds {List: ['ItemText']} must reach `List` even if
     // `ListItem` is itself a top-level name.
     for (let i = parts.length - 1; i >= 1; i--) {
-      const prefix = parts.slice(0, i).join('')
-      if (!set.has(prefix)) continue
-      const suffix = parts.slice(i).join('')
-      if ((compounds?.get(prefix) ?? []).includes(suffix)) {
-        parentOf.set(n, prefix)
-        break
-      }
+      const prefix = parts.slice(0, i).join('');
+      if (!set.has(prefix)) continue;
+      const suffix = parts.slice(i).join('');
+      if ((compounds?.get(prefix) ?? []).includes(suffix)) { parentOf.set(n, prefix); break; }
     }
   }
   // Flatten transitively — TableRowCell → TableRow → Table becomes
@@ -86,47 +73,36 @@ export function partitionSubcomponents(names, compounds) {
   // subs whose immediate parent is itself a sub. Terminates: each parent has
   // strictly fewer PascalCase parts than its child.
   for (const [n] of parentOf) {
-    let p = parentOf.get(n)
-    while (parentOf.has(p)) p = parentOf.get(p)
-    parentOf.set(n, p)
+    let p = parentOf.get(n);
+    while (parentOf.has(p)) p = parentOf.get(p);
+    parentOf.set(n, p);
   }
-  return { parentOf }
+  return { parentOf };
 }
 
 // One Project per package — loadDts/exportedNames share it.
-const projects = new Map()
+const projects = new Map();
 
 function projectFor(pkgDir, typesRoot) {
-  if (projects.has(pkgDir)) return projects.get(pkgDir)
+  if (projects.has(pkgDir)) return projects.get(pkgDir);
   // Derive node_modules for cross-package resolution (React, peer deps).
   // Normalize separators — pkgDir may have backslashes on Windows.
-  const posix = pkgDir.split('\\').join('/')
-  const i = posix.lastIndexOf('/node_modules/')
-  let nodeModules =
-    i >= 0 ? join(pkgDir.slice(0, i), 'node_modules') : join(pkgDir, '..')
+  const posix = pkgDir.split('\\').join('/');
+  const i = posix.lastIndexOf('/node_modules/');
+  let nodeModules = i >= 0 ? join(pkgDir.slice(0, i), 'node_modules') : join(pkgDir, '..');
   // Workspace packages live outside node_modules — walk up to the hoisted
   // root node_modules so @types/react resolves (otherwise React utility types
   // collapse to `any` and inherited props drop out of the emitted bodies).
   if (!existsSync(join(nodeModules, '@types', 'react'))) {
     for (let d = pkgDir; ; d = dirname(d)) {
-      if (existsSync(join(d, 'node_modules', '@types', 'react'))) {
-        nodeModules = join(d, 'node_modules')
-        break
-      }
-      if (dirname(d) === d) break
+      if (existsSync(join(d, 'node_modules', '@types', 'react'))) { nodeModules = join(d, 'node_modules'); break; }
+      if (dirname(d) === d) break;
     }
   }
-  const pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
+  const pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
   // Same publishConfig preference as findTypesRoot — keep the two in sync.
-  const pubEntry = pj.publishConfig?.types
-  const entry = join(
-    pkgDir,
-    (pubEntry && existsSync(join(pkgDir, pubEntry)) ? pubEntry : null) ||
-      pj.types ||
-      pj.typings ||
-      exportsTypesEntry(pj) ||
-      'index.d.ts',
-  )
+  const pubEntry = pj.publishConfig?.types;
+  const entry = join(pkgDir, (pubEntry && existsSync(join(pkgDir, pubEntry)) ? pubEntry : null) || pj.types || pj.typings || exportsTypesEntry(pj) || 'index.d.ts');
   const project = new Project({
     skipAddingFilesFromTsConfig: true,
     compilerOptions: {
@@ -137,39 +113,33 @@ function projectFor(pkgDir, typesRoot) {
       skipLibCheck: true,
       strict: false,
     },
-  })
+  });
   // Add the package's own .d.ts tree plus @types/react (otherwise
   // `ComponentPropsWithoutRef<…>` is `any` and intersection types collapse).
-  const reactTypes = join(nodeModules, '@types', 'react', 'index.d.ts')
+  const reactTypes = join(nodeModules, '@types', 'react', 'index.d.ts');
   // The negation must be absolute-scoped to match the positive pattern —
   // ts-morph's fast-glob ignores bare `!**/node_modules/**` otherwise.
-  const root = typesRoot ?? dirname(entry)
-  project.addSourceFilesAtPaths([
-    `${root}/**/*.d.ts`,
-    `!${root}/**/node_modules/**`,
-  ])
-  console.error(
-    `  [DTS] parsed ${project.getSourceFiles().length} .d.ts files from ${root}`,
-  )
+  const root = typesRoot ?? dirname(entry);
+  project.addSourceFilesAtPaths([`${root}/**/*.d.ts`, `!${root}/**/node_modules/**`]);
+  console.error(`  [DTS] parsed ${project.getSourceFiles().length} .d.ts files from ${root}`);
   // ts-morph StandardizedFilePath is always forward-slash; normalize pkgDir
   // once so fp.startsWith(pkgDir) in isOwnProp/propsBodyFor works on Windows.
   // Trailing slash so a sibling node_modules package whose name is a prefix of
   // this one (foo vs foo-icons) isn't mis-classified as in-package.
-  const pkgDirStd = pkgDir.split('\\').join('/').replace(/\/?$/, '/')
-  if (existsSync(reactTypes)) project.addSourceFileAtPath(reactTypes)
-  else
-    console.error(
-      '\n[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
-        '[DTS_REACT] @types/react not found in node_modules. React utility types\n' +
-        '[DTS_REACT] (ComponentPropsWithoutRef, FC, …) will resolve to `any`, so\n' +
-        '[DTS_REACT] components whose props extend them will emit EMPTY bodies.\n' +
-        '[DTS_REACT] Fix: `npm i -D @types/react` then rebuild.\n' +
-        '[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n',
-    )
-  if (existsSync(entry)) project.addSourceFileAtPath(entry)
-  const ctx = { project, entry, pkgDir: pkgDirStd }
-  projects.set(pkgDir, ctx)
-  return ctx
+  const pkgDirStd = pkgDir.split('\\').join('/').replace(/\/?$/, '/');
+  if (existsSync(reactTypes)) project.addSourceFileAtPath(reactTypes);
+  else console.error(
+    '\n[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
+    '[DTS_REACT] @types/react not found in node_modules. React utility types\n' +
+    '[DTS_REACT] (ComponentPropsWithoutRef, FC, …) will resolve to `any`, so\n' +
+    '[DTS_REACT] components whose props extend them will emit EMPTY bodies.\n' +
+    '[DTS_REACT] Fix: `npm i -D @types/react` then rebuild.\n' +
+    '[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n',
+  );
+  if (existsSync(entry)) project.addSourceFileAtPath(entry);
+  const ctx = { project, entry, pkgDir: pkgDirStd };
+  projects.set(pkgDir, ctx);
+  return ctx;
 }
 
 // Keep a prop unless its declaration lives in React/DOM types or a CSS-in-JS
@@ -178,7 +148,7 @@ function projectFor(pkgDir, typesRoot) {
 // structural props survive when inherited from React. ts-morph's getFilePath()
 // returns StandardizedFilePath (forward-slash), so the substring checks are
 // cross-platform.
-const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/
+const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/;
 // Style-system bases are detected by SHAPE, two-tier (canonical contract —
 // the call sites point here):
 // - EXTERNAL packages: >STYLE_SYSTEM_THRESHOLD CSS/token-named props,
@@ -196,24 +166,24 @@ const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/
 // passes regardless). ASSUMPTION: when inherited shorthands are real API,
 // override per component with cfg.dtsPropsFor.<Name>.
 const CSS_PROP_NAME =
-  /^(m[tblrxy]?$|p[tblrxy]?$|margin|padding|bg|background|color|border|width|height|flex|grid|gap|font|text|display|position|top|left|right|bottom|z|opacity|overflow|shadow|rounded|space)/
-const STYLE_SYSTEM_THRESHOLD = 15
-const IN_PACKAGE_FILE_THRESHOLD = 100
+  /^(m[tblrxy]?$|p[tblrxy]?$|margin|padding|bg|background|color|border|width|height|flex|grid|gap|font|text|display|position|top|left|right|bottom|z|opacity|overflow|shadow|rounded|space)/;
+const STYLE_SYSTEM_THRESHOLD = 15;
+const IN_PACKAGE_FILE_THRESHOLD = 100;
 // The package that owns a path: its deepest node_modules/<pkg>/ boundary
 // (trailing slash), or null for workspace paths. Identity comparison against
 // ownerOf(pkgDir) is the single in-package/external discriminator.
 function ownerOf(p) {
-  const m = /^(.*\/node_modules\/(?:@[^/]+\/)?[^/]+)\//.exec(p)
-  return m ? m[1] + '/' : null
+  const m = /^(.*\/node_modules\/(?:@[^/]+\/)?[^/]+)\//.exec(p);
+  return m ? m[1] + '/' : null;
 }
 function detectStyleSystemDirs(props, pkgDir, declFile) {
-  const pkgOwner = ownerOf(pkgDir)
-  const cssByDir = new Map()
+  const pkgOwner = ownerOf(pkgDir);
+  const cssByDir = new Map();
   for (const p of props) {
-    if (!CSS_PROP_NAME.test(p.getName())) continue
-    const d = p.getDeclarations()[0]
-    if (!d) continue
-    const fp = d.getSourceFile().getFilePath()
+    if (!CSS_PROP_NAME.test(p.getName())) continue;
+    const d = p.getDeclarations()[0];
+    if (!d) continue;
+    const fp = d.getSourceFile().getFilePath();
     // Key shape encodes the tier (see the canonical contract above
     // CSS_PROP_NAME): external packages → node_modules/<pkg>/ prefix key
     // (trailing slash); in-package declarations → exact FILE key. The
@@ -231,131 +201,100 @@ function detectStyleSystemDirs(props, pkgDir, declFile) {
     // Ownerless externals (sibling workspace packages) key per-file at the
     // in-package bar — the documented out-of-scope fallback in the
     // canonical block above.
-    const owner = ownerOf(fp)
-    const inPackage =
-      owner === pkgOwner && (owner !== null || fp.startsWith(pkgDir))
-    const key = inPackage ? fp : (owner ?? fp)
+    const owner = ownerOf(fp);
+    const inPackage = owner === pkgOwner && (owner !== null || fp.startsWith(pkgDir));
+    const key = inPackage ? fp : (owner ?? fp);
     // Never flag the file that declares the component's own Props: in a
     // rolled-up single-file .d.ts the generated style layer co-lives with
     // the API interfaces, and a per-FILE flag would drop the component's
     // own props. Separate generated files still filter; rollups fall back
     // to unfiltered (slow but correct). External dir keys are unaffected.
-    if (key === declFile) continue
-    cssByDir.set(key, (cssByDir.get(key) ?? 0) + 1)
+    if (key === declFile) continue;
+    cssByDir.set(key, (cssByDir.get(key) ?? 0) + 1);
   }
   // Per-tier bars — rationale in the canonical block above CSS_PROP_NAME.
-  const keys = []
+  const keys = [];
   for (const [k, n] of cssByDir) {
-    const bar = k.endsWith('/')
-      ? STYLE_SYSTEM_THRESHOLD
-      : IN_PACKAGE_FILE_THRESHOLD
-    if (n > bar) keys.push(k)
+    const bar = k.endsWith('/') ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    if (n > bar) keys.push(k);
   }
-  return keys
+  return keys;
 }
 function isOwnProp(p, pkgDir, styleSystemDirs) {
-  const name = p.getName()
-  if (KEEP_PROP.test(name)) return true
-  const d = p.getDeclarations()[0]
-  if (!d) return true
-  const fp = d.getSourceFile().getFilePath()
+  const name = p.getName();
+  if (KEEP_PROP.test(name)) return true;
+  const d = p.getDeclarations()[0];
+  if (!d) return true;
+  const fp = d.getSourceFile().getFilePath();
   // Same owner-identity discriminator as detectStyleSystemDirs, same order
   // of authority: a flagged in-package FILE drops first (exact match); then
   // owner-equality keeps the DS's own API — checked BEFORE dir keys because
   // a flagged dir key can be an ANCESTOR of pkgDir (DS synced from inside a
   // host package's node_modules) and must not swallow in-package files;
   // then flagged external packages drop by prefix.
-  if (styleSystemDirs.some((k) => !k.endsWith('/') && fp === k)) return false
-  const owner = ownerOf(fp)
-  if (owner === ownerOf(pkgDir) && (owner !== null || fp.startsWith(pkgDir)))
-    return true
-  if (styleSystemDirs.some((k) => k.endsWith('/') && fp.startsWith(k)))
-    return false
-  if (fp.includes('/@types/react/') || fp.includes('/typescript/lib/'))
-    return false
+  if (styleSystemDirs.some((k) => !k.endsWith('/') && fp === k)) return false;
+  const owner = ownerOf(fp);
+  if (owner === ownerOf(pkgDir) && (owner !== null || fp.startsWith(pkgDir))) return true;
+  if (styleSystemDirs.some((k) => k.endsWith('/') && fp.startsWith(k))) return false;
+  if (fp.includes('/@types/react/') || fp.includes('/typescript/lib/')) return false;
   // DOM-noise name filters apply only to props inherited from other packages.
-  if (/^(on[A-Z]|aria-)/.test(name)) return false
-  return true
+  if (/^(on[A-Z]|aria-)/.test(name)) return false;
+  return true;
 }
 
 // Keep well-known aliases as-written instead of expanding to their full union.
-const KEEP_ALIAS =
-  /^(ReactNode|ReactElement|CSSProperties|JSX\.Element|Key|Ref|RefObject)$/
+const KEEP_ALIAS = /^(ReactNode|ReactElement|CSSProperties|JSX\.Element|Key|Ref|RefObject)$/;
 
 function typeText(t, at) {
-  const alias = t.getAliasSymbol()?.getName()
-  if (alias && KEEP_ALIAS.test(alias)) return `React.${alias}`
-  if (t.isBoolean()) return 'boolean'
-  let s
+  const alias = t.getAliasSymbol()?.getName();
+  if (alias && KEEP_ALIAS.test(alias)) return `React.${alias}`;
+  if (t.isBoolean()) return 'boolean';
+  let s;
   if (t.isUnion()) {
     // Render each member so ReactNode/boolean collapse while literal unions
     // stay expanded; dedup, drop `undefined` (optionality is the `?`).
-    const parts = t
-      .getUnionTypes()
-      .map((u) => typeText(u, at))
-      .filter((p) => p !== 'undefined')
-    let uniq = [...new Set(parts)]
-    if (uniq.length === 2 && uniq.includes('true') && uniq.includes('false'))
-      return 'boolean'
+    const parts = t.getUnionTypes().map((u) => typeText(u, at)).filter((p) => p !== 'undefined');
+    let uniq = [...new Set(parts)];
+    if (uniq.length === 2 && uniq.includes('true') && uniq.includes('false')) return 'boolean';
     // Collapse the structural expansion of React.ReactNode (string | number |
     // ReactElement<…> | Iterable<ReactNode> | ReactPortal | Promise<…>) back to
     // the alias — when the alias symbol is lost, the expansion blows past the
     // length cap below and would truncate into invalid TS.
-    if (
-      uniq.includes('ReactPortal') &&
-      uniq.some((u) => u.startsWith('Iterable<ReactNode>'))
-    ) {
-      const RN_MEMBER =
-        /^(string|number|bigint|boolean|ReactPortal|Iterable<ReactNode>.*|ReactElement<.*|Promise<.*)$/
-      uniq = [
-        ...new Set([
-          ...uniq.filter((u) => !RN_MEMBER.test(u)),
-          'React.ReactNode',
-        ]),
-      ]
+    if (uniq.includes('ReactPortal') && uniq.some((u) => u.startsWith('Iterable<ReactNode>'))) {
+      const RN_MEMBER = /^(string|number|bigint|boolean|ReactPortal|Iterable<ReactNode>.*|ReactElement<.*|Promise<.*)$/;
+      uniq = [...new Set([...uniq.filter((u) => !RN_MEMBER.test(u)), 'React.ReactNode'])];
     }
     // Function-type members are invalid un-parenthesized inside a union
     // (`string | (x) => void` doesn't parse) — wrap them.
-    if (uniq.length > 1)
-      uniq = uniq.map((u) => (u.includes('=>') ? `(${u})` : u))
+    if (uniq.length > 1) uniq = uniq.map((u) => (u.includes('=>') ? `(${u})` : u));
     // Cap very wide unions (icon-name sets can be 600+ members).
-    if (uniq.length > 24)
-      uniq = [
-        ...uniq.slice(0, 16),
-        `(string & {}) /* +${uniq.length - 16} more */`,
-      ]
-    s = uniq.join(' | ').replace(/\bfalse \| true\b/, 'boolean')
+    if (uniq.length > 24) uniq = [...uniq.slice(0, 16), `(string & {}) /* +${uniq.length - 16} more */`];
+    s = uniq.join(' | ').replace(/\bfalse \| true\b/, 'boolean');
   } else {
-    s = t
-      .getText(at, ts.TypeFormatFlags.NoTruncation)
-      .replace(/import\("[^"]*"\)\./g, '')
+    s = t.getText(at, ts.TypeFormatFlags.NoTruncation).replace(/import\("[^"]*"\)\./g, '');
   }
   // Never hard-slice an over-long type — a cut generic/object literal is
   // invalid TS and fails the validator's [DTS_PARSE] check (and the app's
   // API-contract parse). Fall back to a safe wide type instead; the JSDoc
   // line above the prop carries the human-readable detail.
-  return s.length > 240 ? 'unknown' : s
+  return s.length > 240 ? 'unknown' : s;
 }
 
 // PascalCase value exports from the entry module. The checker knows value vs
 // type, so type-only exports never enter the set.
 export function exportedNames(pkgDir, pkgJson) {
-  const { project, entry } = projectFor(pkgDir, findTypesRoot(pkgDir, pkgJson))
-  const sf = project.getSourceFile(entry)
-  const names = new Set()
-  if (!sf) return names
+  const { project, entry } = projectFor(pkgDir, findTypesRoot(pkgDir, pkgJson));
+  const sf = project.getSourceFile(entry);
+  const names = new Set();
+  if (!sf) return names;
   for (const [name, decls] of sf.getExportedDeclarations()) {
-    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue
-    const hasValue = decls.some(
-      (d) =>
-        Node.isVariableDeclaration(d) ||
-        Node.isFunctionDeclaration(d) ||
-        Node.isClassDeclaration(d) ||
-        Node.isSourceFile(d),
-    )
-    if (hasValue) names.add(name)
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    const hasValue = decls.some((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) ||
+      Node.isClassDeclaration(d) || Node.isSourceFile(d));
+    if (hasValue) names.add(name);
   }
-  return names
+  return names;
 }
 
 // Builds the context propsBodyFor/jsdocFor read from. `nonComponents` /
@@ -365,215 +304,156 @@ export function loadDts(typesRoot) {
   // root: the nearest package.json with a `name` field, skipping stubs
   // (`{"type":"module"}` in esm/ or dist/). dirname-fixed-point is the
   // cross-platform root test (`/` vs `C:\`).
-  let walk = typesRoot
+  let walk = typesRoot;
   for (; walk !== dirname(walk); walk = dirname(walk)) {
-    const pj = join(walk, 'package.json')
+    const pj = join(walk, 'package.json');
     if (existsSync(pj)) {
-      try {
-        if (JSON.parse(readFileSync(pj, 'utf8')).name) break
-      } catch {}
+      try { if (JSON.parse(readFileSync(pj, 'utf8')).name) break; } catch {}
     }
   }
   // projectFor normalizes pkgDir to forward-slashes (ts-morph's
   // StandardizedFilePath) — use that for every fp.startsWith() downstream.
-  const { project, entry, pkgDir } = projectFor(walk, typesRoot)
-  const sf = project.getSourceFile(entry)
-  const nonComponents = new Set()
-  const compounds = new Map()
-  if (sf)
-    for (const [name, decls] of sf.getExportedDeclarations()) {
-      if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue
-      // Declaration-merged names (`interface Button {}` + `const Button: …`)
-      // return both decls — prefer the value decl so the merge isn't
-      // misclassified as type-only by whichever the checker listed first.
-      const d =
-        decls.find(
-          (x) =>
-            Node.isVariableDeclaration(x) ||
-            Node.isFunctionDeclaration(x) ||
-            Node.isClassDeclaration(x) ||
-            Node.isSourceFile(x),
-        ) ?? decls[0]
-      // Namespace export (`export * as X`) → compound with its own value members.
-      if (Node.isSourceFile(d)) {
-        const members = [...d.getExportedDeclarations().entries()]
-          .filter(
-            ([n, ds]) =>
-              /^[A-Z][a-z]/.test(n) &&
-              ds.some(
-                (x) =>
-                  !Node.isInterfaceDeclaration(x) &&
-                  !Node.isTypeAliasDeclaration(x),
-              ),
-          )
-          .map(([n]) => n)
-        if (members.length) compounds.set(name, members)
-        else nonComponents.add(name)
-        continue
-      }
-      // Type-only / enum / Context / abstract-class are not components.
-      if (
-        Node.isInterfaceDeclaration(d) ||
-        Node.isTypeAliasDeclaration(d) ||
-        Node.isEnumDeclaration(d)
-      ) {
-        nonComponents.add(name)
-        continue
-      }
-      if (Node.isClassDeclaration(d) && d.isAbstract()) {
-        nonComponents.add(name)
-        continue
-      }
-      if (Node.isClassDeclaration(d)) continue // always renderable; compounds via statics aren't handled here
-      if (!Node.isVariableDeclaration(d) && !Node.isFunctionDeclaration(d))
-        continue
-      // `const X: FC<…> & { Sub: … }` (possibly through an alias/Omit) —
-      // PascalCase callable properties declared in-package are compound members
-      // (React.Component lifecycle names have underscores / fail the full match).
-      const t = d.getType()
-      const members = []
-      // PascalCase props can't be style-system CSS-shorthands, so the empty
-      // list is correct here — detectStyleSystemDirs would contribute nothing.
-      const noStyle = []
-      for (const p of t.getProperties()) {
-        const pn = p.getName()
-        if (!/^[A-Z][a-zA-Z0-9]*$/.test(pn) || !isOwnProp(p, pkgDir, noStyle))
-          continue
-        if (p.getTypeAtLocation(d).getCallSignatures().length) members.push(pn)
-      }
-      if (members.length) compounds.set(name, members)
-      // Only provably-not-renderable consts are filtered: a plain object/record
-      // type whose every property is a primitive (token/enum
-      // objects like Colors or Sizes). Anything with a call signature, construct signature, or a
-      // non-primitive property stays — class components and forwardRef wrappers
-      // without call sigs on the instance type must not be dropped here.
-      if (
-        t.isObject() &&
-        !t.getCallSignatures().length &&
-        !t.getConstructSignatures().length &&
-        !members.length &&
-        !t.isAny()
-      ) {
-        const props = t.getProperties()
-        if (
-          props.length &&
-          props.every((p) => {
-            const pt = p.getTypeAtLocation(d)
-            return (
-              pt.isString() ||
-              pt.isNumber() ||
-              pt.isStringLiteral() ||
-              pt.isNumberLiteral()
-            )
-          })
-        )
-          nonComponents.add(name)
-      }
+  const { project, entry, pkgDir } = projectFor(walk, typesRoot);
+  const sf = project.getSourceFile(entry);
+  const nonComponents = new Set();
+  const compounds = new Map();
+  if (sf) for (const [name, decls] of sf.getExportedDeclarations()) {
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    // Declaration-merged names (`interface Button {}` + `const Button: …`)
+    // return both decls — prefer the value decl so the merge isn't
+    // misclassified as type-only by whichever the checker listed first.
+    const d = decls.find((x) =>
+      Node.isVariableDeclaration(x) || Node.isFunctionDeclaration(x) ||
+      Node.isClassDeclaration(x) || Node.isSourceFile(x)) ?? decls[0];
+    // Namespace export (`export * as X`) → compound with its own value members.
+    if (Node.isSourceFile(d)) {
+      const members = [...d.getExportedDeclarations().entries()]
+        .filter(([n, ds]) => /^[A-Z][a-z]/.test(n) && ds.some((x) => !Node.isInterfaceDeclaration(x) && !Node.isTypeAliasDeclaration(x)))
+        .map(([n]) => n);
+      if (members.length) compounds.set(name, members);
+      else nonComponents.add(name);
+      continue;
     }
-  return { project, entry, pkgDir, nonComponents, compounds }
+    // Type-only / enum / Context / abstract-class are not components.
+    if (Node.isInterfaceDeclaration(d) || Node.isTypeAliasDeclaration(d) || Node.isEnumDeclaration(d)) {
+      nonComponents.add(name);
+      continue;
+    }
+    if (Node.isClassDeclaration(d) && d.isAbstract()) { nonComponents.add(name); continue; }
+    if (Node.isClassDeclaration(d)) continue;  // always renderable; compounds via statics aren't handled here
+    if (!Node.isVariableDeclaration(d) && !Node.isFunctionDeclaration(d)) continue;
+    // `const X: FC<…> & { Sub: … }` (possibly through an alias/Omit) —
+    // PascalCase callable properties declared in-package are compound members
+    // (React.Component lifecycle names have underscores / fail the full match).
+    const t = d.getType();
+    const members = [];
+    // PascalCase props can't be style-system CSS-shorthands, so the empty
+    // list is correct here — detectStyleSystemDirs would contribute nothing.
+    const noStyle = [];
+    for (const p of t.getProperties()) {
+      const pn = p.getName();
+      if (!/^[A-Z][a-zA-Z0-9]*$/.test(pn) || !isOwnProp(p, pkgDir, noStyle)) continue;
+      if (p.getTypeAtLocation(d).getCallSignatures().length) members.push(pn);
+    }
+    if (members.length) compounds.set(name, members);
+    // Only provably-not-renderable consts are filtered: a plain object/record
+    // type whose every property is a primitive (token/enum
+    // objects like Colors or Sizes). Anything with a call signature, construct signature, or a
+    // non-primitive property stays — class components and forwardRef wrappers
+    // without call sigs on the instance type must not be dropped here.
+    if (t.isObject() && !t.getCallSignatures().length && !t.getConstructSignatures().length && !members.length && !t.isAny()) {
+      const props = t.getProperties();
+      if (props.length && props.every((p) => {
+        const pt = p.getTypeAtLocation(d);
+        return pt.isString() || pt.isNumber() || pt.isStringLiteral() || pt.isNumberLiteral();
+      })) nonComponents.add(name);
+    }
+  }
+  return { project, entry, pkgDir, nonComponents, compounds };
 }
 
 // Returns { body, generics, extendsClause, prelude } for emit.mjs. Types are
 // fully resolved into `body`, so extendsClause/prelude stay empty.
 export function propsBodyFor(name, ctx) {
   if (ctx.dtsPropsFor?.[name]) {
-    return {
-      body: ctx.dtsPropsFor[name],
-      generics: '',
-      extendsClause: '',
-      prelude: '',
-    }
+    return { body: ctx.dtsPropsFor[name], generics: '', extendsClause: '', prelude: '' };
   }
-  const { project, entry, pkgDir } = ctx
+  const { project, entry, pkgDir } = ctx;
   // Find <Name>Props across the package's own files (not @types/react).
   // Skip deprecated/legacy/experimental dirs so a stale copy doesn't shadow
   // the live one.
-  let decl = null
+  let decl = null;
   for (const sf of project.getSourceFiles()) {
-    const fp = sf.getFilePath()
-    if (!fp.startsWith(pkgDir)) continue
-    if (/\/(deprecated|legacy|experimental)\//i.test(fp)) continue
-    decl = sf.getInterface(`${name}Props`) ?? sf.getTypeAlias(`${name}Props`)
-    if (decl) break
+    const fp = sf.getFilePath();
+    if (!fp.startsWith(pkgDir)) continue;
+    if (/\/(deprecated|legacy|experimental)\//i.test(fp)) continue;
+    decl = sf.getInterface(`${name}Props`) ?? sf.getTypeAlias(`${name}Props`);
+    if (decl) break;
   }
   // Fallback: derive from the component symbol's first call signature.
   // Prefer the value decl (declaration-merging — see loadDts).
   if (!decl) {
-    const decls =
-      project.getSourceFile(entry)?.getExportedDeclarations().get(name) ?? []
-    const exp =
-      decls.find(
-        (d) =>
-          Node.isVariableDeclaration(d) ||
-          Node.isFunctionDeclaration(d) ||
-          Node.isClassDeclaration(d),
-      ) ?? decls[0]
-    if (!exp || Node.isSourceFile(exp)) return null
-    const sig = exp.getType().getCallSignatures()[0]
-    const p0 = sig?.getParameters()[0]
-    if (!p0) return null
-    return emitBody(p0.getTypeAtLocation(exp), exp, '', pkgDir)
+    const decls = project.getSourceFile(entry)?.getExportedDeclarations().get(name) ?? [];
+    const exp = decls.find((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+    if (!exp || Node.isSourceFile(exp)) return null;
+    const sig = exp.getType().getCallSignatures()[0];
+    const p0 = sig?.getParameters()[0];
+    if (!p0) return null;
+    return emitBody(p0.getTypeAtLocation(exp), exp, '', pkgDir);
   }
   const generics = decl.getTypeParameters?.().length
-    ? `<${decl
-        .getTypeParameters()
-        .map((p) => p.getText())
-        .join(', ')}>`
-    : ''
-  return emitBody(decl.getType(), decl, generics, pkgDir)
+    ? `<${decl.getTypeParameters().map((p) => p.getText()).join(', ')}>`
+    : '';
+  return emitBody(decl.getType(), decl, generics, pkgDir);
 }
 
-let loggedStyleSystemDirs
+let loggedStyleSystemDirs;
 function emitBody(type, at, generics, pkgDir) {
-  const lines = []
-  const props = type.getApparentType().getProperties()
+  const lines = [];
+  const props = type.getApparentType().getProperties();
   // `at` is the component's own Props declaration site — its file is exempt
   // from per-FILE flagging (see detectStyleSystemDirs).
-  const styleSystemDirs = detectStyleSystemDirs(
-    props,
-    pkgDir,
-    at.getSourceFile().getFilePath(),
-  )
+  const styleSystemDirs = detectStyleSystemDirs(props, pkgDir, at.getSourceFile().getFilePath());
   // Surface a one-shot [DTS_STYLE_SYSTEM] line per flagged package so the
   // self-heal loop routes to cfg.dtsPropsFor when the heuristic guesses
   // wrong. ASSUMPTION: props from the named packages are token-typed
   // style shorthands; override a component's contract with cfg.dtsPropsFor.
-  loggedStyleSystemDirs ??= new Set()
+  loggedStyleSystemDirs ??= new Set();
   for (const dir of styleSystemDirs) {
-    if (loggedStyleSystemDirs.has(dir)) continue
-    loggedStyleSystemDirs.add(dir)
-    const isDirKey = dir.endsWith('/')
-    const pkg =
-      /\/node_modules\/((?:@[^/]+\/)?[^/]+)\/$/.exec(dir)?.[1] ??
-      (dir.startsWith(pkgDir) ? dir.slice(pkgDir.length) : dir)
-    const bar = isDirKey ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD
+    if (loggedStyleSystemDirs.has(dir)) continue;
+    loggedStyleSystemDirs.add(dir);
+    const isDirKey = dir.endsWith('/');
+    const pkg = /\/node_modules\/((?:@[^/]+\/)?[^/]+)\/$/.exec(dir)?.[1]
+      ?? (dir.startsWith(pkgDir) ? dir.slice(pkgDir.length) : dir);
+    const bar = isDirKey ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
     console.error(
       `[DTS_STYLE_SYSTEM] filtering ${pkg} props (>${bar} CSS-shorthand-named props) — override a component with cfg.dtsPropsFor.<Name> if these are real API`,
-    )
+    );
   }
   for (const p of props) {
-    if (!isOwnProp(p, pkgDir, styleSystemDirs)) continue
-    const optional = p.hasFlags(ts.SymbolFlags.Optional) ? '?' : ''
-    const pt = p.getTypeAtLocation(at)
-    let tt = typeText(pt, at)
+    if (!isOwnProp(p, pkgDir, styleSystemDirs)) continue;
+    const optional = p.hasFlags(ts.SymbolFlags.Optional) ? '?' : '';
+    const pt = p.getTypeAtLocation(at);
+    let tt = typeText(pt, at);
     // Structural hint when the type text hides the shape (aliased functions /
     // arrays) — smartDefaultProps reads these to pick the right required-stub.
-    const members = pt.isUnion() ? pt.getUnionTypes() : [pt]
-    if (members.some((u) => u.getCallSignatures().length)) tt += ' /* @fn */'
+    const members = pt.isUnion() ? pt.getUnionTypes() : [pt];
+    if (members.some((u) => u.getCallSignatures().length)) tt += ' /* @fn */';
     // Tuples are not @arr — `[]` has the wrong length and `[0]` access crashes
     // either way; optional tuples are safer left unset.
-    else if (members.some((u) => u.isArray())) tt += ' /* @arr */'
+    else if (members.some((u) => u.isArray())) tt += ' /* @arr */';
     // Leading JSDoc on the prop declaration, if any.
-    const d = p.getDeclarations()[0]
-    const doc = d?.getJsDocs?.()?.[0]?.getDescription()?.trim()
-    if (doc) lines.push(`  /** ${doc.replace(/\s+/g, ' ').slice(0, 120)} */`)
-    const pn = p.getName()
+    const d = p.getDeclarations()[0];
+    const doc = d?.getJsDocs?.()?.[0]?.getDescription()?.trim();
+    if (doc) lines.push(`  /** ${doc.replace(/\s+/g, ' ').slice(0, 120)} */`);
+    const pn = p.getName();
     // Hyphenated/index-signature names (`data-*`, `aria-*`) must be quoted.
-    const key = /^[a-zA-Z_$][\w$]*$/.test(pn) ? pn : JSON.stringify(pn)
-    lines.push(`  ${key}${optional}: ${tt};`)
+    const key = /^[a-zA-Z_$][\w$]*$/.test(pn) ? pn : JSON.stringify(pn);
+    lines.push(`  ${key}${optional}: ${tt};`);
   }
-  if (!lines.length) return null
-  return { body: lines.join('\n'), generics, extendsClause: '', prelude: '' }
+  if (!lines.length) return null;
+  return { body: lines.join('\n'), generics, extendsClause: '', prelude: '' };
 }
 
 // Scaffold-preview defaults from the resolved props body. Conservative: fill
@@ -583,163 +463,95 @@ function emitBody(type, at, generics, pkgDir) {
 // helps.
 //
 // Void-element-ish components — a string `children` would throw at render.
-const VOID_LIKE =
-  /^(Text|Number|Search|Password|File|Masked)?Input$|^(TextField|TextArea|Textarea|Img|Image|Avatar|Hr|Br|Spacer|Divider|Separator|Slider|Progress|ProgressBar)$/
+const VOID_LIKE = /^(Text|Number|Search|Password|File|Masked)?Input$|^(TextField|TextArea|Textarea|Img|Image|Avatar|Hr|Br|Spacer|Divider|Separator|Slider|Progress|ProgressBar)$/;
 // Ordered preference for the variant axis — earlier wins. `type` is last so
 // the HTML `type` attr ("button"|"submit"|"reset") doesn't beat `variant`.
-const VARIANT_RANK = [
-  'variant',
-  'intent',
-  'kind',
-  'appearance',
-  'tone',
-  'status',
-  'size',
-  'color',
-  'type',
-]
+const VARIANT_RANK = ['variant', 'intent', 'kind', 'appearance', 'tone', 'status', 'size', 'color', 'type'];
 export function smartDefaultProps(name, pb) {
-  const body = pb?.body ?? ''
-  const props = {}
-  let variants = null
+  const body = pb?.body ?? '';
+  const props = {};
+  let variants = null;
   // Matches the 2-space indent emitBody writes — keep the two in sync.
   // `.+` (not `[^;]+`) so object-param types with inner semicolons still match.
-  for (const m of body.matchAll(
-    /^ {2}([a-zA-Z_$][\w$]*)(\??)\s*:\s*(.+);$/gm,
-  )) {
-    const [, prop, q, t] = m
-    if (prop in props) continue
-    const req = !q
+  for (const m of body.matchAll(/^ {2}([a-zA-Z_$][\w$]*)(\??)\s*:\s*(.+);$/gm)) {
+    const [, prop, q, t] = m;
+    if (prop in props) continue;
+    const req = !q;
     // Union of string literals, optionally with a `string & {}` escape-hatch
     // member (the "autocomplete these, accept any string" TS pattern).
     if (/^(?:(?:"[^"]*"|\(?string\s*&\s*\{\}\)?)\s*\|?\s*)+$/.test(t)) {
-      const lits = [...t.matchAll(/"([^"]*)"/g)]
-        .map((l) => l[1])
-        .filter(Boolean)
+      const lits = [...t.matchAll(/"([^"]*)"/g)].map((l) => l[1]).filter(Boolean);
       if (lits.length >= 2) {
-        const rank = VARIANT_RANK.indexOf(prop.toLowerCase())
+        const rank = VARIANT_RANK.indexOf(prop.toLowerCase());
         // Displace on strictly better rank (prop names are unique, so no ties).
-        if (
-          !variants ||
-          (rank >= 0 && (variants.rank < 0 || rank < variants.rank))
-        ) {
-          variants = { prop, values: lits.slice(0, 4), rank }
+        if (!variants || (rank >= 0 && (variants.rank < 0 || rank < variants.rank))) {
+          variants = { prop, values: lits.slice(0, 4), rank };
         }
-        if (req) props[prop] = lits[0]
-        continue
+        if (req) props[prop] = lits[0];
+        continue;
       }
     }
     // Structural hints (/* @fn */, /* @arr */) from emitBody are authoritative
     // over the text regexes — `(() => void)[]` has @arr, so the `=>` in the
     // element type must not flip it to isFn. The text regexes cover
     // cfg.dtsPropsFor overrides with no hints.
-    const hasFn = t.includes('/* @fn */'),
-      hasArr = t.includes('/* @arr */')
-    const isFn = hasFn || (!hasArr && /=>|\)\s*:/.test(t))
-    const isArr = !isFn && (hasArr || /\[\]|Array</.test(t))
-    if (
-      prop === 'children' &&
-      /React\.ReactNode|ReactElement/.test(t) &&
-      !isFn &&
-      !VOID_LIKE.test(name)
-    )
-      props.children = name
+    const hasFn = t.includes('/* @fn */'), hasArr = t.includes('/* @arr */');
+    const isFn = hasFn || (!hasArr && /=>|\)\s*:/.test(t));
+    const isArr = !isFn && (hasArr || /\[\]|Array</.test(t));
+    if (prop === 'children' && /React\.ReactNode|ReactElement/.test(t) && !isFn && !VOID_LIKE.test(name)) props.children = name;
     // Visibility toggles — an overlay/dialog with open=false renders nothing.
-    else if (
-      /^(open|isOpen|visible|show|defaultOpen|expanded|checked|active|selected)$/.test(
-        prop,
-      ) &&
-      t === 'boolean'
-    )
-      props[prop] = true
+    else if (/^(open|isOpen|visible|show|defaultOpen|expanded|checked|active|selected)$/.test(prop) && t === 'boolean') props[prop] = true;
     // Callable (required or optional) — optional stays unset (DSes guard
     // optional callbacks); required gets a noop.
-    else if (isFn) {
-      if (req) props[prop] = { $raw: '()=>null' }
-    }
+    else if (isFn) { if (req) props[prop] = { $raw: '()=>null' }; }
     // Arrays (required or optional). `[]` is crash-safe but renders nothing.
     // Props that look like data/option lists get a small sample so the
     // preview has visible rows; element shape is best-effort from the type
     // text (string[] → strings; otherwise {id,label,value}).
     else if (isArr) {
-      const isList =
-        /^(items|options|tabs|rows|columns|data|actions|fields|links|steps|choices|values)$/i.test(
-          prop,
-        )
-      const elT = t.replace(/\/\*.*?\*\//g, '').trim()
-      const elIsString =
-        /^(?:readonly\s+)?string\[\]|^ReadonlyArray<string>|^Array<string>/.test(
-          elT,
-        )
+      const isList = /^(items|options|tabs|rows|columns|data|actions|fields|links|steps|choices|values)$/i.test(prop);
+      const elT = t.replace(/\/\*.*?\*\//g, '').trim();
+      const elIsString = /^(?:readonly\s+)?string\[\]|^ReadonlyArray<string>|^Array<string>/.test(elT);
       // Over-provision keys — extra ones are ignored, and this covers the
       // common {id|key} + {label|text|name|title} + value conventions.
       props[prop] = isList
         ? elIsString
           ? ['Item 1', 'Item 2', 'Item 3']
           : [1, 2, 3].map((i) => {
-              const s = String(i),
-                l = `Item ${i}`
-              return {
-                id: s,
-                key: s,
-                value: s,
-                label: l,
-                text: l,
-                name: l,
-                title: l,
-              }
-            })
-        : []
+            const s = String(i), l = `Item ${i}`;
+            return { id: s, key: s, value: s, label: l, text: l, name: l, title: l };
+          })
+        : [];
     }
     // Optional everything-else stays unset — the component's own defaults are
     // safer than a placeholder.
-    else if (!req) continue
+    else if (!req) continue;
     // Required props get a type-appropriate stub so the render doesn't crash
     // on `undefined.…` / `undefined()`. `$raw` values are emitted verbatim by
     // scaffoldPropsExpr (not JSON-stringified).
-    else if (/\bDate\b/.test(t)) props[prop] = { $raw: 'new Date()' }
-    else if (/ElementType|ComponentType|JSXElementConstructor/.test(t))
-      props[prop] = 'div'
-    else if (/React\.ReactNode|ReactElement/.test(t)) props[prop] = name
-    else if (/^string\b/.test(t)) props[prop] = name
-    else if (/^number\b/.test(t)) props[prop] = 0
-    else if (/^boolean\b/.test(t)) props[prop] = false
-    else if (/^\{/.test(t) || /Record<|Partial<|Pick<|Omit</.test(t))
-      props[prop] = {}
+    else if (/\bDate\b/.test(t)) props[prop] = { $raw: 'new Date()' };
+    else if (/ElementType|ComponentType|JSXElementConstructor/.test(t)) props[prop] = 'div';
+    else if (/React\.ReactNode|ReactElement/.test(t)) props[prop] = name;
+    else if (/^string\b/.test(t)) props[prop] = name;
+    else if (/^number\b/.test(t)) props[prop] = 0;
+    else if (/^boolean\b/.test(t)) props[prop] = false;
+    else if (/^\{/.test(t) || /Record<|Partial<|Pick<|Omit</.test(t)) props[prop] = {};
     // Fallback: required prop of unrecognized shape — `{}` is the least likely
     // to crash `.foo` access.
-    else props[prop] = {}
+    else props[prop] = {};
   }
-  return { props, variants }
+  return { props, variants };
 }
 
 // One-line JSDoc from the component's own declaration.
 export function jsdocFor(name, ctx) {
-  const decls =
-    ctx.project
-      ?.getSourceFile(ctx.entry)
-      ?.getExportedDeclarations()
-      .get(name) ?? []
-  const exp =
-    decls.find(
-      (d) =>
-        Node.isVariableDeclaration(d) ||
-        Node.isFunctionDeclaration(d) ||
-        Node.isClassDeclaration(d),
-    ) ?? decls[0]
-  if (!exp || Node.isSourceFile(exp)) return ''
-  const doc =
-    exp.getJsDocs?.()?.[0]?.getDescription() ??
-    exp.getSymbol?.()?.compilerSymbol.getDocumentationComment?.(undefined)?.[0]
-      ?.text
-  if (!doc) return ''
-  return (
-    doc
-      .split('\n')
-      .find((l) => l.trim() && !l.trim().startsWith('@'))
-      ?.trim()
-      .replace(/\s+/g, ' ')
-      .replace(/[^\w\s.,()'/:+-]/g, '')
-      .slice(0, 140) ?? ''
-  )
+  const decls = ctx.project?.getSourceFile(ctx.entry)?.getExportedDeclarations().get(name) ?? [];
+  const exp = decls.find((d) =>
+    Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+  if (!exp || Node.isSourceFile(exp)) return '';
+  const doc = exp.getJsDocs?.()?.[0]?.getDescription()
+    ?? exp.getSymbol?.()?.compilerSymbol.getDocumentationComment?.(undefined)?.[0]?.text;
+  if (!doc) return '';
+  return doc.split('\n').find((l) => l.trim() && !l.trim().startsWith('@'))
+    ?.trim().replace(/\s+/g, ' ').replace(/[^\w\s.,()'/:+-]/g, '').slice(0, 140) ?? '';
 }

--- a/.design-sync/overrides/dts.mjs
+++ b/.design-sync/overrides/dts.mjs
@@ -8,42 +8,52 @@
 // chains and intersections, resolves `(typeof X)[number]` / mapped types to
 // literal unions.
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { Project, Node, ts } from 'ts-morph';
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { Project, Node, ts } from 'ts-morph'
 
 // The `exports` map is the modern (and often only) place a package declares its
 // types entry. Read the "." subpath's `types` condition, tolerating both the
 // nested-conditions form and the shorthand string form.
 function exportsTypesEntry(pkgJson) {
-  const dot = pkgJson.exports?.['.'];
-  if (!dot || typeof dot !== 'object') return undefined;
-  const t = dot.types ?? dot.import?.types ?? dot.default?.types;
-  return typeof t === 'string' ? t : undefined;
+  const dot = pkgJson.exports?.['.']
+  if (!dot || typeof dot !== 'object') return undefined
+  const t = dot.types ?? dot.import?.types ?? dot.default?.types
+  return typeof t === 'string' ? t : undefined
 }
 
 export function findTypesRoot(pkgDir, pkgJson) {
   // Workspace/monorepo packages often point dev `types` at src/*.ts (no .d.ts
   // tree there); publishConfig carries the published .d.ts entry — prefer it
   // when it exists on disk.
-  const pubTypes = pkgJson.publishConfig?.types;
-  if (pubTypes && existsSync(join(pkgDir, pubTypes))) return dirname(join(pkgDir, pubTypes));
-  const t = pkgJson.types || pkgJson.typings || exportsTypesEntry(pkgJson);
-  if (t) return dirname(join(pkgDir, t));
-  const hasDts = (d) => { try { return readdirSync(d).some((f) => f.endsWith('.d.ts')); } catch { return false; } };
-  for (const c of ['build/ts', 'dist/types', 'types', 'lib', 'dist']) {
-    const p = join(pkgDir, c);
-    if (existsSync(p) && (c !== 'dist' || hasDts(p))) return p;
+  const pubTypes = pkgJson.publishConfig?.types
+  if (pubTypes && existsSync(join(pkgDir, pubTypes)))
+    return dirname(join(pkgDir, pubTypes))
+  const t = pkgJson.types || pkgJson.typings || exportsTypesEntry(pkgJson)
+  if (t) return dirname(join(pkgDir, t))
+  const hasDts = (d) => {
+    try {
+      return readdirSync(d).some((f) => f.endsWith('.d.ts'))
+    } catch {
+      return false
+    }
   }
-  return pkgDir;
+  for (const c of ['build/ts', 'dist/types', 'types', 'lib', 'dist']) {
+    const p = join(pkgDir, c)
+    if (existsSync(p) && (c !== 'dist' || hasDts(p))) return p
+  }
+  return pkgDir
 }
 
 // *Props are prop interfaces; ALL-CAPS are object constants; *Manager /
 // *Placements / *Context are utility singletons; use* are hooks — none
 // renderable. (dts.nonComponents also catches React.Context by symbol kind;
 // the suffix check is belt-and-suspenders for DSes where that misses.)
-export const isComponentName = (n) => !n.endsWith('Props') && !/^[A-Z][A-Z0-9_]+$/.test(n)
-  && !/(?:Manager|Placements|Context)$/.test(n) && !/^use[A-Z]/.test(n);
+export const isComponentName = (n) =>
+  !n.endsWith('Props') &&
+  !/^[A-Z][A-Z0-9_]+$/.test(n) &&
+  !/(?:Manager|Placements|Context)$/.test(n) &&
+  !/^use[A-Z]/.test(n)
 
 // Partition into roots and subcomponents. A name is a subcomponent ONLY when
 // another name is a PascalCase prefix of it AND the suffix is an actual
@@ -54,18 +64,21 @@ export const isComponentName = (n) => !n.endsWith('Props') && !/^[A-Z][A-Z0-9_]+
 // that export subparts top-level only (no `Table.Row` namespace), this
 // conservatively does nothing.
 export function partitionSubcomponents(names, compounds) {
-  const set = new Set(names);
-  const parentOf = new Map();
+  const set = new Set(names)
+  const parentOf = new Map()
   for (const n of names) {
-    const parts = n.match(/[A-Z][a-z0-9]*/g) ?? [];
+    const parts = n.match(/[A-Z][a-z0-9]*/g) ?? []
     // Try longest prefix first, keep trying shorter ones — `ListItemText`
     // with compounds {List: ['ItemText']} must reach `List` even if
     // `ListItem` is itself a top-level name.
     for (let i = parts.length - 1; i >= 1; i--) {
-      const prefix = parts.slice(0, i).join('');
-      if (!set.has(prefix)) continue;
-      const suffix = parts.slice(i).join('');
-      if ((compounds?.get(prefix) ?? []).includes(suffix)) { parentOf.set(n, prefix); break; }
+      const prefix = parts.slice(0, i).join('')
+      if (!set.has(prefix)) continue
+      const suffix = parts.slice(i).join('')
+      if ((compounds?.get(prefix) ?? []).includes(suffix)) {
+        parentOf.set(n, prefix)
+        break
+      }
     }
   }
   // Flatten transitively — TableRowCell → TableRow → Table becomes
@@ -73,36 +86,47 @@ export function partitionSubcomponents(names, compounds) {
   // subs whose immediate parent is itself a sub. Terminates: each parent has
   // strictly fewer PascalCase parts than its child.
   for (const [n] of parentOf) {
-    let p = parentOf.get(n);
-    while (parentOf.has(p)) p = parentOf.get(p);
-    parentOf.set(n, p);
+    let p = parentOf.get(n)
+    while (parentOf.has(p)) p = parentOf.get(p)
+    parentOf.set(n, p)
   }
-  return { parentOf };
+  return { parentOf }
 }
 
 // One Project per package — loadDts/exportedNames share it.
-const projects = new Map();
+const projects = new Map()
 
 function projectFor(pkgDir, typesRoot) {
-  if (projects.has(pkgDir)) return projects.get(pkgDir);
+  if (projects.has(pkgDir)) return projects.get(pkgDir)
   // Derive node_modules for cross-package resolution (React, peer deps).
   // Normalize separators — pkgDir may have backslashes on Windows.
-  const posix = pkgDir.split('\\').join('/');
-  const i = posix.lastIndexOf('/node_modules/');
-  let nodeModules = i >= 0 ? join(pkgDir.slice(0, i), 'node_modules') : join(pkgDir, '..');
+  const posix = pkgDir.split('\\').join('/')
+  const i = posix.lastIndexOf('/node_modules/')
+  let nodeModules =
+    i >= 0 ? join(pkgDir.slice(0, i), 'node_modules') : join(pkgDir, '..')
   // Workspace packages live outside node_modules — walk up to the hoisted
   // root node_modules so @types/react resolves (otherwise React utility types
   // collapse to `any` and inherited props drop out of the emitted bodies).
   if (!existsSync(join(nodeModules, '@types', 'react'))) {
     for (let d = pkgDir; ; d = dirname(d)) {
-      if (existsSync(join(d, 'node_modules', '@types', 'react'))) { nodeModules = join(d, 'node_modules'); break; }
-      if (dirname(d) === d) break;
+      if (existsSync(join(d, 'node_modules', '@types', 'react'))) {
+        nodeModules = join(d, 'node_modules')
+        break
+      }
+      if (dirname(d) === d) break
     }
   }
-  const pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+  const pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
   // Same publishConfig preference as findTypesRoot — keep the two in sync.
-  const pubEntry = pj.publishConfig?.types;
-  const entry = join(pkgDir, (pubEntry && existsSync(join(pkgDir, pubEntry)) ? pubEntry : null) || pj.types || pj.typings || exportsTypesEntry(pj) || 'index.d.ts');
+  const pubEntry = pj.publishConfig?.types
+  const entry = join(
+    pkgDir,
+    (pubEntry && existsSync(join(pkgDir, pubEntry)) ? pubEntry : null) ||
+      pj.types ||
+      pj.typings ||
+      exportsTypesEntry(pj) ||
+      'index.d.ts',
+  )
   const project = new Project({
     skipAddingFilesFromTsConfig: true,
     compilerOptions: {
@@ -113,33 +137,39 @@ function projectFor(pkgDir, typesRoot) {
       skipLibCheck: true,
       strict: false,
     },
-  });
+  })
   // Add the package's own .d.ts tree plus @types/react (otherwise
   // `ComponentPropsWithoutRef<…>` is `any` and intersection types collapse).
-  const reactTypes = join(nodeModules, '@types', 'react', 'index.d.ts');
+  const reactTypes = join(nodeModules, '@types', 'react', 'index.d.ts')
   // The negation must be absolute-scoped to match the positive pattern —
   // ts-morph's fast-glob ignores bare `!**/node_modules/**` otherwise.
-  const root = typesRoot ?? dirname(entry);
-  project.addSourceFilesAtPaths([`${root}/**/*.d.ts`, `!${root}/**/node_modules/**`]);
-  console.error(`  [DTS] parsed ${project.getSourceFiles().length} .d.ts files from ${root}`);
+  const root = typesRoot ?? dirname(entry)
+  project.addSourceFilesAtPaths([
+    `${root}/**/*.d.ts`,
+    `!${root}/**/node_modules/**`,
+  ])
+  console.error(
+    `  [DTS] parsed ${project.getSourceFiles().length} .d.ts files from ${root}`,
+  )
   // ts-morph StandardizedFilePath is always forward-slash; normalize pkgDir
   // once so fp.startsWith(pkgDir) in isOwnProp/propsBodyFor works on Windows.
   // Trailing slash so a sibling node_modules package whose name is a prefix of
   // this one (foo vs foo-icons) isn't mis-classified as in-package.
-  const pkgDirStd = pkgDir.split('\\').join('/').replace(/\/?$/, '/');
-  if (existsSync(reactTypes)) project.addSourceFileAtPath(reactTypes);
-  else console.error(
-    '\n[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
-    '[DTS_REACT] @types/react not found in node_modules. React utility types\n' +
-    '[DTS_REACT] (ComponentPropsWithoutRef, FC, …) will resolve to `any`, so\n' +
-    '[DTS_REACT] components whose props extend them will emit EMPTY bodies.\n' +
-    '[DTS_REACT] Fix: `npm i -D @types/react` then rebuild.\n' +
-    '[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n',
-  );
-  if (existsSync(entry)) project.addSourceFileAtPath(entry);
-  const ctx = { project, entry, pkgDir: pkgDirStd };
-  projects.set(pkgDir, ctx);
-  return ctx;
+  const pkgDirStd = pkgDir.split('\\').join('/').replace(/\/?$/, '/')
+  if (existsSync(reactTypes)) project.addSourceFileAtPath(reactTypes)
+  else
+    console.error(
+      '\n[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
+        '[DTS_REACT] @types/react not found in node_modules. React utility types\n' +
+        '[DTS_REACT] (ComponentPropsWithoutRef, FC, …) will resolve to `any`, so\n' +
+        '[DTS_REACT] components whose props extend them will emit EMPTY bodies.\n' +
+        '[DTS_REACT] Fix: `npm i -D @types/react` then rebuild.\n' +
+        '[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n',
+    )
+  if (existsSync(entry)) project.addSourceFileAtPath(entry)
+  const ctx = { project, entry, pkgDir: pkgDirStd }
+  projects.set(pkgDir, ctx)
+  return ctx
 }
 
 // Keep a prop unless its declaration lives in React/DOM types or a CSS-in-JS
@@ -148,7 +178,7 @@ function projectFor(pkgDir, typesRoot) {
 // structural props survive when inherited from React. ts-morph's getFilePath()
 // returns StandardizedFilePath (forward-slash), so the substring checks are
 // cross-platform.
-const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/;
+const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/
 // Style-system bases are detected by SHAPE, two-tier (canonical contract —
 // the call sites point here):
 // - EXTERNAL packages: >STYLE_SYSTEM_THRESHOLD CSS/token-named props,
@@ -166,24 +196,24 @@ const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/;
 // passes regardless). ASSUMPTION: when inherited shorthands are real API,
 // override per component with cfg.dtsPropsFor.<Name>.
 const CSS_PROP_NAME =
-  /^(m[tblrxy]?$|p[tblrxy]?$|margin|padding|bg|background|color|border|width|height|flex|grid|gap|font|text|display|position|top|left|right|bottom|z|opacity|overflow|shadow|rounded|space)/;
-const STYLE_SYSTEM_THRESHOLD = 15;
-const IN_PACKAGE_FILE_THRESHOLD = 100;
+  /^(m[tblrxy]?$|p[tblrxy]?$|margin|padding|bg|background|color|border|width|height|flex|grid|gap|font|text|display|position|top|left|right|bottom|z|opacity|overflow|shadow|rounded|space)/
+const STYLE_SYSTEM_THRESHOLD = 15
+const IN_PACKAGE_FILE_THRESHOLD = 100
 // The package that owns a path: its deepest node_modules/<pkg>/ boundary
 // (trailing slash), or null for workspace paths. Identity comparison against
 // ownerOf(pkgDir) is the single in-package/external discriminator.
 function ownerOf(p) {
-  const m = /^(.*\/node_modules\/(?:@[^/]+\/)?[^/]+)\//.exec(p);
-  return m ? m[1] + '/' : null;
+  const m = /^(.*\/node_modules\/(?:@[^/]+\/)?[^/]+)\//.exec(p)
+  return m ? m[1] + '/' : null
 }
 function detectStyleSystemDirs(props, pkgDir, declFile) {
-  const pkgOwner = ownerOf(pkgDir);
-  const cssByDir = new Map();
+  const pkgOwner = ownerOf(pkgDir)
+  const cssByDir = new Map()
   for (const p of props) {
-    if (!CSS_PROP_NAME.test(p.getName())) continue;
-    const d = p.getDeclarations()[0];
-    if (!d) continue;
-    const fp = d.getSourceFile().getFilePath();
+    if (!CSS_PROP_NAME.test(p.getName())) continue
+    const d = p.getDeclarations()[0]
+    if (!d) continue
+    const fp = d.getSourceFile().getFilePath()
     // Key shape encodes the tier (see the canonical contract above
     // CSS_PROP_NAME): external packages → node_modules/<pkg>/ prefix key
     // (trailing slash); in-package declarations → exact FILE key. The
@@ -201,100 +231,131 @@ function detectStyleSystemDirs(props, pkgDir, declFile) {
     // Ownerless externals (sibling workspace packages) key per-file at the
     // in-package bar — the documented out-of-scope fallback in the
     // canonical block above.
-    const owner = ownerOf(fp);
-    const inPackage = owner === pkgOwner && (owner !== null || fp.startsWith(pkgDir));
-    const key = inPackage ? fp : (owner ?? fp);
+    const owner = ownerOf(fp)
+    const inPackage =
+      owner === pkgOwner && (owner !== null || fp.startsWith(pkgDir))
+    const key = inPackage ? fp : (owner ?? fp)
     // Never flag the file that declares the component's own Props: in a
     // rolled-up single-file .d.ts the generated style layer co-lives with
     // the API interfaces, and a per-FILE flag would drop the component's
     // own props. Separate generated files still filter; rollups fall back
     // to unfiltered (slow but correct). External dir keys are unaffected.
-    if (key === declFile) continue;
-    cssByDir.set(key, (cssByDir.get(key) ?? 0) + 1);
+    if (key === declFile) continue
+    cssByDir.set(key, (cssByDir.get(key) ?? 0) + 1)
   }
   // Per-tier bars — rationale in the canonical block above CSS_PROP_NAME.
-  const keys = [];
+  const keys = []
   for (const [k, n] of cssByDir) {
-    const bar = k.endsWith('/') ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
-    if (n > bar) keys.push(k);
+    const bar = k.endsWith('/')
+      ? STYLE_SYSTEM_THRESHOLD
+      : IN_PACKAGE_FILE_THRESHOLD
+    if (n > bar) keys.push(k)
   }
-  return keys;
+  return keys
 }
 function isOwnProp(p, pkgDir, styleSystemDirs) {
-  const name = p.getName();
-  if (KEEP_PROP.test(name)) return true;
-  const d = p.getDeclarations()[0];
-  if (!d) return true;
-  const fp = d.getSourceFile().getFilePath();
+  const name = p.getName()
+  if (KEEP_PROP.test(name)) return true
+  const d = p.getDeclarations()[0]
+  if (!d) return true
+  const fp = d.getSourceFile().getFilePath()
   // Same owner-identity discriminator as detectStyleSystemDirs, same order
   // of authority: a flagged in-package FILE drops first (exact match); then
   // owner-equality keeps the DS's own API — checked BEFORE dir keys because
   // a flagged dir key can be an ANCESTOR of pkgDir (DS synced from inside a
   // host package's node_modules) and must not swallow in-package files;
   // then flagged external packages drop by prefix.
-  if (styleSystemDirs.some((k) => !k.endsWith('/') && fp === k)) return false;
-  const owner = ownerOf(fp);
-  if (owner === ownerOf(pkgDir) && (owner !== null || fp.startsWith(pkgDir))) return true;
-  if (styleSystemDirs.some((k) => k.endsWith('/') && fp.startsWith(k))) return false;
-  if (fp.includes('/@types/react/') || fp.includes('/typescript/lib/')) return false;
+  if (styleSystemDirs.some((k) => !k.endsWith('/') && fp === k)) return false
+  const owner = ownerOf(fp)
+  if (owner === ownerOf(pkgDir) && (owner !== null || fp.startsWith(pkgDir)))
+    return true
+  if (styleSystemDirs.some((k) => k.endsWith('/') && fp.startsWith(k)))
+    return false
+  if (fp.includes('/@types/react/') || fp.includes('/typescript/lib/'))
+    return false
   // DOM-noise name filters apply only to props inherited from other packages.
-  if (/^(on[A-Z]|aria-)/.test(name)) return false;
-  return true;
+  if (/^(on[A-Z]|aria-)/.test(name)) return false
+  return true
 }
 
 // Keep well-known aliases as-written instead of expanding to their full union.
-const KEEP_ALIAS = /^(ReactNode|ReactElement|CSSProperties|JSX\.Element|Key|Ref|RefObject)$/;
+const KEEP_ALIAS =
+  /^(ReactNode|ReactElement|CSSProperties|JSX\.Element|Key|Ref|RefObject)$/
 
 function typeText(t, at) {
-  const alias = t.getAliasSymbol()?.getName();
-  if (alias && KEEP_ALIAS.test(alias)) return `React.${alias}`;
-  if (t.isBoolean()) return 'boolean';
-  let s;
+  const alias = t.getAliasSymbol()?.getName()
+  if (alias && KEEP_ALIAS.test(alias)) return `React.${alias}`
+  if (t.isBoolean()) return 'boolean'
+  let s
   if (t.isUnion()) {
     // Render each member so ReactNode/boolean collapse while literal unions
     // stay expanded; dedup, drop `undefined` (optionality is the `?`).
-    const parts = t.getUnionTypes().map((u) => typeText(u, at)).filter((p) => p !== 'undefined');
-    let uniq = [...new Set(parts)];
-    if (uniq.length === 2 && uniq.includes('true') && uniq.includes('false')) return 'boolean';
+    const parts = t
+      .getUnionTypes()
+      .map((u) => typeText(u, at))
+      .filter((p) => p !== 'undefined')
+    let uniq = [...new Set(parts)]
+    if (uniq.length === 2 && uniq.includes('true') && uniq.includes('false'))
+      return 'boolean'
     // Collapse the structural expansion of React.ReactNode (string | number |
     // ReactElement<…> | Iterable<ReactNode> | ReactPortal | Promise<…>) back to
     // the alias — when the alias symbol is lost, the expansion blows past the
     // length cap below and would truncate into invalid TS.
-    if (uniq.includes('ReactPortal') && uniq.some((u) => u.startsWith('Iterable<ReactNode>'))) {
-      const RN_MEMBER = /^(string|number|bigint|boolean|ReactPortal|Iterable<ReactNode>.*|ReactElement<.*|Promise<.*)$/;
-      uniq = [...new Set([...uniq.filter((u) => !RN_MEMBER.test(u)), 'React.ReactNode'])];
+    if (
+      uniq.includes('ReactPortal') &&
+      uniq.some((u) => u.startsWith('Iterable<ReactNode>'))
+    ) {
+      const RN_MEMBER =
+        /^(string|number|bigint|boolean|ReactPortal|Iterable<ReactNode>.*|ReactElement<.*|Promise<.*)$/
+      uniq = [
+        ...new Set([
+          ...uniq.filter((u) => !RN_MEMBER.test(u)),
+          'React.ReactNode',
+        ]),
+      ]
     }
     // Function-type members are invalid un-parenthesized inside a union
     // (`string | (x) => void` doesn't parse) — wrap them.
-    if (uniq.length > 1) uniq = uniq.map((u) => (u.includes('=>') ? `(${u})` : u));
+    if (uniq.length > 1)
+      uniq = uniq.map((u) => (u.includes('=>') ? `(${u})` : u))
     // Cap very wide unions (icon-name sets can be 600+ members).
-    if (uniq.length > 24) uniq = [...uniq.slice(0, 16), `(string & {}) /* +${uniq.length - 16} more */`];
-    s = uniq.join(' | ').replace(/\bfalse \| true\b/, 'boolean');
+    if (uniq.length > 24)
+      uniq = [
+        ...uniq.slice(0, 16),
+        `(string & {}) /* +${uniq.length - 16} more */`,
+      ]
+    s = uniq.join(' | ').replace(/\bfalse \| true\b/, 'boolean')
   } else {
-    s = t.getText(at, ts.TypeFormatFlags.NoTruncation).replace(/import\("[^"]*"\)\./g, '');
+    s = t
+      .getText(at, ts.TypeFormatFlags.NoTruncation)
+      .replace(/import\("[^"]*"\)\./g, '')
   }
   // Never hard-slice an over-long type — a cut generic/object literal is
   // invalid TS and fails the validator's [DTS_PARSE] check (and the app's
   // API-contract parse). Fall back to a safe wide type instead; the JSDoc
   // line above the prop carries the human-readable detail.
-  return s.length > 240 ? 'unknown' : s;
+  return s.length > 240 ? 'unknown' : s
 }
 
 // PascalCase value exports from the entry module. The checker knows value vs
 // type, so type-only exports never enter the set.
 export function exportedNames(pkgDir, pkgJson) {
-  const { project, entry } = projectFor(pkgDir, findTypesRoot(pkgDir, pkgJson));
-  const sf = project.getSourceFile(entry);
-  const names = new Set();
-  if (!sf) return names;
+  const { project, entry } = projectFor(pkgDir, findTypesRoot(pkgDir, pkgJson))
+  const sf = project.getSourceFile(entry)
+  const names = new Set()
+  if (!sf) return names
   for (const [name, decls] of sf.getExportedDeclarations()) {
-    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
-    const hasValue = decls.some((d) =>
-      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) ||
-      Node.isClassDeclaration(d) || Node.isSourceFile(d));
-    if (hasValue) names.add(name);
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue
+    const hasValue = decls.some(
+      (d) =>
+        Node.isVariableDeclaration(d) ||
+        Node.isFunctionDeclaration(d) ||
+        Node.isClassDeclaration(d) ||
+        Node.isSourceFile(d),
+    )
+    if (hasValue) names.add(name)
   }
-  return names;
+  return names
 }
 
 // Builds the context propsBodyFor/jsdocFor read from. `nonComponents` /
@@ -304,156 +365,215 @@ export function loadDts(typesRoot) {
   // root: the nearest package.json with a `name` field, skipping stubs
   // (`{"type":"module"}` in esm/ or dist/). dirname-fixed-point is the
   // cross-platform root test (`/` vs `C:\`).
-  let walk = typesRoot;
+  let walk = typesRoot
   for (; walk !== dirname(walk); walk = dirname(walk)) {
-    const pj = join(walk, 'package.json');
+    const pj = join(walk, 'package.json')
     if (existsSync(pj)) {
-      try { if (JSON.parse(readFileSync(pj, 'utf8')).name) break; } catch {}
+      try {
+        if (JSON.parse(readFileSync(pj, 'utf8')).name) break
+      } catch {}
     }
   }
   // projectFor normalizes pkgDir to forward-slashes (ts-morph's
   // StandardizedFilePath) — use that for every fp.startsWith() downstream.
-  const { project, entry, pkgDir } = projectFor(walk, typesRoot);
-  const sf = project.getSourceFile(entry);
-  const nonComponents = new Set();
-  const compounds = new Map();
-  if (sf) for (const [name, decls] of sf.getExportedDeclarations()) {
-    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
-    // Declaration-merged names (`interface Button {}` + `const Button: …`)
-    // return both decls — prefer the value decl so the merge isn't
-    // misclassified as type-only by whichever the checker listed first.
-    const d = decls.find((x) =>
-      Node.isVariableDeclaration(x) || Node.isFunctionDeclaration(x) ||
-      Node.isClassDeclaration(x) || Node.isSourceFile(x)) ?? decls[0];
-    // Namespace export (`export * as X`) → compound with its own value members.
-    if (Node.isSourceFile(d)) {
-      const members = [...d.getExportedDeclarations().entries()]
-        .filter(([n, ds]) => /^[A-Z][a-z]/.test(n) && ds.some((x) => !Node.isInterfaceDeclaration(x) && !Node.isTypeAliasDeclaration(x)))
-        .map(([n]) => n);
-      if (members.length) compounds.set(name, members);
-      else nonComponents.add(name);
-      continue;
+  const { project, entry, pkgDir } = projectFor(walk, typesRoot)
+  const sf = project.getSourceFile(entry)
+  const nonComponents = new Set()
+  const compounds = new Map()
+  if (sf)
+    for (const [name, decls] of sf.getExportedDeclarations()) {
+      if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue
+      // Declaration-merged names (`interface Button {}` + `const Button: …`)
+      // return both decls — prefer the value decl so the merge isn't
+      // misclassified as type-only by whichever the checker listed first.
+      const d =
+        decls.find(
+          (x) =>
+            Node.isVariableDeclaration(x) ||
+            Node.isFunctionDeclaration(x) ||
+            Node.isClassDeclaration(x) ||
+            Node.isSourceFile(x),
+        ) ?? decls[0]
+      // Namespace export (`export * as X`) → compound with its own value members.
+      if (Node.isSourceFile(d)) {
+        const members = [...d.getExportedDeclarations().entries()]
+          .filter(
+            ([n, ds]) =>
+              /^[A-Z][a-z]/.test(n) &&
+              ds.some(
+                (x) =>
+                  !Node.isInterfaceDeclaration(x) &&
+                  !Node.isTypeAliasDeclaration(x),
+              ),
+          )
+          .map(([n]) => n)
+        if (members.length) compounds.set(name, members)
+        else nonComponents.add(name)
+        continue
+      }
+      // Type-only / enum / Context / abstract-class are not components.
+      if (
+        Node.isInterfaceDeclaration(d) ||
+        Node.isTypeAliasDeclaration(d) ||
+        Node.isEnumDeclaration(d)
+      ) {
+        nonComponents.add(name)
+        continue
+      }
+      if (Node.isClassDeclaration(d) && d.isAbstract()) {
+        nonComponents.add(name)
+        continue
+      }
+      if (Node.isClassDeclaration(d)) continue // always renderable; compounds via statics aren't handled here
+      if (!Node.isVariableDeclaration(d) && !Node.isFunctionDeclaration(d))
+        continue
+      // `const X: FC<…> & { Sub: … }` (possibly through an alias/Omit) —
+      // PascalCase callable properties declared in-package are compound members
+      // (React.Component lifecycle names have underscores / fail the full match).
+      const t = d.getType()
+      const members = []
+      // PascalCase props can't be style-system CSS-shorthands, so the empty
+      // list is correct here — detectStyleSystemDirs would contribute nothing.
+      const noStyle = []
+      for (const p of t.getProperties()) {
+        const pn = p.getName()
+        if (!/^[A-Z][a-zA-Z0-9]*$/.test(pn) || !isOwnProp(p, pkgDir, noStyle))
+          continue
+        if (p.getTypeAtLocation(d).getCallSignatures().length) members.push(pn)
+      }
+      if (members.length) compounds.set(name, members)
+      // Only provably-not-renderable consts are filtered: a plain object/record
+      // type whose every property is a primitive (token/enum
+      // objects like Colors or Sizes). Anything with a call signature, construct signature, or a
+      // non-primitive property stays — class components and forwardRef wrappers
+      // without call sigs on the instance type must not be dropped here.
+      if (
+        t.isObject() &&
+        !t.getCallSignatures().length &&
+        !t.getConstructSignatures().length &&
+        !members.length &&
+        !t.isAny()
+      ) {
+        const props = t.getProperties()
+        if (
+          props.length &&
+          props.every((p) => {
+            const pt = p.getTypeAtLocation(d)
+            return (
+              pt.isString() ||
+              pt.isNumber() ||
+              pt.isStringLiteral() ||
+              pt.isNumberLiteral()
+            )
+          })
+        )
+          nonComponents.add(name)
+      }
     }
-    // Type-only / enum / Context / abstract-class are not components.
-    if (Node.isInterfaceDeclaration(d) || Node.isTypeAliasDeclaration(d) || Node.isEnumDeclaration(d)) {
-      nonComponents.add(name);
-      continue;
-    }
-    if (Node.isClassDeclaration(d) && d.isAbstract()) { nonComponents.add(name); continue; }
-    if (Node.isClassDeclaration(d)) continue;  // always renderable; compounds via statics aren't handled here
-    if (!Node.isVariableDeclaration(d) && !Node.isFunctionDeclaration(d)) continue;
-    // `const X: FC<…> & { Sub: … }` (possibly through an alias/Omit) —
-    // PascalCase callable properties declared in-package are compound members
-    // (React.Component lifecycle names have underscores / fail the full match).
-    const t = d.getType();
-    const members = [];
-    // PascalCase props can't be style-system CSS-shorthands, so the empty
-    // list is correct here — detectStyleSystemDirs would contribute nothing.
-    const noStyle = [];
-    for (const p of t.getProperties()) {
-      const pn = p.getName();
-      if (!/^[A-Z][a-zA-Z0-9]*$/.test(pn) || !isOwnProp(p, pkgDir, noStyle)) continue;
-      if (p.getTypeAtLocation(d).getCallSignatures().length) members.push(pn);
-    }
-    if (members.length) compounds.set(name, members);
-    // Only provably-not-renderable consts are filtered: a plain object/record
-    // type whose every property is a primitive (token/enum
-    // objects like Colors or Sizes). Anything with a call signature, construct signature, or a
-    // non-primitive property stays — class components and forwardRef wrappers
-    // without call sigs on the instance type must not be dropped here.
-    if (t.isObject() && !t.getCallSignatures().length && !t.getConstructSignatures().length && !members.length && !t.isAny()) {
-      const props = t.getProperties();
-      if (props.length && props.every((p) => {
-        const pt = p.getTypeAtLocation(d);
-        return pt.isString() || pt.isNumber() || pt.isStringLiteral() || pt.isNumberLiteral();
-      })) nonComponents.add(name);
-    }
-  }
-  return { project, entry, pkgDir, nonComponents, compounds };
+  return { project, entry, pkgDir, nonComponents, compounds }
 }
 
 // Returns { body, generics, extendsClause, prelude } for emit.mjs. Types are
 // fully resolved into `body`, so extendsClause/prelude stay empty.
 export function propsBodyFor(name, ctx) {
   if (ctx.dtsPropsFor?.[name]) {
-    return { body: ctx.dtsPropsFor[name], generics: '', extendsClause: '', prelude: '' };
+    return {
+      body: ctx.dtsPropsFor[name],
+      generics: '',
+      extendsClause: '',
+      prelude: '',
+    }
   }
-  const { project, entry, pkgDir } = ctx;
+  const { project, entry, pkgDir } = ctx
   // Find <Name>Props across the package's own files (not @types/react).
   // Skip deprecated/legacy/experimental dirs so a stale copy doesn't shadow
   // the live one.
-  let decl = null;
+  let decl = null
   for (const sf of project.getSourceFiles()) {
-    const fp = sf.getFilePath();
-    if (!fp.startsWith(pkgDir)) continue;
-    if (/\/(deprecated|legacy|experimental)\//i.test(fp)) continue;
-    decl = sf.getInterface(`${name}Props`) ?? sf.getTypeAlias(`${name}Props`);
-    if (decl) break;
+    const fp = sf.getFilePath()
+    if (!fp.startsWith(pkgDir)) continue
+    if (/\/(deprecated|legacy|experimental)\//i.test(fp)) continue
+    decl = sf.getInterface(`${name}Props`) ?? sf.getTypeAlias(`${name}Props`)
+    if (decl) break
   }
   // Fallback: derive from the component symbol's first call signature.
   // Prefer the value decl (declaration-merging — see loadDts).
   if (!decl) {
-    const decls = project.getSourceFile(entry)?.getExportedDeclarations().get(name) ?? [];
-    const exp = decls.find((d) =>
-      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
-    if (!exp || Node.isSourceFile(exp)) return null;
-    const sig = exp.getType().getCallSignatures()[0];
-    const p0 = sig?.getParameters()[0];
-    if (!p0) return null;
-    return emitBody(p0.getTypeAtLocation(exp), exp, '', pkgDir);
+    const decls =
+      project.getSourceFile(entry)?.getExportedDeclarations().get(name) ?? []
+    const exp =
+      decls.find(
+        (d) =>
+          Node.isVariableDeclaration(d) ||
+          Node.isFunctionDeclaration(d) ||
+          Node.isClassDeclaration(d),
+      ) ?? decls[0]
+    if (!exp || Node.isSourceFile(exp)) return null
+    const sig = exp.getType().getCallSignatures()[0]
+    const p0 = sig?.getParameters()[0]
+    if (!p0) return null
+    return emitBody(p0.getTypeAtLocation(exp), exp, '', pkgDir)
   }
   const generics = decl.getTypeParameters?.().length
-    ? `<${decl.getTypeParameters().map((p) => p.getText()).join(', ')}>`
-    : '';
-  return emitBody(decl.getType(), decl, generics, pkgDir);
+    ? `<${decl
+        .getTypeParameters()
+        .map((p) => p.getText())
+        .join(', ')}>`
+    : ''
+  return emitBody(decl.getType(), decl, generics, pkgDir)
 }
 
-let loggedStyleSystemDirs;
+let loggedStyleSystemDirs
 function emitBody(type, at, generics, pkgDir) {
-  const lines = [];
-  const props = type.getApparentType().getProperties();
+  const lines = []
+  const props = type.getApparentType().getProperties()
   // `at` is the component's own Props declaration site — its file is exempt
   // from per-FILE flagging (see detectStyleSystemDirs).
-  const styleSystemDirs = detectStyleSystemDirs(props, pkgDir, at.getSourceFile().getFilePath());
+  const styleSystemDirs = detectStyleSystemDirs(
+    props,
+    pkgDir,
+    at.getSourceFile().getFilePath(),
+  )
   // Surface a one-shot [DTS_STYLE_SYSTEM] line per flagged package so the
   // self-heal loop routes to cfg.dtsPropsFor when the heuristic guesses
   // wrong. ASSUMPTION: props from the named packages are token-typed
   // style shorthands; override a component's contract with cfg.dtsPropsFor.
-  loggedStyleSystemDirs ??= new Set();
+  loggedStyleSystemDirs ??= new Set()
   for (const dir of styleSystemDirs) {
-    if (loggedStyleSystemDirs.has(dir)) continue;
-    loggedStyleSystemDirs.add(dir);
-    const isDirKey = dir.endsWith('/');
-    const pkg = /\/node_modules\/((?:@[^/]+\/)?[^/]+)\/$/.exec(dir)?.[1]
-      ?? (dir.startsWith(pkgDir) ? dir.slice(pkgDir.length) : dir);
-    const bar = isDirKey ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    if (loggedStyleSystemDirs.has(dir)) continue
+    loggedStyleSystemDirs.add(dir)
+    const isDirKey = dir.endsWith('/')
+    const pkg =
+      /\/node_modules\/((?:@[^/]+\/)?[^/]+)\/$/.exec(dir)?.[1] ??
+      (dir.startsWith(pkgDir) ? dir.slice(pkgDir.length) : dir)
+    const bar = isDirKey ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD
     console.error(
       `[DTS_STYLE_SYSTEM] filtering ${pkg} props (>${bar} CSS-shorthand-named props) — override a component with cfg.dtsPropsFor.<Name> if these are real API`,
-    );
+    )
   }
   for (const p of props) {
-    if (!isOwnProp(p, pkgDir, styleSystemDirs)) continue;
-    const optional = p.hasFlags(ts.SymbolFlags.Optional) ? '?' : '';
-    const pt = p.getTypeAtLocation(at);
-    let tt = typeText(pt, at);
+    if (!isOwnProp(p, pkgDir, styleSystemDirs)) continue
+    const optional = p.hasFlags(ts.SymbolFlags.Optional) ? '?' : ''
+    const pt = p.getTypeAtLocation(at)
+    let tt = typeText(pt, at)
     // Structural hint when the type text hides the shape (aliased functions /
     // arrays) — smartDefaultProps reads these to pick the right required-stub.
-    const members = pt.isUnion() ? pt.getUnionTypes() : [pt];
-    if (members.some((u) => u.getCallSignatures().length)) tt += ' /* @fn */';
+    const members = pt.isUnion() ? pt.getUnionTypes() : [pt]
+    if (members.some((u) => u.getCallSignatures().length)) tt += ' /* @fn */'
     // Tuples are not @arr — `[]` has the wrong length and `[0]` access crashes
     // either way; optional tuples are safer left unset.
-    else if (members.some((u) => u.isArray())) tt += ' /* @arr */';
+    else if (members.some((u) => u.isArray())) tt += ' /* @arr */'
     // Leading JSDoc on the prop declaration, if any.
-    const d = p.getDeclarations()[0];
-    const doc = d?.getJsDocs?.()?.[0]?.getDescription()?.trim();
-    if (doc) lines.push(`  /** ${doc.replace(/\s+/g, ' ').slice(0, 120)} */`);
-    const pn = p.getName();
+    const d = p.getDeclarations()[0]
+    const doc = d?.getJsDocs?.()?.[0]?.getDescription()?.trim()
+    if (doc) lines.push(`  /** ${doc.replace(/\s+/g, ' ').slice(0, 120)} */`)
+    const pn = p.getName()
     // Hyphenated/index-signature names (`data-*`, `aria-*`) must be quoted.
-    const key = /^[a-zA-Z_$][\w$]*$/.test(pn) ? pn : JSON.stringify(pn);
-    lines.push(`  ${key}${optional}: ${tt};`);
+    const key = /^[a-zA-Z_$][\w$]*$/.test(pn) ? pn : JSON.stringify(pn)
+    lines.push(`  ${key}${optional}: ${tt};`)
   }
-  if (!lines.length) return null;
-  return { body: lines.join('\n'), generics, extendsClause: '', prelude: '' };
+  if (!lines.length) return null
+  return { body: lines.join('\n'), generics, extendsClause: '', prelude: '' }
 }
 
 // Scaffold-preview defaults from the resolved props body. Conservative: fill
@@ -463,95 +583,163 @@ function emitBody(type, at, generics, pkgDir) {
 // helps.
 //
 // Void-element-ish components — a string `children` would throw at render.
-const VOID_LIKE = /^(Text|Number|Search|Password|File|Masked)?Input$|^(TextField|TextArea|Textarea|Img|Image|Avatar|Hr|Br|Spacer|Divider|Separator|Slider|Progress|ProgressBar)$/;
+const VOID_LIKE =
+  /^(Text|Number|Search|Password|File|Masked)?Input$|^(TextField|TextArea|Textarea|Img|Image|Avatar|Hr|Br|Spacer|Divider|Separator|Slider|Progress|ProgressBar)$/
 // Ordered preference for the variant axis — earlier wins. `type` is last so
 // the HTML `type` attr ("button"|"submit"|"reset") doesn't beat `variant`.
-const VARIANT_RANK = ['variant', 'intent', 'kind', 'appearance', 'tone', 'status', 'size', 'color', 'type'];
+const VARIANT_RANK = [
+  'variant',
+  'intent',
+  'kind',
+  'appearance',
+  'tone',
+  'status',
+  'size',
+  'color',
+  'type',
+]
 export function smartDefaultProps(name, pb) {
-  const body = pb?.body ?? '';
-  const props = {};
-  let variants = null;
+  const body = pb?.body ?? ''
+  const props = {}
+  let variants = null
   // Matches the 2-space indent emitBody writes — keep the two in sync.
   // `.+` (not `[^;]+`) so object-param types with inner semicolons still match.
-  for (const m of body.matchAll(/^ {2}([a-zA-Z_$][\w$]*)(\??)\s*:\s*(.+);$/gm)) {
-    const [, prop, q, t] = m;
-    if (prop in props) continue;
-    const req = !q;
+  for (const m of body.matchAll(
+    /^ {2}([a-zA-Z_$][\w$]*)(\??)\s*:\s*(.+);$/gm,
+  )) {
+    const [, prop, q, t] = m
+    if (prop in props) continue
+    const req = !q
     // Union of string literals, optionally with a `string & {}` escape-hatch
     // member (the "autocomplete these, accept any string" TS pattern).
     if (/^(?:(?:"[^"]*"|\(?string\s*&\s*\{\}\)?)\s*\|?\s*)+$/.test(t)) {
-      const lits = [...t.matchAll(/"([^"]*)"/g)].map((l) => l[1]).filter(Boolean);
+      const lits = [...t.matchAll(/"([^"]*)"/g)]
+        .map((l) => l[1])
+        .filter(Boolean)
       if (lits.length >= 2) {
-        const rank = VARIANT_RANK.indexOf(prop.toLowerCase());
+        const rank = VARIANT_RANK.indexOf(prop.toLowerCase())
         // Displace on strictly better rank (prop names are unique, so no ties).
-        if (!variants || (rank >= 0 && (variants.rank < 0 || rank < variants.rank))) {
-          variants = { prop, values: lits.slice(0, 4), rank };
+        if (
+          !variants ||
+          (rank >= 0 && (variants.rank < 0 || rank < variants.rank))
+        ) {
+          variants = { prop, values: lits.slice(0, 4), rank }
         }
-        if (req) props[prop] = lits[0];
-        continue;
+        if (req) props[prop] = lits[0]
+        continue
       }
     }
     // Structural hints (/* @fn */, /* @arr */) from emitBody are authoritative
     // over the text regexes — `(() => void)[]` has @arr, so the `=>` in the
     // element type must not flip it to isFn. The text regexes cover
     // cfg.dtsPropsFor overrides with no hints.
-    const hasFn = t.includes('/* @fn */'), hasArr = t.includes('/* @arr */');
-    const isFn = hasFn || (!hasArr && /=>|\)\s*:/.test(t));
-    const isArr = !isFn && (hasArr || /\[\]|Array</.test(t));
-    if (prop === 'children' && /React\.ReactNode|ReactElement/.test(t) && !isFn && !VOID_LIKE.test(name)) props.children = name;
+    const hasFn = t.includes('/* @fn */'),
+      hasArr = t.includes('/* @arr */')
+    const isFn = hasFn || (!hasArr && /=>|\)\s*:/.test(t))
+    const isArr = !isFn && (hasArr || /\[\]|Array</.test(t))
+    if (
+      prop === 'children' &&
+      /React\.ReactNode|ReactElement/.test(t) &&
+      !isFn &&
+      !VOID_LIKE.test(name)
+    )
+      props.children = name
     // Visibility toggles — an overlay/dialog with open=false renders nothing.
-    else if (/^(open|isOpen|visible|show|defaultOpen|expanded|checked|active|selected)$/.test(prop) && t === 'boolean') props[prop] = true;
+    else if (
+      /^(open|isOpen|visible|show|defaultOpen|expanded|checked|active|selected)$/.test(
+        prop,
+      ) &&
+      t === 'boolean'
+    )
+      props[prop] = true
     // Callable (required or optional) — optional stays unset (DSes guard
     // optional callbacks); required gets a noop.
-    else if (isFn) { if (req) props[prop] = { $raw: '()=>null' }; }
+    else if (isFn) {
+      if (req) props[prop] = { $raw: '()=>null' }
+    }
     // Arrays (required or optional). `[]` is crash-safe but renders nothing.
     // Props that look like data/option lists get a small sample so the
     // preview has visible rows; element shape is best-effort from the type
     // text (string[] → strings; otherwise {id,label,value}).
     else if (isArr) {
-      const isList = /^(items|options|tabs|rows|columns|data|actions|fields|links|steps|choices|values)$/i.test(prop);
-      const elT = t.replace(/\/\*.*?\*\//g, '').trim();
-      const elIsString = /^(?:readonly\s+)?string\[\]|^ReadonlyArray<string>|^Array<string>/.test(elT);
+      const isList =
+        /^(items|options|tabs|rows|columns|data|actions|fields|links|steps|choices|values)$/i.test(
+          prop,
+        )
+      const elT = t.replace(/\/\*.*?\*\//g, '').trim()
+      const elIsString =
+        /^(?:readonly\s+)?string\[\]|^ReadonlyArray<string>|^Array<string>/.test(
+          elT,
+        )
       // Over-provision keys — extra ones are ignored, and this covers the
       // common {id|key} + {label|text|name|title} + value conventions.
       props[prop] = isList
         ? elIsString
           ? ['Item 1', 'Item 2', 'Item 3']
           : [1, 2, 3].map((i) => {
-            const s = String(i), l = `Item ${i}`;
-            return { id: s, key: s, value: s, label: l, text: l, name: l, title: l };
-          })
-        : [];
+              const s = String(i),
+                l = `Item ${i}`
+              return {
+                id: s,
+                key: s,
+                value: s,
+                label: l,
+                text: l,
+                name: l,
+                title: l,
+              }
+            })
+        : []
     }
     // Optional everything-else stays unset — the component's own defaults are
     // safer than a placeholder.
-    else if (!req) continue;
+    else if (!req) continue
     // Required props get a type-appropriate stub so the render doesn't crash
     // on `undefined.…` / `undefined()`. `$raw` values are emitted verbatim by
     // scaffoldPropsExpr (not JSON-stringified).
-    else if (/\bDate\b/.test(t)) props[prop] = { $raw: 'new Date()' };
-    else if (/ElementType|ComponentType|JSXElementConstructor/.test(t)) props[prop] = 'div';
-    else if (/React\.ReactNode|ReactElement/.test(t)) props[prop] = name;
-    else if (/^string\b/.test(t)) props[prop] = name;
-    else if (/^number\b/.test(t)) props[prop] = 0;
-    else if (/^boolean\b/.test(t)) props[prop] = false;
-    else if (/^\{/.test(t) || /Record<|Partial<|Pick<|Omit</.test(t)) props[prop] = {};
+    else if (/\bDate\b/.test(t)) props[prop] = { $raw: 'new Date()' }
+    else if (/ElementType|ComponentType|JSXElementConstructor/.test(t))
+      props[prop] = 'div'
+    else if (/React\.ReactNode|ReactElement/.test(t)) props[prop] = name
+    else if (/^string\b/.test(t)) props[prop] = name
+    else if (/^number\b/.test(t)) props[prop] = 0
+    else if (/^boolean\b/.test(t)) props[prop] = false
+    else if (/^\{/.test(t) || /Record<|Partial<|Pick<|Omit</.test(t))
+      props[prop] = {}
     // Fallback: required prop of unrecognized shape — `{}` is the least likely
     // to crash `.foo` access.
-    else props[prop] = {};
+    else props[prop] = {}
   }
-  return { props, variants };
+  return { props, variants }
 }
 
 // One-line JSDoc from the component's own declaration.
 export function jsdocFor(name, ctx) {
-  const decls = ctx.project?.getSourceFile(ctx.entry)?.getExportedDeclarations().get(name) ?? [];
-  const exp = decls.find((d) =>
-    Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
-  if (!exp || Node.isSourceFile(exp)) return '';
-  const doc = exp.getJsDocs?.()?.[0]?.getDescription()
-    ?? exp.getSymbol?.()?.compilerSymbol.getDocumentationComment?.(undefined)?.[0]?.text;
-  if (!doc) return '';
-  return doc.split('\n').find((l) => l.trim() && !l.trim().startsWith('@'))
-    ?.trim().replace(/\s+/g, ' ').replace(/[^\w\s.,()'/:+-]/g, '').slice(0, 140) ?? '';
+  const decls =
+    ctx.project
+      ?.getSourceFile(ctx.entry)
+      ?.getExportedDeclarations()
+      .get(name) ?? []
+  const exp =
+    decls.find(
+      (d) =>
+        Node.isVariableDeclaration(d) ||
+        Node.isFunctionDeclaration(d) ||
+        Node.isClassDeclaration(d),
+    ) ?? decls[0]
+  if (!exp || Node.isSourceFile(exp)) return ''
+  const doc =
+    exp.getJsDocs?.()?.[0]?.getDescription() ??
+    exp.getSymbol?.()?.compilerSymbol.getDocumentationComment?.(undefined)?.[0]
+      ?.text
+  if (!doc) return ''
+  return (
+    doc
+      .split('\n')
+      .find((l) => l.trim() && !l.trim().startsWith('@'))
+      ?.trim()
+      .replace(/\s+/g, ' ')
+      .replace(/[^\w\s.,()'/:+-]/g, '')
+      .slice(0, 140) ?? ''
+  )
 }

--- a/.design-sync/patch-sb-reference.mjs
+++ b/.design-sync/patch-sb-reference.mjs
@@ -1,0 +1,83 @@
+// Patches .design-sync/sb-reference/iframe.html so the compare harness can tell
+// that a story has rendered. Idempotent — safe to re-run.
+//
+// RUN THIS EVERY TIME THE REFERENCE STORYBOOK IS REBUILT:
+//   npx storybook build -c apps/storybook/.storybook -o .design-sync/sb-reference
+//   node .design-sync/patch-sb-reference.mjs
+//
+// Why it is needed
+// ---------------
+// compare.mjs decides a story is ready by waiting for
+//   :is(#storybook-root, #root) > :not(style,script,link,meta,template)
+// via playwright's waitForSelector, whose default state is 'visible'. Playwright
+// resolves that selector to its FIRST match and waits for THAT element to become
+// visible.
+//
+// Every story in this repo is wrapped by the .storybook/preview.tsx decorator in
+// <BaseProviders>, which renders three portal mount points around its children:
+//
+//   <div id="network-check-portal" />   <- FIRST child, always empty
+//   {children}
+//   <div id="popover-portal" />
+//   <div id="footer-portal" />
+//
+// So the first non-script child is an empty div with height 0 — never 'visible'.
+// waitForSelector times out on all 66 stories and compare reports
+// `sb-error: no storybook root content` for every one of them, even though the
+// stories render perfectly (verified by hand: #storybook-root has 1152 bytes of
+// HTML and innerText "Button" with zero page errors).
+//
+// compare.mjs already anticipates the shape of this problem — its comment notes
+// that "CSS-in-JS runtimes often inject <style>/<script> as the first root child
+// and waitForSelector locks onto the first match" — but its :not() list only
+// excludes style/script/link/meta/template, not an empty layout div. The harness
+// is the fidelity oracle and must not be forked, so the fix goes into the local
+// reference artifact instead.
+//
+// Why this is layout-neutral (and so does not distort the oracle)
+// -------------------------------------------------------------
+// The three divs are always empty and already contribute 0 height in normal
+// flow. `position: absolute` removes them from flow — no sibling moves — and the
+// 1x1 box makes them 'visible' to playwright. They have no background, border or
+// content, so they paint nothing and the screenshots are byte-comparable to an
+// unpatched render. Verified: root height for primitives-button--default is 40px
+// both with and without the patch.
+//
+// Portals opened by a story still work: radix/headless portals append their own
+// children to document.body or to these mounts, and an absolutely-positioned
+// mount does not clip descendants (no overflow:hidden is introduced).
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const iframe = join(here, 'sb-reference', 'iframe.html')
+
+const MARKER = 'ds-sync-portal-visibility'
+const STYLE = `<style id="${MARKER}">
+/* injected by .design-sync/patch-sb-reference.mjs — see that file for why */
+:is(#storybook-root, #root) > #network-check-portal,
+:is(#storybook-root, #root) > #popover-portal,
+:is(#storybook-root, #root) > #footer-portal {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+}
+</style>`
+
+let html = readFileSync(iframe, 'utf8')
+
+if (html.includes(`id="${MARKER}"`)) {
+  console.log('sb-reference already patched — nothing to do')
+  process.exit(0)
+}
+
+if (!html.includes('</head>')) {
+  console.error('✗ no </head> in', iframe, '— is this a storybook iframe.html?')
+  process.exit(1)
+}
+
+html = html.replace('</head>', `${STYLE}\n</head>`)
+writeFileSync(iframe, html)
+console.log('✓ patched', iframe)

--- a/.design-sync/tailwind.config.mjs
+++ b/.design-sync/tailwind.config.mjs
@@ -1,0 +1,38 @@
+// Tailwind config used ONLY to compile the design-sync stylesheet
+// (packages/ui/dist/design-sync.css, wired as cfg.cssEntry).
+//
+// Why this file exists rather than reusing apps/storybook/tailwind.config.js:
+// that config carries no `content` of its own and inherits the shared preset's
+// RELATIVE globs ('./components/**', '../../packages/ui/src/**'). Run through
+// the tailwindcss CLI those globs resolve to nothing — the scan reports
+// "Potential classes: 1" and the output contains the preflight and
+// react-datepicker rules but ZERO utilities, so every component ships
+// unstyled. Absolute globs fix it (same run: 33,923 candidates, 76 KB of
+// utilities). Storybook's own Vite/postcss pipeline resolves them fine, which
+// is why the reference build looks correct and only the CLI path breaks.
+//
+// The content list is the shared preset's own list resolved against
+// apps/storybook — deliberately IDENTICAL to what the reference storybook
+// scans, so previews and the storybook oracle have the same class vocabulary.
+// Note it does NOT include apps/storybook/stories/**: the preset omits it, so
+// classes used only inside story files are absent from the reference render
+// too. Adding them here would make previews render styling the oracle cannot,
+// turning a config choice into a fidelity mismatch.
+//
+// Paths derive from import.meta.url so the compile works from any cwd and on
+// any clone. The preset is imported by repo-relative path because this file
+// lives in .design-sync/, whose only node_modules is the converter-deps symlink.
+
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import sharedConfig from '../config/tailwindcss/index.js'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const storybookDir = join(repoRoot, 'apps/storybook')
+
+export default {
+  darkMode: 'class',
+  presets: [sharedConfig],
+  content: sharedConfig.content.map((glob) => resolve(storybookDir, glob)),
+  theme: { extend: {} },
+}

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,10 @@ package-lock.json
 
 # yarn lock file (we use pnpm)
 yarn.lock
+# design-sync (claude.ai/design)
+.ds-sync/
+ds-bundle/
+.design-sync/sb-reference/
+.design-sync/learnings/
+.design-sync/.cache/
+.design-sync/node_modules

--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,7 @@
       "coverage",
       "packages/graph-client/src/subgraphs/**/*.graphql",
       "packages/stellar",
+      ".design-sync/overrides",
       "apps/web/src/lib/wagmi/hooks/exploits/data/rp2-approvals.json",
       "**/*-env.d.ts",
       "**/*-cache.d.ts"


### PR DESCRIPTION
Imports the 33 storied components of `@sushiswap/ui` into a Claude Design project, so the design agent there builds UIs from our **real compiled components** instead of generic ones.

**Project:** https://claude.ai/design/p/f6c69bc8-5fa2-48c8-83b1-ba8192b43f13

All 33 components verified story-by-story against our own Storybook render — 66 stories, plus the 3 extra `TextField` variants the default capture cap would have skipped. Every story graded `match`. Validator exits 0; render check 33/33 with `bad: 0`.

## What's in this PR

Only sync inputs — no product code changes. Verified state lives in the project's uploaded `_ds_sync.json`, not in git.

| File | Why |
|---|---|
| `config.json` | converter config (pkg, provider, titleMap, cssEntry, extraEntries, storyImports) |
| `NOTES.md` | root causes, triaged warnings, and a **Re-sync risks** watch-list |
| `conventions.md` | prepended to the generated README; teaches the design agent our Tailwind vocabulary. Every class/token/export in it was validated against the built artifacts |
| `overrides/dts.mjs` | narrow converter fork (see below) |
| `ds-runtime-shim.mjs`, `ds-story-globals.mjs` | bundled into `_ds_bundle.js` |
| `tailwind.config.mjs`, `patch-sb-reference.mjs` | build/verification steps |

## Four problems, each of which had taken down the whole library

1. **0 components discovered** — `packages/ui/package.json` declares its `.d.ts` entry only under `exports['.'].types`; the converter reads only legacy top-level `types`. Fixed by a narrow fork, **deletable** once `packages/ui` gains `"types": "./dist/index.d.ts"`.
2. **`process is not defined` at bundle load** — `next/image` reads `process.env.__NEXT_IMAGE_OPTS` at module scope, so `window.SushiswapUi` was never assigned. Our Storybook hides this with `define: {'process.env': {}}`; the shipped bundle needs the shim inside it.
3. **`Invariant failed: Unsupported currency type`** — previews compile story code into a bundle separate from the components, so a token built by the story's copy of `sushi` failed `card.js`'s `instanceof EvmToken` check. Fixed by re-exporting the 4 `sushi` symbols the stories use so both sides share one class.
4. **All 66 stories reported `sb-error`** — `BaseProviders` renders an empty `#network-check-portal` div as its first child, and the compare harness waits for the *first* root child to become **visible**. Patched in the local reference artifact, verified layout-neutral (root height 40px patched and unpatched). The oracle itself is never forked.

## Known limitation (deliberate)

The shipped stylesheet is content-scanned: it carries the utilities our components use plus most common layout ones, but `p-8`, `gap-8`, `md:grid-cols-2`, `lg:px-8` are verifiably **absent**, and responsive variants exist only where the DS uses them. A safelist would give previews classes the reference Storybook's own CSS lacks, breaking the lockstep the compare oracle relies on and invalidating all 33 grades — so it needs safelist + a `--force` full re-verify in one run. `conventions.md` steers the agent accordingly; the tradeoff is recorded in `NOTES.md`.

## Two upstream bugs found (not fixed here)

- **`font-sans` is dead.** `config/tailwindcss/index.js` maps `fontFamily.sans` to `var(--font-inter)`, which nothing in the DS defines. Text is still Inter only because `index.css` sets it on `html, body`.
- **`pnpm install` fails without `TRADING_VIEW_GH_READ_TOKEN`** — the root `preinstall` hook hard-exits before dependency resolution.