### PR TITLE
feat(launchpad): support EIP-1271 metadata signatures

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-metadata.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-metadata.test.ts
@@ -5,6 +5,7 @@ import {
   LAUNCHPAD_METADATA_DESCRIPTION_MAX_BYTES,
   buildLaunchpadMetadataDocument,
   buildUpdateMetadataTypedData,
+  canSubmitLaunchpadMetadataSignature,
   launchpadMetadataDescriptionSchema,
 } from './launchpad-metadata'
 
@@ -61,5 +62,36 @@ describe('launchpad metadata signature', () => {
         }),
       ),
     ).toBe('0xfd81f1275045fa6ac852a1715497231403a4032c663aa6d3d3b7c85987f3f0e8')
+  })
+
+  it('allows the creator or a signer for a deployed contract creator', () => {
+    const creatorAddress = '0x1111111111111111111111111111111111111111'
+    const connectedAddress = '0x2222222222222222222222222222222222222222'
+
+    expect(
+      canSubmitLaunchpadMetadataSignature({
+        connectedAddress: creatorAddress,
+        creatorAddress,
+      }),
+    ).toBe(true)
+    expect(
+      canSubmitLaunchpadMetadataSignature({
+        connectedAddress,
+        creatorAddress,
+      }),
+    ).toBe(false)
+    expect(
+      canSubmitLaunchpadMetadataSignature({
+        connectedAddress,
+        creatorAddress,
+        creatorBytecode: '0x6000',
+      }),
+    ).toBe(true)
+    expect(
+      canSubmitLaunchpadMetadataSignature({
+        creatorAddress,
+        creatorBytecode: '0x6000',
+      }),
+    ).toBe(false)
   })
 })

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-metadata.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-metadata.ts
@@ -1,6 +1,6 @@
 import { updateLaunchpadMetadata } from '@sushiswap/graph-client/data-api'
 import type { EvmAddress } from 'sushi/evm'
-import { type Hex, sha256, zeroHash } from 'viem'
+import { type Hex, isAddressEqual, sha256, zeroHash } from 'viem'
 import { z } from 'zod'
 import type { LaunchpadChainId } from '../constants'
 import { prepareLaunchpadLogoFile } from './launchpad-logo'
