### PR TITLE
fix(web): restrict image proxy upstream

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/api/proxy-image/route.ts
+++ b/apps/web/src/app/(networks)/(evm)/api/proxy-image/route.ts
@@ -1,14 +1,52 @@
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url)
-  const url = searchParams.get('url')
-  if (!url) return new Response('Missing url', { status: 400 })
+const HYPERLIQUID_ICON_ORIGIN = 'https://app.hyperliquid.xyz'
+const HYPERLIQUID_ICON_PATH = /^\/coins\/[^/?#%]+\.svg$/
 
-  const response = await fetch(url)
+function getAllowedImageUrl(value: string): URL | undefined {
+  try {
+    const url = new URL(value)
+
+    if (
+      url.origin !== HYPERLIQUID_ICON_ORIGIN ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      !HYPERLIQUID_ICON_PATH.test(url.pathname)
+    ) {
+      return undefined
+    }
+
+    return url
+  } catch {
+    return undefined
+  }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url)
+  const value = searchParams.get('url')
+  if (!value) return new Response('Missing url', { status: 400 })
+
+  const url = getAllowedImageUrl(value)
+  if (!url) return new Response('Invalid image url', { status: 400 })
+
+  let response: Response
+  try {
+    response = await fetch(url, { redirect: 'error' })
+  } catch {
+    return new Response('Failed to fetch image', { status: 502 })
+  }
+
+  const contentType = response.headers.get('Content-Type')
+  if (!response.ok || !contentType?.toLowerCase().startsWith('image/')) {
+    return new Response('Upstream response is not an image', { status: 502 })
+  }
+
   const buffer = await response.arrayBuffer()
 
   return new Response(buffer, {
     headers: {
-      'Content-Type': response.headers.get('Content-Type') ?? 'image/svg',
+      'Content-Type': contentType,
       'Access-Control-Allow-Origin': '*',
       'Cache-Control': 'public, max-age=86400',
     },


### PR DESCRIPTION
## Summary

- restrict the image proxy to the Hyperliquid HTTPS origin and coin SVG path
- reject credentials, query strings, fragments, and malformed URLs
- disable redirect following and reject unsuccessful or non-image upstream responses

## Security

This closes the arbitrary-server request path in the image proxy and prevents redirect-based SSRF.

## Validation

- pnpm exec biome check apps/web/src/app/(networks)/(evm)/api/proxy-image/route.ts
- git diff --check
- pnpm --filter web check (blocked by 143 pre-existing missing workspace icon/hook module errors in unrelated files)