### PR TITLE
feat(web): redesign V3 pool depth charts

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/area.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/area.test.ts
@@ -1,0 +1,36 @@
+import { scaleLinear } from 'd3'
+import { describe, expect, it } from 'vitest'
+import { prepareSeriesForRendering } from './area'
+
+const xScale = scaleLinear().domain([0, 10]).range([0, 100])
+
+describe('prepareSeriesForRendering', () => {
+  it('extends a final positive step to the visible right boundary', () => {
+    expect(
+      prepareSeriesForRendering(
+        [{ activeLiquidity: 10, price0: 4 }],
+        xScale,
+        (entry) => entry.price0,
+      ),
+    ).toEqual([
+      { activeLiquidity: 10, price0: 4 },
+      { activeLiquidity: 10, price0: 10 },
+    ])
+  })
+
+  it('uses an off-screen zero-liquidity point to close the visible step', () => {
+    expect(
+      prepareSeriesForRendering(
+        [
+          { activeLiquidity: 10, price0: 4 },
+          { activeLiquidity: 0, price0: 20 },
+        ],
+        xScale,
+        (entry) => entry.price0,
+      ),
+    ).toEqual([
+      { activeLiquidity: 10, price0: 4 },
+      { activeLiquidity: 0, price0: 10 },
+    ])
+  })
+})

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/area.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/area.tsx
@@ -30,7 +30,7 @@ interface AreaProps {
  * - Clamp x-coordinates to [minX, maxX] so steps fill the visible area properly
  *   (also avoids issues with very large numbers that may not render correctly)
  */
-function prepareSeriesForRendering(
+export function prepareSeriesForRendering(
   series: ChartEntry[],
   xScale: ScaleLinear<number, number>,
   xValue: (d: ChartEntry) => number,
@@ -60,12 +60,19 @@ function prepareSeriesForRendering(
 
   // Slice and clamp x-coordinates to [minX, maxX]
   // This avoids rendering issues with very large numbers (scientific notation, etc.)
-  return series.slice(startIdx, endIdx).map((d) => {
+  const preparedSeries = series.slice(startIdx, endIdx).map((d) => {
     return {
       ...d,
       price0: Math.min(maxX, Math.max(d.price0, minX)),
     }
   })
+
+  const lastEntry = preparedSeries.at(-1)
+  if (lastEntry && lastEntry.price0 < maxX) {
+    preparedSeries.push({ ...lastEntry, price0: maxX })
+  }
+
+  return preparedSeries
 }
 
 export const Area: FC<AreaProps> = ({

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/hooks.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/hooks.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { getDensityChartData } from './hooks'
+
+describe('getDensityChartData', () => {
+  it('preserves zero-liquidity entries that close a range', () => {
+    expect(
+      getDensityChartData([
+        {
+          tick: 100,
+          liquidityActive: 10n,
+          liquidityNet: 10n,
+          price0: '1',
+        },
+        {
+          tick: 200,
+          liquidityActive: 0n,
+          liquidityNet: -10n,
+          price0: '2',
+        },
+      ]),
+    ).toEqual([
+      { activeLiquidity: 10, price0: 1 },
+      { activeLiquidity: 0, price0: 2 },
+    ])
+  })
+
+  it('drops invalid negative active liquidity', () => {
+    expect(
+      getDensityChartData([
+        {
+          tick: 100,
+          liquidityActive: -1n,
+          liquidityNet: 0n,
+          price0: '1',
+        },
+      ]),
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/hooks.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/_ui/LiquidityChartRangeInput/hooks.ts
@@ -18,6 +18,17 @@ interface UseDensityChartData {
   enabled?: boolean
 }
 
+export function getDensityChartData(data: TickProcessed[]): ChartEntry[] {
+  return data.flatMap((tick) => {
+    const chartEntry = {
+      activeLiquidity: Number.parseFloat(tick.liquidityActive.toString()),
+      price0: Number.parseFloat(tick.price0),
+    }
+
+    return chartEntry.activeLiquidity >= 0 ? [chartEntry] : []
+  })
+}
+
 export function useDensityChartData({
   chainId,
   token0,
@@ -37,23 +48,9 @@ export function useDensityChartData({
     const data = activeLiquidity.data
     if (!data) return activeLiquidity
 
-    const newData: ChartEntry[] = []
-    for (let i = 0; i < data.length; i++) {
-      const t: TickProcessed = data[i]
-
-      const chartEntry = {
-        activeLiquidity: Number.parseFloat(t.liquidityActive.toString()),
-        price0: Number.parseFloat(t.price0),
-      }
-
-      if (chartEntry.activeLiquidity > 0) {
-        newData.push(chartEntry)
-      }
-    }
-
     return {
       ...activeLiquidity,
-      data: newData,
+      data: getDensityChartData(data),
     }
   }, [activeLiquidity])
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/_ui/pool-chart-graph.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/_ui/pool-chart-graph.tsx
@@ -41,6 +41,7 @@ interface PoolChartProps {
   period: PoolChartPeriod
   pool: RawV2Pool | V2Pool | RawV3Pool | V3Pool | BladePool
   protocol: SushiSwapProtocol
+  height?: number
 }
 
 const tailwind = resolveConfig(tailwindConfig)
@@ -59,6 +60,7 @@ export const PoolChartGraph: FC<PoolChartProps> = ({
   period,
   pool,
   protocol,
+  height = 400,
 }) => {
   const {
     data: buckets,
@@ -268,16 +270,17 @@ export const PoolChartGraph: FC<PoolChartProps> = ({
         {isLoading ? (
           <SkeletonBox
             className={classNames(
-              'h-[400px] w-full dark:via-slate-800 dark:to-slate-900',
+              'w-full dark:via-slate-800 dark:to-slate-900',
             )}
+            style={{ height }}
           />
         ) : isError ? (
-          <div className="h-[400px] w-full" />
+          <div className="w-full" style={{ height }} />
         ) : (
           <ReactEchartsCore
             echarts={echarts}
             option={DEFAULT_OPTION}
-            style={{ height: 400 }}
+            style={{ height }}
           />
         )}
       </CardContent>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildPoolDepthData } from './depth-chart'
+import {
+  buildPoolDepthData,
+  getInitialVisibleSteps,
+  getNextVisibleSteps,
+} from './depth-chart'
 
 describe('buildPoolDepthData', () => {
   it('builds cumulative sell and buy depth around the current price', () => {
@@ -58,5 +62,37 @@ describe('buildPoolDepthData', () => {
         token1Decimals: 18,
       }),
     ).toEqual({ sell: [], buy: [] })
+  })
+})
+
+describe('depth chart zoom', () => {
+  it('shows every point by default for sparse pools', () => {
+    expect(getInitialVisibleSteps(3)).toBe(3)
+    expect(getInitialVisibleSteps(8)).toBe(8)
+    expect(getInitialVisibleSteps(10)).toBe(4)
+  })
+
+  it('always changes the visible range when zooming is available', () => {
+    expect(
+      getNextVisibleSteps({
+        visibleSteps: 2,
+        maxSteps: 10,
+        direction: 'in',
+      }),
+    ).toBe(1)
+    expect(
+      getNextVisibleSteps({
+        visibleSteps: 2,
+        maxSteps: 10,
+        direction: 'out',
+      }),
+    ).toBe(3)
+    expect(
+      getNextVisibleSteps({
+        visibleSteps: 9,
+        maxSteps: 10,
+        direction: 'out',
+      }),
+    ).toBe(10)
   })
 })

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { buildPoolDepthData } from './depth-chart'
+
+describe('buildPoolDepthData', () => {
+  it('builds cumulative sell and buy depth around the current price', () => {
+    const result = buildPoolDepthData({
+      series: [
+        { activeLiquidity: 100, price0: 1 },
+        { activeLiquidity: 200, price0: 2 },
+        { activeLiquidity: 0, price0: 4 },
+      ],
+      currentPrice: 2.5,
+      token0Decimals: 18,
+      token1Decimals: 18,
+    })
+
+    expect(
+      result.sell.map(({ logicalIndex, price }) => ({ logicalIndex, price })),
+    ).toEqual([
+      { logicalIndex: -2, price: 1 },
+      { logicalIndex: -1, price: 2 },
+      { logicalIndex: 0, price: 2.5 },
+    ])
+    expect(
+      result.buy.map(({ logicalIndex, price }) => ({ logicalIndex, price })),
+    ).toEqual([
+      { logicalIndex: 0, price: 2.5 },
+      { logicalIndex: 1, price: 4 },
+    ])
+    expect(result.sell[0].depth).toBeGreaterThan(result.sell[1].depth)
+    expect(result.buy[1].depth).toBeGreaterThan(0)
+  })
+
+  it('keeps the two sides evenly spaced regardless of price magnitude', () => {
+    const result = buildPoolDepthData({
+      series: [
+        { activeLiquidity: 100, price0: 41_000_000 },
+        { activeLiquidity: 100, price0: 43_000_000 },
+        { activeLiquidity: 0, price0: 389_000_000 },
+      ],
+      currentPrice: 44_000_000,
+      token0Decimals: 18,
+      token1Decimals: 18,
+    })
+
+    expect(result.sell.map(({ logicalIndex }) => logicalIndex)).toEqual([
+      -2, -1, 0,
+    ])
+    expect(result.buy.map(({ logicalIndex }) => logicalIndex)).toEqual([0, 1])
+  })
+
+  it('returns empty sides when the current range cannot be identified', () => {
+    expect(
+      buildPoolDepthData({
+        series: [{ activeLiquidity: 100, price0: 2 }],
+        currentPrice: 1,
+        token0Decimals: 18,
+        token1Decimals: 18,
+      }),
+    ).toEqual({ sell: [], buy: [] })
+  })
+})

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
@@ -13,15 +13,14 @@ import React, {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import type { ChartEntry } from '~evm/[chainId]/_ui/LiquidityChartRangeInput/types'
 
-const CHART_WIDTH = 600
-const CHART_HEIGHT = 320
-const MARGIN = { top: 18, right: 68, bottom: 38, left: 16 }
-const INNER_WIDTH = CHART_WIDTH - MARGIN.left - MARGIN.right
-const INNER_HEIGHT = CHART_HEIGHT - MARGIN.top - MARGIN.bottom
+const DEFAULT_CHART_WIDTH = 600
+const DEFAULT_CHART_HEIGHT = 380
+const MARGIN = { top: 18, right: 16, bottom: 38, left: 16 }
 const SELL_COLOR = '#22c55e'
 const BUY_COLOR = '#ef4444'
 
@@ -224,6 +223,13 @@ export function DepthChart({
   token1Decimals,
 }: DepthChartProps) {
   const id = useId().replaceAll(':', '')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [{ width: chartWidth, height: chartHeight }, setChartSize] = useState({
+    width: DEFAULT_CHART_WIDTH,
+    height: DEFAULT_CHART_HEIGHT,
+  })
+  const innerWidth = Math.max(1, chartWidth - MARGIN.left - MARGIN.right)
+  const innerHeight = Math.max(1, chartHeight - MARGIN.top - MARGIN.bottom)
   const data = useMemo(
     () =>
       buildPoolDepthData({
@@ -243,6 +249,19 @@ export function DepthChart({
     setVisibleSteps(initialVisibleSteps)
   }, [initialVisibleSteps])
 
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      setChartSize({ width, height })
+    })
+    observer.observe(container)
+
+    return () => observer.disconnect()
+  }, [])
+
   const visibleData = useMemo(
     () => ({
       sell: data.sell.filter(
@@ -259,8 +278,8 @@ export function DepthChart({
     () =>
       scaleLinear()
         .domain([-visibleSteps - 0.5, visibleSteps + 0.5])
-        .range([0, INNER_WIDTH]),
-    [visibleSteps],
+        .range([0, innerWidth]),
+    [innerWidth, visibleSteps],
   )
   const maxDepth =
     max([...visibleData.sell, ...visibleData.buy], ({ depth }) => depth) ?? 0
@@ -268,9 +287,9 @@ export function DepthChart({
     () =>
       scaleLinear()
         .domain([0, maxDepth > 0 ? maxDepth * 1.08 : 1])
-        .range([INNER_HEIGHT, 0])
+        .range([innerHeight, 0])
         .nice(),
-    [maxDepth],
+    [innerHeight, maxDepth],
   )
 
   const createArea = useCallback(
@@ -278,9 +297,9 @@ export function DepthChart({
       area<DepthPoint>()
         .curve(curveStepAfter)
         .x(({ logicalIndex }) => xScale(logicalIndex))
-        .y0(INNER_HEIGHT)
+        .y0(innerHeight)
         .y1(({ depth }) => yScale(depth))(points) ?? undefined,
-    [xScale, yScale],
+    [innerHeight, xScale, yScale],
   )
   const renderData = useMemo(() => {
     const leftEdge = -visibleSteps - 0.5
@@ -302,7 +321,6 @@ export function DepthChart({
   const sellPath = createArea(renderData.sell)
   const buyPath = createArea(renderData.buy)
   const axisPoints = getAxisPoints(visibleData.sell, visibleData.buy)
-  const yTicks = yScale.ticks(4).filter((tick) => tick > 0)
   const interactivePoints = [...visibleData.sell, ...visibleData.buy].filter(
     ({ logicalIndex }) => logicalIndex !== 0,
   )
@@ -312,7 +330,7 @@ export function DepthChart({
       if (interactivePoints.length === 0) return
       const bounds = event.currentTarget.getBoundingClientRect()
       const chartX =
-        ((event.clientX - bounds.left) / bounds.width) * CHART_WIDTH -
+        ((event.clientX - bounds.left) / bounds.width) * chartWidth -
         MARGIN.left
       const logicalIndex = xScale.invert(chartX)
       const nearest = interactivePoints.reduce((closest, point) =>
@@ -323,7 +341,7 @@ export function DepthChart({
       )
       setHoveredPoint(nearest)
     },
-    [interactivePoints, xScale],
+    [chartWidth, interactivePoints, xScale],
   )
 
   const hoverX = hoveredPoint ? xScale(hoveredPoint.logicalIndex) : null
@@ -331,75 +349,68 @@ export function DepthChart({
   const rangePercent = hoveredPoint
     ? ((hoveredPoint.price - currentPrice) / currentPrice) * 100
     : 0
-  const tooltipLeft = hoverX ? ((hoverX + MARGIN.left) / CHART_WIDTH) * 100 : 50
+  const tooltipLeft = hoverX ? ((hoverX + MARGIN.left) / chartWidth) * 100 : 50
 
   if (data.sell.length <= 1 && data.buy.length <= 1) {
     return (
-      <div className="flex h-[360px] items-center justify-center text-sm text-muted-foreground">
+      <div className="flex h-[380px] items-center justify-center text-sm text-muted-foreground">
         Liquidity depth is unavailable for this pool.
       </div>
     )
   }
 
   return (
-    <div className="relative min-h-[360px] overflow-hidden px-4 pb-3 pt-5 sm:px-6">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <div className="text-xs font-medium text-muted-foreground">
-            Current price
-          </div>
-          <div className="mt-1 text-lg font-semibold tracking-tight">
-            1 {baseSymbol} = {formatNumber(currentPrice)} {quoteSymbol}
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Button
-            size="sm"
-            variant="secondary"
-            aria-label="Zoom in"
-            disabled={visibleSteps <= 1}
-            onClick={() =>
-              setVisibleSteps((steps) => Math.max(1, Math.ceil(steps / 1.5)))
-            }
-          >
-            <MagnifyingGlassPlusIcon width={18} height={18} />
-          </Button>
-          <Button
-            size="sm"
-            variant="secondary"
-            aria-label="Zoom out"
-            disabled={visibleSteps >= maxSteps}
-            onClick={() =>
-              setVisibleSteps((steps) =>
-                Math.min(maxSteps, Math.ceil(steps * 1.5)),
-              )
-            }
-          >
-            <MagnifyingGlassMinusIcon width={18} height={18} />
-          </Button>
-          <Button
-            size="sm"
-            variant="secondary"
-            aria-label="Reset zoom"
-            disabled={visibleSteps === initialVisibleSteps}
-            onClick={() => setVisibleSteps(initialVisibleSteps)}
-          >
-            <ArrowPathIcon width={18} height={18} />
-          </Button>
-        </div>
+    <div
+      ref={containerRef}
+      className="relative h-[380px] w-full overflow-hidden"
+    >
+      <div className="absolute right-4 top-4 z-10 flex gap-2">
+        <Button
+          size="sm"
+          variant="secondary"
+          aria-label="Zoom in"
+          disabled={visibleSteps <= 1}
+          onClick={() =>
+            setVisibleSteps((steps) => Math.max(1, Math.ceil(steps / 1.5)))
+          }
+        >
+          <MagnifyingGlassPlusIcon width={18} height={18} />
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          aria-label="Zoom out"
+          disabled={visibleSteps >= maxSteps}
+          onClick={() =>
+            setVisibleSteps((steps) =>
+              Math.min(maxSteps, Math.ceil(steps * 1.5)),
+            )
+          }
+        >
+          <MagnifyingGlassMinusIcon width={18} height={18} />
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          aria-label="Reset zoom"
+          disabled={visibleSteps === initialVisibleSteps}
+          onClick={() => setVisibleSteps(initialVisibleSteps)}
+        >
+          <ArrowPathIcon width={18} height={18} />
+        </Button>
       </div>
 
       <svg
         role="img"
         aria-label={`${baseSymbol} and ${quoteSymbol} liquidity depth`}
-        className="mt-3 h-auto w-full touch-none select-none"
-        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className="h-full w-full touch-none select-none"
+        viewBox={`0 0 ${chartWidth} ${chartHeight}`}
         onPointerMove={handlePointerMove}
         onPointerLeave={() => setHoveredPoint(null)}
       >
         <defs>
           <clipPath id={`${id}-clip`}>
-            <rect width={INNER_WIDTH} height={INNER_HEIGHT} />
+            <rect width={innerWidth} height={innerHeight} />
           </clipPath>
           <linearGradient id={`${id}-sell`} x1="0" x2="0" y1="0" y2="1">
             <stop offset="0%" stopColor={SELL_COLOR} stopOpacity="0.42" />
@@ -409,44 +420,9 @@ export function DepthChart({
             <stop offset="0%" stopColor={BUY_COLOR} stopOpacity="0.42" />
             <stop offset="100%" stopColor={BUY_COLOR} stopOpacity="0.04" />
           </linearGradient>
-          <pattern
-            id={`${id}-dots`}
-            width="24"
-            height="24"
-            patternUnits="userSpaceOnUse"
-          >
-            <circle cx="1" cy="1" r="1" fill="currentColor" opacity="0.12" />
-          </pattern>
         </defs>
 
         <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
-          <rect
-            width={INNER_WIDTH}
-            height={INNER_HEIGHT}
-            fill={`url(#${id}-dots)`}
-            className="text-slate-400"
-          />
-          {yTicks.map((tick) => (
-            <g key={tick}>
-              <line
-                x1={0}
-                x2={INNER_WIDTH}
-                y1={yScale(tick)}
-                y2={yScale(tick)}
-                stroke="currentColor"
-                strokeDasharray="2 6"
-                className="text-slate-300 dark:text-slate-700"
-              />
-              <text
-                x={INNER_WIDTH + 10}
-                y={yScale(tick) + 4}
-                className="fill-slate-400 text-[10px]"
-              >
-                {formatNumber(tick)}
-              </text>
-            </g>
-          ))}
-
           <g clipPath={`url(#${id}-clip)`}>
             <path
               d={sellPath}
@@ -466,7 +442,7 @@ export function DepthChart({
               x1={xScale(0)}
               x2={xScale(0)}
               y1={0}
-              y2={INNER_HEIGHT}
+              y2={innerHeight}
               stroke="currentColor"
               strokeDasharray="4 5"
               className="text-slate-500"
@@ -477,7 +453,7 @@ export function DepthChart({
                   x1={hoverX}
                   x2={hoverX}
                   y1={0}
-                  y2={INNER_HEIGHT}
+                  y2={innerHeight}
                   stroke="currentColor"
                   strokeDasharray="3 4"
                   className="text-slate-400"
@@ -496,9 +472,9 @@ export function DepthChart({
 
           <line
             x1={0}
-            x2={INNER_WIDTH}
-            y1={INNER_HEIGHT}
-            y2={INNER_HEIGHT}
+            x2={innerWidth}
+            y1={innerHeight}
+            y2={innerHeight}
             stroke="currentColor"
             className="text-slate-300 dark:text-slate-700"
           />
@@ -506,30 +482,13 @@ export function DepthChart({
             <text
               key={`${point.side}-${point.logicalIndex}`}
               x={xScale(point.logicalIndex)}
-              y={INNER_HEIGHT + 24}
+              y={innerHeight + 24}
               textAnchor="middle"
               className="fill-slate-400 text-[10px]"
             >
               {formatNumber(point.price)}
             </text>
           ))}
-          <text
-            x={4}
-            y={14}
-            fill={SELL_COLOR}
-            className="text-[10px] font-medium"
-          >
-            Sell {baseSymbol}
-          </text>
-          <text
-            x={INNER_WIDTH - 4}
-            y={14}
-            textAnchor="end"
-            fill={BUY_COLOR}
-            className="text-[10px] font-medium"
-          >
-            Buy {baseSymbol}
-          </text>
         </g>
       </svg>
 
@@ -538,7 +497,7 @@ export function DepthChart({
           className="pointer-events-none absolute z-20 min-w-44 rounded-xl border border-accent bg-background/95 p-3 text-xs shadow-xl backdrop-blur"
           style={{
             left: `${tooltipLeft}%`,
-            top: 86,
+            top: 56,
             transform:
               tooltipLeft > 70 ? 'translateX(-100%)' : 'translateX(8px)',
           }}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
@@ -20,7 +20,7 @@ import type { ChartEntry } from '~evm/[chainId]/_ui/LiquidityChartRangeInput/typ
 
 const DEFAULT_CHART_WIDTH = 600
 const DEFAULT_CHART_HEIGHT = 380
-const MARGIN = { top: 18, right: 16, bottom: 38, left: 16 }
+const MARGIN = { top: 26, right: 16, bottom: 38, left: 16 }
 const SELL_COLOR = '#22c55e'
 const BUY_COLOR = '#ef4444'
 

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
@@ -36,6 +36,35 @@ export interface PoolDepthData {
   buy: DepthPoint[]
 }
 
+const SPARSE_POOL_MAX_STEPS = 8
+
+export function getInitialVisibleSteps(maxSteps: number): number {
+  if (maxSteps <= SPARSE_POOL_MAX_STEPS) return maxSteps
+  return Math.max(1, Math.ceil(maxSteps * 0.4))
+}
+
+export function getNextVisibleSteps({
+  visibleSteps,
+  maxSteps,
+  direction,
+}: {
+  visibleSteps: number
+  maxSteps: number
+  direction: 'in' | 'out'
+}): number {
+  if (direction === 'in') {
+    return Math.max(
+      1,
+      Math.min(visibleSteps - 1, Math.floor(visibleSteps / 1.5)),
+    )
+  }
+
+  return Math.min(
+    maxSteps,
+    Math.max(visibleSteps + 1, Math.ceil(visibleSteps * 1.5)),
+  )
+}
+
 function getBaseTokenDepth({
   liquidity,
   lowerPrice,
@@ -241,7 +270,7 @@ export function DepthChart({
     [currentPrice, series, token0Decimals, token1Decimals],
   )
   const maxSteps = Math.max(data.sell.length - 1, data.buy.length - 1, 1)
-  const initialVisibleSteps = Math.max(1, Math.ceil(maxSteps * 0.4))
+  const initialVisibleSteps = getInitialVisibleSteps(maxSteps)
   const [visibleSteps, setVisibleSteps] = useState(initialVisibleSteps)
   const [hoveredPoint, setHoveredPoint] = useState<DepthPoint | null>(null)
 
@@ -371,7 +400,13 @@ export function DepthChart({
           aria-label="Zoom in"
           disabled={visibleSteps <= 1}
           onClick={() =>
-            setVisibleSteps((steps) => Math.max(1, Math.ceil(steps / 1.5)))
+            setVisibleSteps((steps) =>
+              getNextVisibleSteps({
+                visibleSteps: steps,
+                maxSteps,
+                direction: 'in',
+              }),
+            )
           }
         >
           <MagnifyingGlassPlusIcon width={18} height={18} />
@@ -383,7 +418,11 @@ export function DepthChart({
           disabled={visibleSteps >= maxSteps}
           onClick={() =>
             setVisibleSteps((steps) =>
-              Math.min(maxSteps, Math.ceil(steps * 1.5)),
+              getNextVisibleSteps({
+                visibleSteps: steps,
+                maxSteps,
+                direction: 'out',
+              }),
             )
           }
         >

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/depth-chart.tsx
@@ -1,0 +1,581 @@
+'use client'
+
+import {
+  MagnifyingGlassMinusIcon,
+  MagnifyingGlassPlusIcon,
+} from '@heroicons/react/20/solid'
+import { ArrowPathIcon } from '@heroicons/react/24/outline'
+import { Button } from '@sushiswap/ui'
+import { area, curveStepAfter, max, scaleLinear } from 'd3'
+import React, {
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react'
+import type { ChartEntry } from '~evm/[chainId]/_ui/LiquidityChartRangeInput/types'
+
+const CHART_WIDTH = 600
+const CHART_HEIGHT = 320
+const MARGIN = { top: 18, right: 68, bottom: 38, left: 16 }
+const INNER_WIDTH = CHART_WIDTH - MARGIN.left - MARGIN.right
+const INNER_HEIGHT = CHART_HEIGHT - MARGIN.top - MARGIN.bottom
+const SELL_COLOR = '#22c55e'
+const BUY_COLOR = '#ef4444'
+
+export interface DepthPoint {
+  logicalIndex: number
+  price: number
+  depth: number
+  side: 'sell' | 'buy'
+}
+
+export interface PoolDepthData {
+  sell: DepthPoint[]
+  buy: DepthPoint[]
+}
+
+function getBaseTokenDepth({
+  liquidity,
+  lowerPrice,
+  upperPrice,
+  token0Decimals,
+  token1Decimals,
+}: {
+  liquidity: number
+  lowerPrice: number
+  upperPrice: number
+  token0Decimals: number
+  token1Decimals: number
+}): number {
+  if (
+    liquidity <= 0 ||
+    lowerPrice <= 0 ||
+    upperPrice <= lowerPrice ||
+    !Number.isFinite(liquidity)
+  ) {
+    return 0
+  }
+
+  const decimalScale = 10 ** (token0Decimals - token1Decimals)
+  const lowerSqrtPrice = Math.sqrt(lowerPrice / decimalScale)
+  const upperSqrtPrice = Math.sqrt(upperPrice / decimalScale)
+  const rawAmount =
+    liquidity * Math.abs(1 / lowerSqrtPrice - 1 / upperSqrtPrice)
+
+  return rawAmount / 10 ** token0Decimals
+}
+
+export function buildPoolDepthData({
+  series,
+  currentPrice,
+  token0Decimals,
+  token1Decimals,
+}: {
+  series: ChartEntry[]
+  currentPrice: number
+  token0Decimals: number
+  token1Decimals: number
+}): PoolDepthData {
+  const sorted = series
+    .filter(
+      ({ activeLiquidity, price0 }) =>
+        activeLiquidity >= 0 &&
+        price0 > 0 &&
+        Number.isFinite(activeLiquidity) &&
+        Number.isFinite(price0),
+    )
+    .toSorted((a, b) => a.price0 - b.price0)
+
+  let activeIndex = -1
+  for (let i = 0; i < sorted.length; i++) {
+    if (sorted[i].price0 <= currentPrice) activeIndex = i
+  }
+
+  if (activeIndex < 0 || activeIndex >= sorted.length) {
+    return { sell: [], buy: [] }
+  }
+
+  const sellSteps: Omit<DepthPoint, 'logicalIndex'>[] = []
+  let cumulativeSellDepth = 0
+  for (let i = activeIndex; i >= 0; i--) {
+    const lowerPrice = sorted[i].price0
+    const upperPrice = i === activeIndex ? currentPrice : sorted[i + 1].price0
+    if (lowerPrice >= upperPrice) continue
+
+    cumulativeSellDepth += getBaseTokenDepth({
+      liquidity: sorted[i].activeLiquidity,
+      lowerPrice,
+      upperPrice,
+      token0Decimals,
+      token1Decimals,
+    })
+
+    if (cumulativeSellDepth > 0) {
+      sellSteps.unshift({
+        price: lowerPrice,
+        depth: cumulativeSellDepth,
+        side: 'sell',
+      })
+    }
+  }
+
+  const sell = sellSteps.map((point, index) => ({
+    ...point,
+    logicalIndex: index - sellSteps.length,
+  }))
+  sell.push({
+    logicalIndex: 0,
+    price: currentPrice,
+    depth: 0,
+    side: 'sell',
+  })
+
+  const buy: DepthPoint[] = [
+    {
+      logicalIndex: 0,
+      price: currentPrice,
+      depth: 0,
+      side: 'buy',
+    },
+  ]
+  let cumulativeBuyDepth = 0
+  for (let i = activeIndex; i < sorted.length - 1; i++) {
+    const lowerPrice = Math.max(currentPrice, sorted[i].price0)
+    const upperPrice = sorted[i + 1].price0
+    if (lowerPrice >= upperPrice) continue
+
+    cumulativeBuyDepth += getBaseTokenDepth({
+      liquidity: sorted[i].activeLiquidity,
+      lowerPrice,
+      upperPrice,
+      token0Decimals,
+      token1Decimals,
+    })
+
+    if (cumulativeBuyDepth > 0) {
+      buy.push({
+        logicalIndex: buy.length,
+        price: upperPrice,
+        depth: cumulativeBuyDepth,
+        side: 'buy',
+      })
+    }
+  }
+
+  return { sell, buy }
+}
+
+function formatNumber(value: number): string {
+  const absoluteValue = Math.abs(value)
+  if (absoluteValue >= 1_000) {
+    return new Intl.NumberFormat('en', {
+      notation: 'compact',
+      maximumFractionDigits: 2,
+    }).format(value)
+  }
+  if (absoluteValue >= 1) {
+    return new Intl.NumberFormat('en', {
+      maximumFractionDigits: 4,
+    }).format(value)
+  }
+  if (absoluteValue >= 0.001) {
+    return new Intl.NumberFormat('en', {
+      maximumFractionDigits: 6,
+    }).format(value)
+  }
+  return value === 0 ? '0' : value.toExponential(2)
+}
+
+function getAxisPoints(sell: DepthPoint[], buy: DepthPoint[]): DepthPoint[] {
+  const candidates = [
+    sell[0],
+    sell[Math.floor((sell.length - 1) / 2)],
+    sell.at(-1),
+    buy[Math.floor((buy.length - 1) / 2)],
+    buy.at(-1),
+  ].filter((point): point is DepthPoint => Boolean(point))
+
+  return candidates.filter(
+    (point, index) =>
+      candidates.findIndex(
+        (candidate) => candidate.logicalIndex === point.logicalIndex,
+      ) === index,
+  )
+}
+
+interface DepthChartProps {
+  series: ChartEntry[]
+  currentPrice: number
+  baseSymbol: string
+  quoteSymbol: string
+  token0Decimals: number
+  token1Decimals: number
+}
+
+export function DepthChart({
+  series,
+  currentPrice,
+  baseSymbol,
+  quoteSymbol,
+  token0Decimals,
+  token1Decimals,
+}: DepthChartProps) {
+  const id = useId().replaceAll(':', '')
+  const data = useMemo(
+    () =>
+      buildPoolDepthData({
+        series,
+        currentPrice,
+        token0Decimals,
+        token1Decimals,
+      }),
+    [currentPrice, series, token0Decimals, token1Decimals],
+  )
+  const maxSteps = Math.max(data.sell.length - 1, data.buy.length - 1, 1)
+  const initialVisibleSteps = Math.max(1, Math.ceil(maxSteps * 0.4))
+  const [visibleSteps, setVisibleSteps] = useState(initialVisibleSteps)
+  const [hoveredPoint, setHoveredPoint] = useState<DepthPoint | null>(null)
+
+  useEffect(() => {
+    setVisibleSteps(initialVisibleSteps)
+  }, [initialVisibleSteps])
+
+  const visibleData = useMemo(
+    () => ({
+      sell: data.sell.filter(
+        ({ logicalIndex }) => Math.abs(logicalIndex) <= visibleSteps,
+      ),
+      buy: data.buy.filter(
+        ({ logicalIndex }) => Math.abs(logicalIndex) <= visibleSteps,
+      ),
+    }),
+    [data, visibleSteps],
+  )
+
+  const xScale = useMemo(
+    () =>
+      scaleLinear()
+        .domain([-visibleSteps - 0.5, visibleSteps + 0.5])
+        .range([0, INNER_WIDTH]),
+    [visibleSteps],
+  )
+  const maxDepth =
+    max([...visibleData.sell, ...visibleData.buy], ({ depth }) => depth) ?? 0
+  const yScale = useMemo(
+    () =>
+      scaleLinear()
+        .domain([0, maxDepth > 0 ? maxDepth * 1.08 : 1])
+        .range([INNER_HEIGHT, 0])
+        .nice(),
+    [maxDepth],
+  )
+
+  const createArea = useCallback(
+    (points: DepthPoint[]) =>
+      area<DepthPoint>()
+        .curve(curveStepAfter)
+        .x(({ logicalIndex }) => xScale(logicalIndex))
+        .y0(INNER_HEIGHT)
+        .y1(({ depth }) => yScale(depth))(points) ?? undefined,
+    [xScale, yScale],
+  )
+  const renderData = useMemo(() => {
+    const leftEdge = -visibleSteps - 0.5
+    const rightEdge = visibleSteps + 0.5
+    const firstSell = visibleData.sell[0]
+    const lastBuy = visibleData.buy.at(-1)
+
+    return {
+      sell:
+        firstSell && firstSell.logicalIndex > leftEdge
+          ? [{ ...firstSell, logicalIndex: leftEdge }, ...visibleData.sell]
+          : visibleData.sell,
+      buy:
+        lastBuy && lastBuy.logicalIndex < rightEdge
+          ? [...visibleData.buy, { ...lastBuy, logicalIndex: rightEdge }]
+          : visibleData.buy,
+    }
+  }, [visibleData, visibleSteps])
+  const sellPath = createArea(renderData.sell)
+  const buyPath = createArea(renderData.buy)
+  const axisPoints = getAxisPoints(visibleData.sell, visibleData.buy)
+  const yTicks = yScale.ticks(4).filter((tick) => tick > 0)
+  const interactivePoints = [...visibleData.sell, ...visibleData.buy].filter(
+    ({ logicalIndex }) => logicalIndex !== 0,
+  )
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<SVGSVGElement>) => {
+      if (interactivePoints.length === 0) return
+      const bounds = event.currentTarget.getBoundingClientRect()
+      const chartX =
+        ((event.clientX - bounds.left) / bounds.width) * CHART_WIDTH -
+        MARGIN.left
+      const logicalIndex = xScale.invert(chartX)
+      const nearest = interactivePoints.reduce((closest, point) =>
+        Math.abs(point.logicalIndex - logicalIndex) <
+        Math.abs(closest.logicalIndex - logicalIndex)
+          ? point
+          : closest,
+      )
+      setHoveredPoint(nearest)
+    },
+    [interactivePoints, xScale],
+  )
+
+  const hoverX = hoveredPoint ? xScale(hoveredPoint.logicalIndex) : null
+  const hoverY = hoveredPoint ? yScale(hoveredPoint.depth) : null
+  const rangePercent = hoveredPoint
+    ? ((hoveredPoint.price - currentPrice) / currentPrice) * 100
+    : 0
+  const tooltipLeft = hoverX ? ((hoverX + MARGIN.left) / CHART_WIDTH) * 100 : 50
+
+  if (data.sell.length <= 1 && data.buy.length <= 1) {
+    return (
+      <div className="flex h-[360px] items-center justify-center text-sm text-muted-foreground">
+        Liquidity depth is unavailable for this pool.
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative min-h-[360px] overflow-hidden px-4 pb-3 pt-5 sm:px-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-xs font-medium text-muted-foreground">
+            Current price
+          </div>
+          <div className="mt-1 text-lg font-semibold tracking-tight">
+            1 {baseSymbol} = {formatNumber(currentPrice)} {quoteSymbol}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            aria-label="Zoom in"
+            disabled={visibleSteps <= 1}
+            onClick={() =>
+              setVisibleSteps((steps) => Math.max(1, Math.ceil(steps / 1.5)))
+            }
+          >
+            <MagnifyingGlassPlusIcon width={18} height={18} />
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            aria-label="Zoom out"
+            disabled={visibleSteps >= maxSteps}
+            onClick={() =>
+              setVisibleSteps((steps) =>
+                Math.min(maxSteps, Math.ceil(steps * 1.5)),
+              )
+            }
+          >
+            <MagnifyingGlassMinusIcon width={18} height={18} />
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            aria-label="Reset zoom"
+            disabled={visibleSteps === initialVisibleSteps}
+            onClick={() => setVisibleSteps(initialVisibleSteps)}
+          >
+            <ArrowPathIcon width={18} height={18} />
+          </Button>
+        </div>
+      </div>
+
+      <svg
+        role="img"
+        aria-label={`${baseSymbol} and ${quoteSymbol} liquidity depth`}
+        className="mt-3 h-auto w-full touch-none select-none"
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        onPointerMove={handlePointerMove}
+        onPointerLeave={() => setHoveredPoint(null)}
+      >
+        <defs>
+          <clipPath id={`${id}-clip`}>
+            <rect width={INNER_WIDTH} height={INNER_HEIGHT} />
+          </clipPath>
+          <linearGradient id={`${id}-sell`} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={SELL_COLOR} stopOpacity="0.42" />
+            <stop offset="100%" stopColor={SELL_COLOR} stopOpacity="0.04" />
+          </linearGradient>
+          <linearGradient id={`${id}-buy`} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={BUY_COLOR} stopOpacity="0.42" />
+            <stop offset="100%" stopColor={BUY_COLOR} stopOpacity="0.04" />
+          </linearGradient>
+          <pattern
+            id={`${id}-dots`}
+            width="24"
+            height="24"
+            patternUnits="userSpaceOnUse"
+          >
+            <circle cx="1" cy="1" r="1" fill="currentColor" opacity="0.12" />
+          </pattern>
+        </defs>
+
+        <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+          <rect
+            width={INNER_WIDTH}
+            height={INNER_HEIGHT}
+            fill={`url(#${id}-dots)`}
+            className="text-slate-400"
+          />
+          {yTicks.map((tick) => (
+            <g key={tick}>
+              <line
+                x1={0}
+                x2={INNER_WIDTH}
+                y1={yScale(tick)}
+                y2={yScale(tick)}
+                stroke="currentColor"
+                strokeDasharray="2 6"
+                className="text-slate-300 dark:text-slate-700"
+              />
+              <text
+                x={INNER_WIDTH + 10}
+                y={yScale(tick) + 4}
+                className="fill-slate-400 text-[10px]"
+              >
+                {formatNumber(tick)}
+              </text>
+            </g>
+          ))}
+
+          <g clipPath={`url(#${id}-clip)`}>
+            <path
+              d={sellPath}
+              fill={`url(#${id}-sell)`}
+              stroke={SELL_COLOR}
+              strokeWidth="2"
+              strokeLinejoin="round"
+            />
+            <path
+              d={buyPath}
+              fill={`url(#${id}-buy)`}
+              stroke={BUY_COLOR}
+              strokeWidth="2"
+              strokeLinejoin="round"
+            />
+            <line
+              x1={xScale(0)}
+              x2={xScale(0)}
+              y1={0}
+              y2={INNER_HEIGHT}
+              stroke="currentColor"
+              strokeDasharray="4 5"
+              className="text-slate-500"
+            />
+            {hoverX !== null && hoverY !== null ? (
+              <>
+                <line
+                  x1={hoverX}
+                  x2={hoverX}
+                  y1={0}
+                  y2={INNER_HEIGHT}
+                  stroke="currentColor"
+                  strokeDasharray="3 4"
+                  className="text-slate-400"
+                />
+                <circle
+                  cx={hoverX}
+                  cy={hoverY}
+                  r="4"
+                  fill={hoveredPoint?.side === 'sell' ? SELL_COLOR : BUY_COLOR}
+                  stroke="white"
+                  strokeWidth="2"
+                />
+              </>
+            ) : null}
+          </g>
+
+          <line
+            x1={0}
+            x2={INNER_WIDTH}
+            y1={INNER_HEIGHT}
+            y2={INNER_HEIGHT}
+            stroke="currentColor"
+            className="text-slate-300 dark:text-slate-700"
+          />
+          {axisPoints.map((point) => (
+            <text
+              key={`${point.side}-${point.logicalIndex}`}
+              x={xScale(point.logicalIndex)}
+              y={INNER_HEIGHT + 24}
+              textAnchor="middle"
+              className="fill-slate-400 text-[10px]"
+            >
+              {formatNumber(point.price)}
+            </text>
+          ))}
+          <text
+            x={4}
+            y={14}
+            fill={SELL_COLOR}
+            className="text-[10px] font-medium"
+          >
+            Sell {baseSymbol}
+          </text>
+          <text
+            x={INNER_WIDTH - 4}
+            y={14}
+            textAnchor="end"
+            fill={BUY_COLOR}
+            className="text-[10px] font-medium"
+          >
+            Buy {baseSymbol}
+          </text>
+        </g>
+      </svg>
+
+      {hoveredPoint ? (
+        <div
+          className="pointer-events-none absolute z-20 min-w-44 rounded-xl border border-accent bg-background/95 p-3 text-xs shadow-xl backdrop-blur"
+          style={{
+            left: `${tooltipLeft}%`,
+            top: 86,
+            transform:
+              tooltipLeft > 70 ? 'translateX(-100%)' : 'translateX(8px)',
+          }}
+        >
+          <div className="mb-2 flex items-center gap-2 font-medium">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{
+                backgroundColor:
+                  hoveredPoint.side === 'sell' ? SELL_COLOR : BUY_COLOR,
+              }}
+            />
+            {hoveredPoint.side === 'sell' ? 'Sell depth' : 'Buy depth'}
+          </div>
+          <div className="space-y-1.5 text-muted-foreground">
+            <div className="flex justify-between gap-6">
+              <span>Range</span>
+              <span className="font-medium text-foreground">
+                {rangePercent >= 0 ? '+' : ''}
+                {rangePercent.toFixed(2)}%
+              </span>
+            </div>
+            <div className="flex justify-between gap-6">
+              <span>Price</span>
+              <span className="font-medium text-foreground">
+                {formatNumber(hoveredPoint.price)} {quoteSymbol}
+              </span>
+            </div>
+            <div className="flex justify-between gap-6">
+              <span>Depth</span>
+              <span className="font-medium text-foreground">
+                {formatNumber(hoveredPoint.depth)} {baseSymbol}
+              </span>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/liquidity-depth-widget.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/liquidity-depth-widget.tsx
@@ -2,13 +2,12 @@
 
 import { SkeletonBox } from '@sushiswap/ui'
 import React, { type FC, useMemo } from 'react'
-import { Bound } from 'src/lib/constants'
 import { useConcentratedLiquidityPoolStats } from 'src/lib/hooks/react-query'
 import type { SushiSwapV3ChainId } from 'sushi/evm'
 import type { Address } from 'viem'
-import { LiquidityChartRangeInput } from '~evm/[chainId]/_ui/LiquidityChartRangeInput'
 import { useDensityChartData } from '~evm/[chainId]/_ui/LiquidityChartRangeInput/hooks'
 import { useConcentratedDerivedMintInfo } from '~evm/[chainId]/_ui/concentrated-liquidity-provider'
+import { DepthChart } from './depth-chart'
 
 interface LiquidityDepthWidget {
   address: Address
@@ -52,29 +51,15 @@ export const LiquidityDepthWidget: FC<LiquidityDepthWidget> = ({
 
   return (
     <>
-      {isLoading && <SkeletonBox className="w-full h-full" />}
+      {isLoading && <SkeletonBox className="h-[360px] w-full" />}
       {!noLiquidity && !isLoading && data && current && poolStats && (
-        <LiquidityChartRangeInput
-          chainId={chainId}
-          currencyA={poolStats.token0}
-          currencyB={poolStats.token1}
-          feeAmount={poolStats.feeAmount}
-          ticksAtLimit={{ [Bound.LOWER]: false, [Bound.UPPER]: false }}
-          price={
-            price
-              ? Number.parseFloat(
-                  (invertPrice ? price.invert() : price).toSignificant(8),
-                )
-              : undefined
-          }
-          weightLockedCurrencyBase={undefined}
-          priceRange={undefined}
-          priceLower={undefined}
-          priceUpper={undefined}
-          interactive={false}
-          hideBrushes={true}
-          onLeftRangeInput={() => {}}
-          onRightRangeInput={() => {}}
+        <DepthChart
+          series={data}
+          currentPrice={current}
+          baseSymbol={poolStats.token0.symbol ?? 'Token 0'}
+          quoteSymbol={poolStats.token1.symbol ?? 'Token 1'}
+          token0Decimals={poolStats.token0.decimals}
+          token1Decimals={poolStats.token1.decimals}
         />
       )}
     </>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/liquidity-depth-widget.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/liquidity-depth-widget.tsx
@@ -51,7 +51,7 @@ export const LiquidityDepthWidget: FC<LiquidityDepthWidget> = ({
 
   return (
     <>
-      {isLoading && <SkeletonBox className="h-[360px] w-full" />}
+      {isLoading && <SkeletonBox className="h-[380px] w-full" />}
       {!noLiquidity && !isLoading && data && current && poolStats && (
         <DepthChart
           series={data}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/statistics-chart-v3.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/statistics-chart-v3.tsx
@@ -49,20 +49,16 @@ export const StatisticsChartsV3: FC<Charts> = ({ address, chainId, pool }) => {
   return (
     <Card className="self-start overflow-hidden">
       <div className="border-b border-accent px-6 py-4 flex flex-wrap items-center justify-between gap-4">
-        <div className="flex mx-auto">
-          <PoolChartTypes
-            charts={statisticsChart}
-            selectedChart={chart}
-            setChart={setChart}
-          />
-        </div>
-        <div className="flex mx-auto">
-          <PoolChartPeriods
-            periods={periods}
-            selectedPeriod={period}
-            setPeriod={setPeriod}
-          />
-        </div>
+        <PoolChartTypes
+          charts={statisticsChart}
+          selectedChart={chart}
+          setChart={setChart}
+        />
+        <PoolChartPeriods
+          periods={periods}
+          selectedPeriod={period}
+          setPeriod={setPeriod}
+        />
       </div>
       {chart === PoolChartType.Depth ? (
         <LiquidityDepthWidget chainId={chainId} address={address} />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/statistics-chart-v3.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/statistics-chart-v3.tsx
@@ -47,7 +47,7 @@ export const StatisticsChartsV3: FC<Charts> = ({ address, chainId, pool }) => {
   }, [chart])
 
   return (
-    <Card>
+    <Card className="self-start overflow-hidden">
       <div className="border-b border-accent px-6 py-4 flex flex-wrap items-center justify-between gap-4">
         <div className="flex mx-auto">
           <PoolChartTypes
@@ -72,6 +72,7 @@ export const StatisticsChartsV3: FC<Charts> = ({ address, chainId, pool }) => {
           period={period}
           pool={pool}
           protocol={SushiSwapProtocol.SUSHISWAP_V3}
+          height={260}
         />
       )}
     </Card>

--- a/apps/web/src/lib/compute-surrounding-ticks.test.ts
+++ b/apps/web/src/lib/compute-surrounding-ticks.test.ts
@@ -1,0 +1,69 @@
+import { EvmChainId, EvmToken } from 'sushi/evm'
+import { describe, expect, it } from 'vitest'
+import computeSurroundingTicks from './functions'
+
+const token0 = new EvmToken({
+  chainId: EvmChainId.ETHEREUM,
+  address: '0x0000000000000000000000000000000000000001',
+  decimals: 18,
+  symbol: 'TOKEN0',
+  name: 'Token 0',
+})
+const token1 = new EvmToken({
+  chainId: EvmChainId.ETHEREUM,
+  address: '0x0000000000000000000000000000000000000002',
+  decimals: 18,
+  symbol: 'TOKEN1',
+  name: 'Token 1',
+})
+
+describe('computeSurroundingTicks', () => {
+  it('includes the lower pivot when the active tick is not initialized', () => {
+    const result = computeSurroundingTicks(
+      token0,
+      token1,
+      {
+        tick: 120,
+        liquidityActive: 100n,
+        liquidityNet: 0n,
+        price0: '1',
+      },
+      [
+        { tickIdx: -100, liquidityNet: 50n },
+        { tickIdx: 100, liquidityNet: -50n },
+        { tickIdx: 200, liquidityNet: -100n },
+      ],
+      1,
+      false,
+    )
+
+    expect(
+      result.map(({ tick, liquidityActive }) => ({ tick, liquidityActive })),
+    ).toEqual([
+      { tick: -100, liquidityActive: 150n },
+      { tick: 100, liquidityActive: 100n },
+    ])
+  })
+
+  it('does not duplicate the pivot when it is the active tick', () => {
+    const result = computeSurroundingTicks(
+      token0,
+      token1,
+      {
+        tick: 100,
+        liquidityActive: 100n,
+        liquidityNet: -50n,
+        price0: '1',
+      },
+      [
+        { tickIdx: -100, liquidityNet: 50n },
+        { tickIdx: 100, liquidityNet: -50n },
+        { tickIdx: 200, liquidityNet: -50n },
+      ],
+      1,
+      false,
+    )
+
+    expect(result.map(({ tick }) => tick)).toEqual([-100])
+  })
+})

--- a/apps/web/src/lib/functions.ts
+++ b/apps/web/src/lib/functions.ts
@@ -192,8 +192,12 @@ export default function computeSurroundingTicks(
   // Iterate outwards (either up or down depending on direction) from the active tick,
   // building active liquidity for every tick.
   let processedTicks: TickProcessed[] = []
+  const pivotIsActiveTick =
+    Number(sortedTickData[pivot].tickIdx) === activeTickProcessed.tick
+  const startIndex = ascending ? pivot + 1 : pivot - (pivotIsActiveTick ? 1 : 0)
+
   for (
-    let i = pivot + (ascending ? 1 : -1);
+    let i = startIndex;
     ascending ? i < sortedTickData.length : i >= 0;
     ascending ? i++ : i--
   ) {


### PR DESCRIPTION
## Summary

- replace the range-selector reuse with a dedicated two-sided cumulative depth chart inspired by the Uniswap depth view
- show sell and buy liquidity around the current price with balanced logical spacing, stepped fills, hover details, and zoom controls
- preserve zero-liquidity boundaries and fix lower-tick traversal so sparse pools render their complete ranges
- add regression coverage for cumulative depth, extreme price gaps, sparse boundaries, and off-screen ranges

## Root cause

The previous pool depth tab reused the LP range-selection chart. Sparse V3 pools could also collapse to a single positive point because zero-liquidity boundaries were filtered out and the nearest lower initialized tick was skipped. D3 then rendered a zero-width area that appeared as a faint vertical line.

## Testing

- pnpm --filter web test:unit (175 passed, 1 skipped)
- pnpm --filter web check
- pnpm lint
- pnpm format

## Visual verification

Verified locally against the Robinhood pool from the report. The depth tab now renders both sides around the current price and keeps the very distant upper boundary readable.