### PR TITLE
fix(web): show v3 depth loading state

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/liquidity-depth-widget.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/liquidity-depth-widget.tsx
@@ -19,12 +19,15 @@ export const LiquidityDepthWidget: FC<LiquidityDepthWidget> = ({
   address,
   chainId,
 }) => {
-  const { data: poolStats } = useConcentratedLiquidityPoolStats({
-    chainId,
-    address,
-  })
+  const { data: poolStats, isLoading: isPoolStatsLoading } =
+    useConcentratedLiquidityPoolStats({ chainId, address })
 
-  const { price, invertPrice, noLiquidity } = useConcentratedDerivedMintInfo({
+  const {
+    price,
+    invertPrice,
+    noLiquidity,
+    isLoading: isMintInfoLoading,
+  } = useConcentratedDerivedMintInfo({
     account: undefined,
     chainId,
     token0: poolStats?.token0,
@@ -34,7 +37,7 @@ export const LiquidityDepthWidget: FC<LiquidityDepthWidget> = ({
     existingPosition: undefined,
   })
 
-  const { isLoading, data } = useDensityChartData({
+  const { isLoading: isDensityDataLoading, data } = useDensityChartData({
     chainId,
     token0: poolStats?.token0,
     token1: poolStats?.token1,
@@ -49,19 +52,30 @@ export const LiquidityDepthWidget: FC<LiquidityDepthWidget> = ({
     )
   }, [invertPrice, price])
 
+  const isLoading =
+    isPoolStatsLoading ||
+    (Boolean(poolStats) && (isMintInfoLoading || isDensityDataLoading))
+
+  if (isLoading) {
+    return <SkeletonBox className="h-[380px] w-full" />
+  }
+
+  if (noLiquidity || !poolStats || !data || !current) {
+    return (
+      <div className="flex h-[380px] items-center justify-center text-sm text-muted-foreground">
+        Liquidity depth is unavailable for this pool.
+      </div>
+    )
+  }
+
   return (
-    <>
-      {isLoading && <SkeletonBox className="h-[380px] w-full" />}
-      {!noLiquidity && !isLoading && data && current && poolStats && (
-        <DepthChart
-          series={data}
-          currentPrice={current}
-          baseSymbol={poolStats.token0.symbol ?? 'Token 0'}
-          quoteSymbol={poolStats.token1.symbol ?? 'Token 1'}
-          token0Decimals={poolStats.token0.decimals}
-          token1Decimals={poolStats.token1.decimals}
-        />
-      )}
-    </>
+    <DepthChart
+      series={data}
+      currentPrice={current}
+      baseSymbol={poolStats.token0.symbol ?? 'Token 0'}
+      quoteSymbol={poolStats.token1.symbol ?? 'Token 1'}
+      token0Decimals={poolStats.token0.decimals}
+      token1Decimals={poolStats.token1.decimals}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- include pool metadata and on-chain pool requests in the depth-tab loading state
- preserve the chart height while data loads
- show an explicit unavailable state when required depth data cannot be resolved

## Validation
- `pnpm --filter web test:unit --run src/app/.../depth-chart.test.ts` (189 passed, 1 skipped)
- `pnpm --filter web check`
- `pnpm format`
- `pnpm lint`