### PR TITLE
chore(web): disable production browser source maps

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -50,7 +50,7 @@ const contentSecurityPolicyHeader =
 const nextConfig = bundleAnalyzer({
   reactCompiler: process.env.REACT_COMPILER !== 'false',
   reactStrictMode: true,
-  productionBrowserSourceMaps: true,
+  productionBrowserSourceMaps: false,
   poweredByHeader: false,
   staticPageGenerationTimeout: 180,
   turbopack: {


### PR DESCRIPTION
## Summary

- disable production browser source maps for the web app
- reduce build memory, duration, and generated output size
- keep React Compiler enabled

## Benchmark

Clean A/B/A Next.js production builds:

| Configuration | Wall time | Peak RSS |
| --- | ---: | ---: |
| Source maps enabled #1 | 1:23.61 | 6.03 GiB |
| Source maps disabled | 1:15.07 | 5.60 GiB |
| Source maps enabled #2 | 1:17.53 | 6.05 GiB |

Disabling source maps reduced peak RSS by approximately 450 MiB and generated output by approximately 261 MiB.

## Validation

- pnpm format
- pnpm lint
- pnpm --filter web build