@@ -37,6 +37,19 @@ export interface LaunchpadMetadataFormValues {
   homepage: string
   x: string
   telegram: string
+}
+
+export function canSubmitLaunchpadMetadataSignature(input: {
+  connectedAddress?: EvmAddress
+  creatorAddress: EvmAddress
+  creatorBytecode?: Hex
+}): boolean {
+  if (!input.connectedAddress) return false
+
+  return (
+    isAddressEqual(input.connectedAddress, input.creatorAddress) ||
+    Boolean(input.creatorBytecode && input.creatorBytecode !== '0x')
+  )
 }
 
 const metadataTypes = {

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/create/_ui/create-launch-review-step.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/create/_ui/create-launch-review-step.tsx
@@ -111,7 +111,12 @@ export function CreateLaunchReviewStep({
           <div className="text-sm font-semibold text-perps-muted">
             Ready to launch
           </div>
-          {launchedTokenAddress && !isWaitingForIndexing && tokenHref ? (
+          {isWaitingForIndexing ? (
+            <>
+              Waiting for indexing
+              <Dots />
+            </>
+          ) : launchedTokenAddress && tokenHref ? (
             <Button
               asChild
               fullWidth
@@ -152,6 +157,7 @@ export function CreateLaunchReviewStep({
                     initialBuyAmountRaw !== undefined &&
                     initialBuyAmountRaw > 0n
                   }
+                  variant="perps-default"
                 >
                   <Button
                     type="button"
@@ -168,16 +174,7 @@ export function CreateLaunchReviewStep({
                     }
                     onClick={onOpenLegalDialog}
                   >
-                    {isWaitingForIndexing ? (
-                      <>
-                        Waiting for indexing
-                        <Dots />
-                      </>
-                    ) : isLaunching ? (
-                      'Creating token…'
-                    ) : (
-                      'Create token'
-                    )}
+                    {isLaunching ? 'Creating token…' : 'Create token'}
                   </Button>
                 </Checker.ApproveERC20>
               </Checker.Network>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
@@ -80,6 +80,21 @@ type MetadataForm = z.infer<typeof metadataSchema>
 
 const SAVED_STATUS_DURATION_MS = ms('3s')
 
+const METADATA_GUARD_TEXT = {
+  pending: 'Checking creator',
+  unknown: 'Creator check failed',
+  contract: 'Connect authorized wallet',
+  eoa: 'Connect creator wallet',
+} as const
+
+const METADATA_SIGNER_ERROR = {
+  pending: 'Still checking the creator address, try again in a moment',
+  unknown:
+    'Could not check whether the creator is a contract, reload and try again',
+  contract: 'Connect a wallet authorized by the creator contract first',
+  eoa: 'Connect the creator wallet first',
+} as const
+
 export function ManageTokenPage({
   chainId,
   address,
@@ -99,7 +114,11 @@ export function ManageTokenPage({
     isPending,
     refetch,
   } = useLaunchpadToken(chainId, address)
-  const { data: creatorBytecode } = useBytecode({
+  const {
+    data: creatorBytecode,
+    isLoading: isCreatorBytecodeLoading,
+    isError: isCreatorBytecodeError,
+  } = useBytecode({
     address: token?.creator,
     chainId,
     query: {
@@ -114,6 +133,13 @@ export function ManageTokenPage({
       })
     : false
   const isContractCreator = Boolean(creatorBytecode && creatorBytecode !== '0x')
+  const creatorKind = isCreatorBytecodeLoading
+    ? 'pending'
+    : isCreatorBytecodeError
+      ? 'unknown'
+      : isContractCreator
+        ? 'contract'
+        : 'eoa'
   const {
     data: distributionSimulation,
     isError: isDistributionSimulationError,
@@ -181,11 +207,7 @@ export function ManageTokenPage({
     try {
       if (!token) throw new Error('Launch token is no longer available')
       if (!connectedAddress || !canSubmitMetadataSignature) {
-        throw new Error(
-          isContractCreator
-            ? 'Connect a wallet authorized by the creator contract first'
-            : 'Connect the creator wallet first',
-        )
+        throw new Error(METADATA_SIGNER_ERROR[creatorKind])
       }
       if (connectedChainId !== chainId) {
         throw new Error(
@@ -496,11 +518,7 @@ export function ManageTokenPage({
                   >
                     <Checker.Guard
                       guardWhen={!canSubmitMetadataSignature}
-                      guardText={
-                        isContractCreator
-                          ? 'Connect authorized wallet'
-                          : 'Connect creator wallet'
-                      }
+                      guardText={METADATA_GUARD_TEXT[creatorKind]}
                       fullWidth={false}
                       size="lg"
                       type="button"
@@ -561,9 +579,11 @@ export function ManageTokenPage({
               {token.creator}
             </p>
             <p className="mt-3 text-xs leading-5 text-perps-muted-50">
+              The backend verifies this immutable address independently for
+              every metadata and logo signature
               {isContractCreator
-                ? 'This contract verifies metadata and logo signatures through EIP-1271.'
-                : 'The backend verifies this immutable address independently for every metadata and logo signature.'}
+                ? ', including EIP-1271 signatures if this contract supports them.'
+                : '.'}
             </p>
           </PerpsCard>
         </div>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
@@ -33,8 +33,8 @@ import { Checker } from 'src/lib/wagmi/systems/Checker'
 import { formatPercent } from 'sushi'
 import type { EvmAddress } from 'sushi/evm'
 import { getEvmChainById } from 'sushi/evm'
-import { isAddressEqual } from 'viem'
 import {
+  useBytecode,
   useConnection,
   usePublicClient,
   useSignTypedData,
@@ -50,6 +50,7 @@ import {
 } from '../../../_lib/launchpad-contract'
 import type { PreparedLaunchpadLogoFile } from '../../../_lib/launchpad-logo'
 import {
+  canSubmitLaunchpadMetadataSignature,
   launchpadMetadataDescriptionSchema,
   saveLaunchpadMetadata,
 } from '../../../_lib/launchpad-metadata'
@@ -98,6 +99,21 @@ export function ManageTokenPage({
     isPending,
     refetch,
   } = useLaunchpadToken(chainId, address)
+  const { data: creatorBytecode } = useBytecode({
+    address: token?.creator,
+    chainId,
+    query: {
+      enabled: Boolean(token),
+    },
+  })
+  const canSubmitMetadataSignature = token
+    ? canSubmitLaunchpadMetadataSignature({
+        connectedAddress,
+        creatorAddress: token.creator,
+        creatorBytecode,
+      })
+    : false
+  const isContractCreator = Boolean(creatorBytecode && creatorBytecode !== '0x')
   const {
     data: distributionSimulation,
     isError: isDistributionSimulationError,
@@ -164,9 +180,12 @@ export function ManageTokenPage({
 
     try {
       if (!token) throw new Error('Launch token is no longer available')
-      if (!connectedAddress) throw new Error('Connect the creator wallet first')
-      if (!isAddressEqual(connectedAddress, token.creator)) {
-        throw new Error('Connect the creator wallet first')
+      if (!connectedAddress || !canSubmitMetadataSignature) {
+        throw new Error(
+          isContractCreator
+            ? 'Connect a wallet authorized by the creator contract first'
+            : 'Connect the creator wallet first',
+        )
       }
       if (connectedChainId !== chainId) {
         throw new Error(
@@ -181,7 +200,8 @@ export function ManageTokenPage({
         expectedRevision: token.metadata.revision,
         values,
         logoFile: logo?.file,
-        signTypedData: (typedData) => signTypedDataAsync(typedData),
+        signTypedData: (typedData) =>
+          signTypedDataAsync({ ...typedData, account: connectedAddress }),
       })
       await refetch()
       setSaved(true)
@@ -475,11 +495,12 @@ export function ManageTokenPage({
                     hideChainName
                   >
                     <Checker.Guard
-                      guardWhen={
-                        !connectedAddress ||
-                        !isAddressEqual(connectedAddress, token.creator)
+                      guardWhen={!canSubmitMetadataSignature}
+                      guardText={
+                        isContractCreator
+                          ? 'Connect authorized wallet'
+                          : 'Connect creator wallet'
                       }
-                      guardText="Connect creator wallet"
                       fullWidth={false}
                       size="lg"
                       type="button"
@@ -540,8 +561,9 @@ export function ManageTokenPage({
               {token.creator}
             </p>
             <p className="mt-3 text-xs leading-5 text-perps-muted-50">
-              The backend verifies this immutable address independently for
-              every metadata and logo signature.
+              {isContractCreator
+                ? 'This contract verifies metadata and logo signatures through EIP-1271.'
+                : 'The backend verifies this immutable address independently for every metadata and logo signature.'}
             </p>
           </PerpsCard>
         </div>


### PR DESCRIPTION
## Summary

- detect deployed contract creators before applying the frontend signer gate
- allow authorized connected accounts to produce opaque EIP-1271 signatures while preserving strict EOA creator matching
- pass the connected signing account explicitly and show contract-wallet-specific authorization messaging

## Validation

- pnpm --filter web test:unit --run src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-metadata.test.ts
- pnpm --filter web check
- Biome check on the three touched files