### PR TITLE
refactor(web): reuse network header shell

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/header.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/header.tsx
@@ -1,13 +1,6 @@
 'use client'
 
-import { Navigation, SushiNavigationDropdown } from '@sushiswap/ui'
-import { SushiIcon } from '@sushiswap/ui/icons/SushiIcon'
-import { SushiWithTextIcon } from '@sushiswap/ui/icons/SushiWithTextIcon'
-import React, { type FC } from 'react'
-import { headerElements } from 'src/app/_common/header-elements'
-import { WagmiHeaderComponents } from 'src/lib/wagmi/components/wagmi-header-components'
 import { ChainId } from 'sushi'
-import { useChainId } from 'wagmi'
 import { Header as _Header } from '~evm/[chainId]/header'
 
 interface HeaderProps {
@@ -15,46 +8,12 @@ interface HeaderProps {
   networks?: readonly ChainId[]
 }
 
-export const Header: FC<HeaderProps> = ({ chainId, networks }) => {
-  return chainId === ChainId.KATANA ? (
-    <TransparentHeader chainId={chainId} networks={networks} />
-  ) : (
-    <_Header chainId={chainId} networks={networks} />
-  )
-}
-
-const TransparentHeader: FC<HeaderProps> = ({
-  chainId: _chainId,
-  networks,
-}) => {
-  const connectedChainId = useChainId()
-  const chainId = _chainId ?? connectedChainId
-
+export function Header({ chainId, networks }: HeaderProps) {
   return (
-    <div className="w-full h-[56px] z-20">
-      <div className="fixed w-full flex z-20">
-        <div className="hidden lg:flex justify-between items-center px-1 h-14 flex-shrink-0 border-transparent border-b">
-          <SushiNavigationDropdown className="!px-2">
-            <SushiWithTextIcon width={90} />
-          </SushiNavigationDropdown>
-        </div>
-        <div className="flex lg:hidden justify-between items-center pl-4 border-transparent border-b">
-          <SushiNavigationDropdown>
-            <SushiIcon width={24} height={24} />
-          </SushiNavigationDropdown>
-        </div>
-        <Navigation
-          className="!pl-0 lg:!pl-4 !z-[unset] !bg-[unset] dark:!bg-[unset] !border-transparent dark:!border-transparent"
-          hideSushiDropdown
-          leftElements={headerElements({ chainId })}
-          rightElement={
-            <WagmiHeaderComponents
-              networks={networks}
-              selectedNetwork={chainId}
-            />
-          }
-        />
-      </div>
-    </div>
+    <_Header
+      chainId={chainId}
+      networks={networks}
+      variant={chainId === ChainId.KATANA ? 'transparent' : 'default'}
+    />
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/header.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/header.tsx
@@ -1,10 +1,6 @@
 'use client'
 
-import { Navigation, SushiNavigationDropdown, classNames } from '@sushiswap/ui'
-import { SushiIcon } from '@sushiswap/ui/icons/SushiIcon'
-import { SushiWithTextIcon } from '@sushiswap/ui/icons/SushiWithTextIcon'
-import React, { type FC } from 'react'
-import { headerElements } from 'src/app/_common/header-elements'
+import { HeaderShell } from 'src/app/(networks)/_ui/header-shell'
 import { WagmiHeaderComponents } from 'src/lib/wagmi/components/wagmi-header-components'
 import type { ChainId } from 'sushi'
 import { useChainId } from 'wagmi'
@@ -12,41 +8,20 @@ import { useChainId } from 'wagmi'
 interface HeaderProps {
   chainId?: ChainId
   networks?: readonly ChainId[]
+  variant?: 'default' | 'transparent'
 }
 
-export const Header: FC<HeaderProps> = ({ chainId: _chainId, networks }) => {
+export function Header({ chainId: _chainId, networks, variant }: HeaderProps) {
   const connectedChainId = useChainId()
   const chainId = _chainId ?? connectedChainId
 
   return (
-    <div className="w-full h-[56px] z-20">
-      <div className="fixed w-full flex z-20">
-        <div
-          className={classNames(
-            'hidden lg:flex justify-between items-center px-1 h-14 flex-shrink-0 bg-gray-100 dark:bg-slate-900 border-gray-200 dark:border-slate-800 border-b',
-          )}
-        >
-          <SushiNavigationDropdown className="!px-2">
-            <SushiWithTextIcon width={90} />
-          </SushiNavigationDropdown>
-        </div>
-        <div className="flex lg:hidden justify-between items-center pl-4 bg-gray-100 dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800">
-          <SushiNavigationDropdown>
-            <SushiIcon width={24} height={24} />
-          </SushiNavigationDropdown>
-        </div>
-        <Navigation
-          className="!pl-0 lg:!pl-4 !z-[unset]"
-          hideSushiDropdown
-          leftElements={headerElements({ chainId })}
-          rightElement={
-            <WagmiHeaderComponents
-              networks={networks}
-              selectedNetwork={chainId}
-            />
-          }
-        />
-      </div>
-    </div>
+    <HeaderShell
+      chainId={chainId}
+      variant={variant}
+      rightElement={
+        <WagmiHeaderComponents networks={networks} selectedNetwork={chainId} />
+      }
+    />
   )
 }

--- a/apps/web/src/app/(networks)/(non-evm)/aptos/header.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/aptos/header.tsx
@@ -1,50 +1,29 @@
 'use client'
 
-import { Navigation, SushiNavigationDropdown, classNames } from '@sushiswap/ui'
-import { SushiIcon } from '@sushiswap/ui/icons/SushiIcon'
-import { SushiWithTextIcon } from '@sushiswap/ui/icons/SushiWithTextIcon'
-import React, { type FC, Suspense } from 'react'
-import { headerElements } from 'src/app/_common/header-elements'
+import { Suspense } from 'react'
+import { HeaderShell } from 'src/app/(networks)/_ui/header-shell'
 import { HeaderNetworkSelector } from 'src/lib/wagmi/components/header-network-selector'
 import { ChainId } from 'sushi'
 import { UserProfile } from './_common/ui/user-profile/user-profile'
 
-export const Header: FC<{
+export function Header({
+  networks,
+}: {
   networks?: readonly ChainId[]
-}> = ({ networks }) => {
+}) {
   return (
-    <div className="w-full h-[56px] z-20">
-      <div className="fixed w-full flex z-20">
-        <div
-          className={classNames(
-            'hidden lg:flex justify-between items-center px-1 h-14 flex-shrink-0 bg-gray-100 dark:bg-slate-900 border-gray-200 dark:border-slate-800 border-b',
-          )}
-        >
-          <SushiNavigationDropdown className="!px-2">
-            <SushiWithTextIcon width={90} />
-          </SushiNavigationDropdown>
-        </div>
-        <div className="flex lg:hidden justify-between items-center pl-4 bg-gray-100 dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800">
-          <SushiNavigationDropdown>
-            <SushiIcon width={24} height={24} />
-          </SushiNavigationDropdown>
-        </div>
-        <Navigation
-          className="!pl-0 lg:!pl-4 !z-[unset]"
-          hideSushiDropdown
-          leftElements={headerElements({ chainId: ChainId.APTOS })}
-          rightElement={
-            <Suspense>
-              <HeaderNetworkSelector
-                networks={networks}
-                selectedNetwork={ChainId.APTOS}
-                className="flex"
-              />
-              <UserProfile />
-            </Suspense>
-          }
-        />
-      </div>
-    </div>
+    <HeaderShell
+      chainId={ChainId.APTOS}
+      rightElement={
+        <Suspense>
+          <HeaderNetworkSelector
+            networks={networks}
+            selectedNetwork={ChainId.APTOS}
+            className="flex"
+          />
+          <UserProfile />
+        </Suspense>
+      }
+    />
   )
 }

--- a/apps/web/src/app/(networks)/(non-evm)/solana/header.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/solana/header.tsx
@@ -1,50 +1,29 @@
 'use client'
 
-import { Navigation, SushiNavigationDropdown, classNames } from '@sushiswap/ui'
-import { SushiIcon } from '@sushiswap/ui/icons/SushiIcon'
-import { SushiWithTextIcon } from '@sushiswap/ui/icons/SushiWithTextIcon'
-import React, { type FC, Suspense } from 'react'
-import { headerElements } from 'src/app/_common/header-elements'
+import { Suspense } from 'react'
+import { HeaderShell } from 'src/app/(networks)/_ui/header-shell'
 import { HeaderNetworkSelector } from 'src/lib/wagmi/components/header-network-selector'
 import { ChainId } from 'sushi'
 import { UserPortfolio } from '../../_ui/user-portfolio'
 
-export const Header: FC<{
+export function Header({
+  networks,
+}: {
   networks?: readonly ChainId[]
-}> = ({ networks }) => {
+}) {
   return (
-    <div className="w-full h-[56px] z-20">
-      <div className="fixed w-full flex z-20">
-        <div
-          className={classNames(
-            'hidden lg:flex justify-between items-center px-1 h-14 flex-shrink-0 bg-gray-100 dark:bg-slate-900 border-gray-200 dark:border-slate-800 border-b',
-          )}
-        >
-          <SushiNavigationDropdown className="!px-2">
-            <SushiWithTextIcon width={90} />
-          </SushiNavigationDropdown>
-        </div>
-        <div className="flex lg:hidden justify-between items-center pl-4 bg-gray-100 dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800">
-          <SushiNavigationDropdown>
-            <SushiIcon width={24} height={24} />
-          </SushiNavigationDropdown>
-        </div>
-        <Navigation
-          className="!pl-0 lg:!pl-4 !z-[unset]"
-          hideSushiDropdown
-          leftElements={headerElements({ chainId: ChainId.SOLANA })}
-          rightElement={
-            <Suspense>
-              <HeaderNetworkSelector
-                networks={networks}
-                selectedNetwork={ChainId.SOLANA}
-                className="flex"
-              />
-              <UserPortfolio selectedNetwork={ChainId.SOLANA} />
-            </Suspense>
-          }
-        />
-      </div>
-    </div>
+    <HeaderShell
+      chainId={ChainId.SOLANA}
+      rightElement={
+        <Suspense>
+          <HeaderNetworkSelector
+            networks={networks}
+            selectedNetwork={ChainId.SOLANA}
+            className="flex"
+          />
+          <UserPortfolio selectedNetwork={ChainId.SOLANA} />
+        </Suspense>
+      }
+    />
   )
 }

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/header.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/header.tsx
@@ -1,54 +1,33 @@
 'use client'
 
-import { Navigation, SushiNavigationDropdown, classNames } from '@sushiswap/ui'
-import { SushiIcon } from '@sushiswap/ui/icons/SushiIcon'
-import { SushiWithTextIcon } from '@sushiswap/ui/icons/SushiWithTextIcon'
-import React, { type FC } from 'react'
-import { headerElements } from 'src/app/_common/header-elements'
+import { HeaderShell } from 'src/app/(networks)/_ui/header-shell'
 import { HeaderNetworkSelector } from 'src/lib/wagmi/components/header-network-selector'
 import { ChainId } from 'sushi'
 import { UserPortfolio } from '../../_ui/user-portfolio'
 
-export const Header: FC<{
+export function Header({
+  networks,
+}: {
   networks?: readonly ChainId[]
-}> = ({ networks }) => {
+}) {
   return (
-    <div className="w-full h-[56px] flex">
-      <div
-        className={classNames(
-          'hidden lg:flex justify-between items-center px-1 h-14 flex-shrink-0 bg-gray-100 dark:bg-slate-900 border-gray-200 dark:border-slate-800 border-b',
-        )}
-      >
-        <SushiNavigationDropdown className="!px-2">
-          <SushiWithTextIcon width={90} />
-        </SushiNavigationDropdown>
-      </div>
-      <div className="flex lg:hidden justify-between items-center pl-4 bg-gray-100 dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800">
-        <SushiNavigationDropdown>
-          <SushiIcon width={24} height={24} />
-        </SushiNavigationDropdown>
-      </div>
-      <Navigation
-        className="!pl-0 lg:!pl-4 !z-[unset]"
-        hideSushiDropdown
-        leftElements={headerElements({
-          chainId: ChainId.STELLAR,
-          includeOnramper: true,
-        })}
-        rightElement={
-          <>
-            <HeaderNetworkSelector
-              networks={networks}
-              selectedNetwork={ChainId.STELLAR}
-              className="flex"
-            />
-            <UserPortfolio
-              namespace="stellar"
-              selectedNetwork={ChainId.STELLAR}
-            />
-          </>
-        }
-      />
-    </div>
+    <HeaderShell
+      chainId={ChainId.STELLAR}
+      includeOnramper
+      position="static"
+      rightElement={
+        <>
+          <HeaderNetworkSelector
+            networks={networks}
+            selectedNetwork={ChainId.STELLAR}
+            className="flex"
+          />
+          <UserPortfolio
+            namespace="stellar"
+            selectedNetwork={ChainId.STELLAR}
+          />
+        </>
+      }
+    />
   )
 }

--- a/apps/web/src/app/(networks)/_ui/header-shell.tsx
+++ b/apps/web/src/app/(networks)/_ui/header-shell.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { Navigation, SushiNavigationDropdown, classNames } from '@sushiswap/ui'
+import { SushiIcon } from '@sushiswap/ui/icons/SushiIcon'
+import { SushiWithTextIcon } from '@sushiswap/ui/icons/SushiWithTextIcon'
+import type { ReactNode } from 'react'
+import { headerElements } from 'src/app/_common/header-elements'
+import type { ChainId } from 'sushi'
+
+interface HeaderShellProps {
+  chainId: ChainId
+  rightElement: ReactNode
+  includeOnramper?: boolean
+  position?: 'fixed' | 'static'
+  variant?: 'default' | 'transparent'
+}
+
+export function HeaderShell({
+  chainId,
+  rightElement,
+  includeOnramper,
+  position = 'fixed',
+  variant = 'default',
+}: HeaderShellProps) {
+  const content = (
+    <>
+      <div
+        className={classNames(
+          'hidden lg:flex justify-between items-center px-1 h-14 flex-shrink-0 border-b',
+          variant === 'default' &&
+            'bg-gray-100 dark:bg-slate-900 border-gray-200 dark:border-slate-800',
+          variant === 'transparent' && 'border-transparent',
+        )}
+      >
+        <SushiNavigationDropdown className="!px-2">
+          <SushiWithTextIcon width={90} />
+        </SushiNavigationDropdown>
+      </div>
+      <div
+        className={classNames(
+          'flex lg:hidden justify-between items-center pl-4 border-b',
+          variant === 'default' &&
+            'bg-gray-100 dark:bg-slate-900 border-gray-200 dark:border-slate-800',
+          variant === 'transparent' && 'border-transparent',
+        )}
+      >
+        <SushiNavigationDropdown>
+          <SushiIcon width={24} height={24} />
+        </SushiNavigationDropdown>
+      </div>
+      <Navigation
+        className={classNames(
+          '!pl-0 lg:!pl-4 !z-[unset]',
+          variant === 'transparent' &&
+            '!bg-[unset] dark:!bg-[unset] !border-transparent dark:!border-transparent',
+        )}
+        hideSushiDropdown
+        leftElements={headerElements({ chainId, includeOnramper })}
+        rightElement={rightElement}
+      />
+    </>
+  )
+
+  if (position === 'static') {
+    return <div className="w-full h-[56px] flex">{content}</div>
+  }
+
+  return (
+    <div className="w-full h-[56px] z-20">
+      <div className="fixed w-full flex z-20">{content}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- extract the shared network header chrome into a reusable `HeaderShell`
- retain chain-specific wallet and network controls in the existing EVM, Aptos, Solana, and Stellar wrappers
- express Katana transparency and Stellar positioning as explicit shell options
- leave claim routing and unrelated navigation behavior unchanged

This is the focused replacement for the stale #1969 draft.

## Validation

- `pnpm --filter web check`
- `pnpm format`
- `pnpm lint`
- `git diff --check`