### PR TITLE
fix(ui): handle unavailable token logo transforms

### DIFF
--- a/packages/ui/src/cloudinary.ts
+++ b/packages/ui/src/cloudinary.ts
@@ -43,14 +43,9 @@ export function cloudinaryLogoFetchLoader({
 export function cloudinaryLogoImageLoader({
   src,
   width,
-  quality: _quality,
+  quality,
 }: ImageLoaderProps) {
-  const params = [
-    'f_auto',
-    'c_limit',
-    `w_${width}`,
-    // `q_${quality || 'auto'}`
-  ]
+  const params = ['f_auto', 'c_limit', `w_${width}`, `q_${quality || 'auto'}`]
   return `https://cdn.sushi.com/image/upload/${params.join(
     ',',
   )}/${normalizeSrc(src)}`

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -35,28 +35,53 @@ const AvatarImage = React.forwardRef<
   AvatarImageProps
 >(({ className, width, src, onLoadingStatusChange }, ref) => {
   const _width = Number(width) ?? 40
+  const [directCdnFallbackSrc, setDirectCdnFallbackSrc] = React.useState<
+    string | null
+  >(null)
 
   const isAbsoluteUrl = /^https?:\/\//.test(src)
   const isCloudinaryUploadPath =
     src.startsWith('native-currency') || src.startsWith('tokens')
-  const loader = isAbsoluteUrl
-    ? cloudinaryLogoFetchLoader
-    : isCloudinaryUploadPath
-      ? cloudinaryLogoImageLoader
-      : undefined
+  const isUsingDirectCdnFallback = directCdnFallbackSrc === src
+  const imageSrc = isUsingDirectCdnFallback
+    ? `https://cdn.sushi.com/${src}`
+    : src
+  const loader = isUsingDirectCdnFallback
+    ? undefined
+    : isAbsoluteUrl
+      ? cloudinaryLogoFetchLoader
+      : isCloudinaryUploadPath
+        ? cloudinaryLogoImageLoader
+        : undefined
+
+  function handleLoadingStatusChange(
+    status: 'idle' | 'loading' | 'loaded' | 'error',
+  ) {
+    if (
+      status === 'error' &&
+      isCloudinaryUploadPath &&
+      !isUsingDirectCdnFallback
+    ) {
+      setDirectCdnFallbackSrc(src)
+      return
+    }
+
+    onLoadingStatusChange?.(status)
+  }
 
   return (
     <AvatarPrimitive.Image
-      src={loader ? loader({ src, width: _width }) : src}
+      src={loader ? loader({ src: imageSrc, width: _width }) : imageSrc}
       asChild
       ref={ref}
       className={classNames('aspect-square h-full w-full', className)}
-      onLoadingStatusChange={onLoadingStatusChange}
+      onLoadingStatusChange={handleLoadingStatusChange}
     >
       <Image
         loader={loader}
+        unoptimized={isUsingDirectCdnFallback}
         alt="avatar"
-        src={src}
+        src={imageSrc}
         width={_width}
         height={_width}
       />


### PR DESCRIPTION
## Summary

- include automatic quality in internal token logo transformations to avoid the broken Cloudinary browser variant
- retry internal logos from their direct CDN path when the optimized transformation fails
- preserve the existing fallback avatar when both requests fail

## Validation

- pnpm --filter @sushiswap/ui check
- Biome format and lint on touched files
- browser-like Chrome request returns 200 for the updated optimized URL
- direct fallback URL returns 200