### PR TITLE
fix(launchpad): stabilize live and portfolio data

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/portfolio/_ui/portfolio-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/portfolio/_ui/portfolio-page.tsx
@@ -52,10 +52,23 @@ function PnlValue({
   pnlPercent,
   large = false,
 }: {
-  pnlUsd: number
-  pnlPercent: number
+  pnlUsd: number | null
+  pnlPercent: number | null
   large?: boolean
 }) {
+  if (pnlUsd === null || pnlPercent === null) {
+    return (
+      <span
+        className={classNames(
+          'font-semibold tracking-tight text-perps-muted',
+          large ? 'text-lg' : 'text-sm',
+        )}
+      >
+        -
+      </span>
+    )
+  }
+
   return (
     <div
       className={classNames(

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_lib/use-launchpad-live-trades.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_lib/use-launchpad-live-trades.ts
@@ -276,8 +276,14 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
       })
     }
 
-    function handleReady() {
+    function handleReady(currentSource: EventSource): void {
+      if (disposed || source !== currentSource) return
       setStreamStatus('live')
+    }
+
+    function handleStreamError(currentSource: EventSource): void {
+      if (disposed || source !== currentSource) return
+      setStreamStatus('reconnecting')
     }
 
     function handleTradeUpsert(event: Event) {
@@ -362,8 +368,31 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
       )
       if (!payload || !isExpected(payload)) return
 
-      source?.close()
-      void refetchSnapshotAndReconnect(false, true)
+      const currentSource = source
+      const currentSynchronization = synchronization.current
+      if (!currentSource) return
+
+      void refreshActiveCandleSnapshots()
+        .then(({ synchronized }) => {
+          if (
+            synchronized ||
+            disposed ||
+            source !== currentSource ||
+            synchronization.current !== currentSynchronization
+          ) {
+            return
+          }
+          void refetchSnapshotAndReconnect(false, true)
+        })
+        .catch(() => {
+          if (
+            !disposed &&
+            source === currentSource &&
+            synchronization.current === currentSynchronization
+          ) {
+            void refetchSnapshotAndReconnect(false, true)
+          }
+        })
     }
 
     function handleMetricsUpdate(event: Event) {
@@ -416,9 +445,9 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
       source = nextSource
       sourceAfterCursor = streamCursor
 
-      nextSource.onopen = () => setStreamStatus('live')
-      nextSource.onerror = () => setStreamStatus('reconnecting')
-      nextSource.addEventListener('stream.ready', handleReady)
+      nextSource.onopen = () => handleReady(nextSource)
+      nextSource.onerror = () => handleStreamError(nextSource)
+      nextSource.addEventListener('stream.ready', () => handleReady(nextSource))
       nextSource.addEventListener('trade.upsert', handleTradeUpsert)
       nextSource.addEventListener('trade.remove', handleTradeRemove)
       nextSource.addEventListener('candle.update', handleCandleUpdate)

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_lib/use-launchpad-live-trades.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_lib/use-launchpad-live-trades.ts
@@ -46,6 +46,7 @@ const launchpadChainIdSchema = z.custom<LaunchpadChainId>(
   'Invalid launchpad chain ID',
 )
 const unsignedIntegerSchema = z.string().regex(/^(0|[1-9][0-9]*)$/)
+const closedStreamRetryDelay = ms('2s')
 const streamIdentitySchema = z.object({
   chainId: launchpadChainIdSchema,
   tokenAddress: evmAddressSchema,
@@ -242,6 +243,7 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
     let source: EventSource | undefined
     let sourceAfterCursor: string | undefined
     let snapshotRetryTimer: ReturnType<typeof setTimeout> | undefined
+    let closedStreamRetryTimer: ReturnType<typeof setTimeout> | undefined
     let candleSnapshotCursor: string | undefined
     let tradeSnapshotCursor: string | undefined
 
@@ -276,14 +278,46 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
       })
     }
 
+    function clearClosedStreamRetry(): void {
+      if (closedStreamRetryTimer === undefined) return
+      clearTimeout(closedStreamRetryTimer)
+      closedStreamRetryTimer = undefined
+    }
+
     function handleReady(currentSource: EventSource): void {
       if (disposed || source !== currentSource) return
+      clearClosedStreamRetry()
       setStreamStatus('live')
     }
 
-    function handleStreamError(currentSource: EventSource): void {
+    function handleStreamError(
+      currentSource: EventSource,
+      hasOpened: boolean,
+      streamCursor: string,
+      currentSynchronization: number,
+    ): void {
       if (disposed || source !== currentSource) return
-      setStreamStatus('reconnecting')
+      if (hasOpened) {
+        setStreamStatus('reconnecting')
+      }
+      if (closedStreamRetryTimer !== undefined) return
+
+      closedStreamRetryTimer = setTimeout(() => {
+        closedStreamRetryTimer = undefined
+        if (
+          disposed ||
+          source !== currentSource ||
+          currentSynchronization !== synchronization.current ||
+          currentSource.readyState !== EventSource.CLOSED
+        ) {
+          return
+        }
+
+        currentSource.close()
+        source = undefined
+        sourceAfterCursor = undefined
+        openStream(streamCursor, currentSynchronization)
+      }, closedStreamRetryDelay)
     }
 
     function handleTradeUpsert(event: Event) {
@@ -434,6 +468,7 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
         return
       }
 
+      clearClosedStreamRetry()
       const nextSource = new EventSource(
         launchpadEventsUrl({
           apiBaseUrl: SUSHI_DATA_API_HOST,
@@ -445,9 +480,20 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
       source = nextSource
       sourceAfterCursor = streamCursor
 
-      nextSource.onopen = () => handleReady(nextSource)
-      nextSource.onerror = () => handleStreamError(nextSource)
-      nextSource.addEventListener('stream.ready', () => handleReady(nextSource))
+      let hasOpened = false
+      const markReady = () => {
+        hasOpened = true
+        handleReady(nextSource)
+      }
+      nextSource.onopen = markReady
+      nextSource.onerror = () =>
+        handleStreamError(
+          nextSource,
+          hasOpened,
+          streamCursor,
+          currentSynchronization,
+        )
+      nextSource.addEventListener('stream.ready', markReady)
       nextSource.addEventListener('trade.upsert', handleTradeUpsert)
       nextSource.addEventListener('trade.remove', handleTradeRemove)
       nextSource.addEventListener('candle.update', handleCandleUpdate)
@@ -475,6 +521,7 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
         source.close()
         source = undefined
         sourceAfterCursor = undefined
+        clearClosedStreamRetry()
       }
 
       openStream(streamCursor, currentSynchronization)
@@ -517,6 +564,7 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
       source?.close()
       source = undefined
       sourceAfterCursor = undefined
+      clearClosedStreamRetry()
       tradeSnapshotCursor = undefined
       if (refetchCandles) {
         candleSnapshotCursor = undefined
@@ -625,6 +673,7 @@ export function useLaunchpadLiveTrades(input: LaunchpadTradesInput) {
       if (snapshotRetryTimer !== undefined) {
         clearTimeout(snapshotRetryTimer)
       }
+      clearClosedStreamRetry()
       unsubscribeCandleSnapshot()
       source?.close()
     }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/datafeed.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/datafeed.test.ts
@@ -27,6 +27,7 @@ import { createLaunchpadDatafeed, getLaunchpadChartSymbol } from './datafeed'
 const CHAIN_ID = 4663
 const TOKEN_ADDRESS = '0x1111111111111111111111111111111111111111'
 const RESOLUTION = '60' as ResolutionString
+const FIVE_MINUTE_RESOLUTION = '5' as ResolutionString
 const ONE_MINUTE_RESOLUTION = '1' as ResolutionString
 const MARKET_CAP_MULTIPLIER = 1_000
 const PRICESCALES = {
@@ -73,6 +74,35 @@ function createSnapshot(
 }
 
 describe('launchpad TradingView datafeed', () => {
+  it('caps and aligns candle requests to 2,000 buckets', async () => {
+    const to = 1_785_841_500
+    const from = to - 600_307
+    mocks.getLaunchpadCandles.mockReset().mockResolvedValue({
+      streamCursor: '40',
+      nodes: [],
+    })
+    const datafeed = createLaunchpadDatafeed(DATAFEED_OPTIONS)
+
+    await new Promise<Bar[]>((resolve, reject) => {
+      datafeed.getBars(
+        SYMBOL_INFO,
+        FIVE_MINUTE_RESOLUTION,
+        { from, to, countBack: 2_001, firstDataRequest: true },
+        resolve,
+        reject,
+      )
+    })
+
+    expect(mocks.getLaunchpadCandles).toHaveBeenCalledOnce()
+    expect(mocks.getLaunchpadCandles).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        interval: 'FIVE_MINUTES',
+        from: 1_785_241_500,
+        to,
+      }),
+    })
+  })
+
   it('does not synthesize candles for no-trade intervals', async () => {
     const datafeed = createLaunchpadDatafeed(DATAFEED_OPTIONS)
     const symbolInfo = await new Promise<LibrarySymbolInfo>((resolve) => {
@@ -175,7 +205,7 @@ describe('launchpad TradingView datafeed', () => {
     expect(mocks.getLaunchpadCandles).toHaveBeenNthCalledWith(2, {
       input: expect.objectContaining({
         interval: 'ONE_MINUTE',
-        from: to - 2_000 * 60,
+        from: Math.ceil((to - 2_000 * 60) / 60) * 60,
         to,
       }),
     })
@@ -228,7 +258,7 @@ describe('launchpad TradingView datafeed', () => {
     expect(mocks.getLaunchpadCandles).toHaveBeenNthCalledWith(2, {
       input: expect.objectContaining({
         interval: 'ONE_MINUTE',
-        from: currentCandle.timestamp - 2_000 * 60,
+        from: Math.ceil((currentCandle.timestamp - 2_000 * 60) / 60) * 60,
         to: currentCandle.timestamp,
       }),
     })
@@ -268,7 +298,9 @@ describe('launchpad TradingView datafeed', () => {
     expect(mocks.getLaunchpadCandles).toHaveBeenNthCalledWith(3, {
       input: expect.objectContaining({
         interval: 'ONE_DAY',
-        from: to - 2_000 * 24 * 60 * 60,
+        from:
+          Math.ceil((to - 2_000 * 24 * 60 * 60) / (24 * 60 * 60)) *
+          (24 * 60 * 60),
         to,
       }),
     })
@@ -379,7 +411,11 @@ describe('launchpad TradingView datafeed', () => {
     expect(resetResult.streamCursor).toBe('50')
     expect(mocks.getLaunchpadCandles).toHaveBeenCalledTimes(4)
     expect(mocks.getLaunchpadCandles).toHaveBeenLastCalledWith({
-      input: expect.objectContaining({ fresh: true, from, to }),
+      input: expect.objectContaining({
+        fresh: true,
+        from: Math.floor(from / (60 * 60)) * (60 * 60),
+        to,
+      }),
     })
     expect(onReset).toHaveBeenCalledTimes(2)
     expect(onResetData).toHaveBeenCalledOnce()

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/datafeed.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/datafeed.ts
@@ -36,6 +36,20 @@ const SUPPORTED_RESOLUTIONS = [
 const MAX_CANDLES_PER_REQUEST = 2_000
 const ONE_DAY_SECONDS = 24 * 60 * 60
 
+function getCandleRequestFrom(
+  from: number,
+  to: number,
+  intervalSeconds: number,
+): number {
+  const alignedFrom = Math.floor(from / intervalSeconds) * intervalSeconds
+  const earliestAllowedFrom =
+    Math.ceil(
+      (to - intervalSeconds * MAX_CANDLES_PER_REQUEST) / intervalSeconds,
+    ) * intervalSeconds
+
+  return Math.max(alignedFrom, earliestAllowedFrom)
+}
+
 const RESOLUTION_CONFIG = new Map<
   ResolutionString,
   {
@@ -226,13 +240,15 @@ export function createLaunchpadDatafeed({
     from: number
     to: number
   }): Promise<LaunchpadCandleSnapshot> {
-    const { interval, streamInterval } = getResolutionConfig(resolution)
+    const { interval, seconds, streamInterval } =
+      getResolutionConfig(resolution)
+    const requestFrom = getCandleRequestFrom(from, to, seconds)
     const response = await getLaunchpadCandles({
       input: {
         chainId,
         tokenAddress,
         interval,
-        from,
+        from: requestFrom,
         to,
         ...(fresh ? { fresh: true } : {}),
       },
@@ -245,7 +261,7 @@ export function createLaunchpadDatafeed({
 
     const currentSnapshot = snapshots.get(resolution)
     if (!currentSnapshot || to >= currentSnapshot.to) {
-      snapshots.set(resolution, { from, snapshot, to })
+      snapshots.set(resolution, { from: requestFrom, snapshot, to })
     }
     publishLaunchpadCandleSnapshot(streamIdentity, snapshot.streamCursor)
     return snapshot

--- a/packages/graph-client/src/subgraphs/data-api/schema.graphql
+++ b/packages/graph-client/src/subgraphs/data-api/schema.graphql
@@ -106,15 +106,16 @@ type LaunchpadUserStats {
 
   """
   Current holdings value plus indexed sell proceeds, minus indexed buy cost
-  across both open and fully exited launchpad positions.
+  across both open and fully exited launchpad positions. Null when any position
+  has no indexed cost basis.
   """
-  totalPnlUsd: Float!
+  totalPnlUsd: Float
 
   """
   Total PnL divided by gross indexed buy cost across both open and fully exited
-  launchpad positions. Returns zero without USD cost.
+  launchpad positions. Null when any position has no indexed cost basis.
   """
-  totalPnlPercent: Float!
+  totalPnlPercent: Float
   totalHoldingsUsd: Float!
 }
 
@@ -126,13 +127,14 @@ type LaunchpadUserHolding {
 
   """
   Current holding value plus indexed sell proceeds, minus indexed buy cost.
+  Null when the acquisition has no indexed USD cost basis yet.
   """
-  pnlUsd: Float!
+  pnlUsd: Float
 
   """
-  Token PnL divided by gross indexed buy cost. Returns zero without USD cost.
+  Token PnL divided by gross indexed buy cost. Null without indexed USD cost.
   """
-  pnlPercent: Float!
+  pnlPercent: Float
 }
 
 type LaunchpadUserHoldingToken {


### PR DESCRIPTION
## Summary
- refresh active candle snapshots in place on `candle.reset` without replacing a healthy trade stream
- cap and bucket-align every candle request to the API limit of 2,000 intervals
- explicitly retry a terminally closed initial `EventSource`, covering the window before a new launch is confirmed and stream-visible
- preserve native browser retries for transient connections and fall back to full synchronization when candle refresh fails
- prepare portfolio PnL fields for nullable cost basis and render unavailable PnL as `-`

## Context
Production investigation found two independent live-data paths:

1. A five-minute candle request covered 2,001 aligned buckets and exceeded the backend 600,000-second limit.
2. Newly projected launches can return an initial stream 404 until they become confirmed and visible. A terminal initial EventSource failure previously required a page refresh.

Separately, `candle.reset` was closing a healthy shared SSE connection and causing the UI to bootstrap a new one. The portfolio schema update prepares the client for a future API change where PnL is null until indexed USD cost basis is available.

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm --filter @sushiswap/graph-client check`
- launchpad datafeed and stream unit tests (15 passing)

The full web typecheck is currently blocked by an unrelated `master` error: `send-token-dialog.tsx` imports `isAddressEqual` from `sushi`, where it is no longer exported.