### PR TITLE
refactor(graph-client): reduce V3 pool schema

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(positions)/pool/_ui/positions-tab.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(positions)/pool/_ui/positions-tab.tsx
@@ -26,7 +26,6 @@ import {
   SushiSwapProtocol,
   getEvmChainById,
   isBladeChainId,
-  isSushiSwapChainId,
   isSushiSwapV2ChainId,
   isSushiSwapV3ChainId,
 } from 'sushi/evm'
@@ -198,7 +197,7 @@ export const PositionsTab: FC<{
             hideClosedPositions={hideClosedPositions}
           />
         </TabsContent>
-        {isSushiSwapChainId(chainId) && (
+        {isSushiSwapV2ChainId(chainId) && (
           <TabsContent value="v2">
             <PositionsTable
               chainId={chainId}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/explore/navigation-items.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/explore/navigation-items.tsx
@@ -1,11 +1,10 @@
+import {
+  isPoolChainId,
+  isSushiSwapChainId,
+} from '@sushiswap/graph-client/data-api'
 import { LinkInternal } from '@sushiswap/ui'
 import { PathnameButton } from 'src/app/_ui/pathname-button'
-import {
-  type EvmChainId,
-  getEvmChainById,
-  isBladeChainId,
-  isSushiSwapChainId,
-} from 'sushi/evm'
+import { type EvmChainId, getEvmChainById, isBladeChainId } from 'sushi/evm'
 
 export function NavigationItems({ chainId }: { chainId: EvmChainId }) {
   const chainKey = getEvmChainById(chainId).key
@@ -23,7 +22,7 @@ export function NavigationItems({ chainId }: { chainId: EvmChainId }) {
       <NavigationItem
         pathname={`/${chainKey}/explore/pools`}
         id="pools"
-        disabled={!isSushiSwapChainId(chainId)}
+        disabled={!isPoolChainId(chainId)}
       >
         Pools
       </NavigationItem>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/explore/tokens/_ui/tokens-table.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/explore/tokens/_ui/tokens-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Slot } from '@radix-ui/react-slot'
-import type { Token } from '@sushiswap/graph-client/data-api'
+import type { SushiSwapChainId, Token } from '@sushiswap/graph-client/data-api'
 import {
   Card,
   CardHeader,
@@ -23,7 +23,7 @@ import React, {
   useState,
 } from 'react'
 import { useTokens } from 'src/lib/hooks'
-import { type SushiSwapChainId, getEvmChainById } from 'sushi/evm'
+import { getEvmChainById } from 'sushi/evm'
 import {
   FDV_COLUMN,
   PRICE_CHANGE_1D_COLUMN,

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/explore/tokens/layout.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/explore/tokens/layout.tsx
@@ -1,8 +1,11 @@
+import {
+  SushiSwapChainIds,
+  isSushiSwapChainId,
+} from '@sushiswap/graph-client/data-api'
 import { Container } from '@sushiswap/ui'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import type React from 'react'
-import { SUSHISWAP_SUPPORTED_CHAIN_IDS, isSushiSwapChainId } from 'sushi/evm'
 import { Header } from '../../header'
 import { GlobalStatsCharts } from '../_ui/global-stats-charts'
 import { NavigationItems } from '../navigation-items'
@@ -29,7 +32,7 @@ export default async function ExploreLayout(props: {
 
   return (
     <>
-      <Header chainId={chainId} networks={SUSHISWAP_SUPPORTED_CHAIN_IDS} />
+      <Header chainId={chainId} networks={SushiSwapChainIds} />
       <main className="flex flex-col h-full flex-1 animate-slide">
         <Container maxWidth="7xl" className="px-4 py-4">
           <GlobalStatsCharts chainId={chainId} />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/explore/tokens/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/explore/tokens/page.tsx
@@ -1,7 +1,7 @@
+import { isSushiSwapChainId } from '@sushiswap/graph-client/data-api'
 import { Container } from '@sushiswap/ui'
 import { notFound } from 'next/navigation'
 import React from 'react'
-import { isSushiSwapChainId } from 'sushi/evm'
 import { TableFiltersSearchToken } from './_ui/table-filters-search-token'
 import { TokensTable } from './_ui/tokens-table'
 

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/_ui/charts/price-chart.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/_ui/charts/price-chart.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { SushiSwapChainId } from '@sushiswap/graph-client/data-api'
 import {
   SkeletonChartLoadingStateMask,
   SkeletonChartXAxe,
@@ -13,7 +14,7 @@ import { useTheme } from 'next-themes'
 import { type FC, useCallback, useMemo, useState } from 'react'
 import { useTokenPriceChart } from 'src/lib/hooks/api/use-token-price-chart'
 import { formatPercent, formatUSD } from 'sushi'
-import type { SerializedEvmToken, SushiSwapChainId } from 'sushi/evm'
+import type { EvmAddress } from 'sushi/evm'
 
 enum CHART_DURATION {
   DAY = 'DAY',
@@ -23,17 +24,18 @@ enum CHART_DURATION {
 }
 
 interface PriceChartProps {
-  token: SerializedEvmToken
+  chainId: SushiSwapChainId
+  address: EvmAddress
 }
 
-export const PriceChart: FC<PriceChartProps> = ({ token }) => {
+export const PriceChart: FC<PriceChartProps> = ({ chainId, address }) => {
   const { resolvedTheme } = useTheme()
 
   const [duration, setDuration] = useState<CHART_DURATION>(CHART_DURATION.DAY)
 
   const { data, isLoading } = useTokenPriceChart({
-    chainId: token.chainId as SushiSwapChainId,
-    address: token.address,
+    chainId,
+    address,
     duration,
   })
 

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/_ui/charts/token-chart.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/_ui/charts/token-chart.tsx
@@ -2,6 +2,7 @@
 
 import { DocumentDuplicateIcon } from '@heroicons/react/20/solid'
 import { ChevronDownIcon } from '@heroicons/react/24/outline'
+import type { SushiSwapChainId } from '@sushiswap/graph-client/data-api'
 import {
   ClipboardController,
   Currency,
@@ -25,10 +26,11 @@ import { PriceChart } from './price-chart'
 type ChartType = 'Price' // | 'Volume' | 'TVL'
 
 interface TokenChartProps {
+  chainId: SushiSwapChainId
   token: SerializedEvmToken
 }
 
-export const TokenChart: FC<TokenChartProps> = ({ token }) => {
+export const TokenChart: FC<TokenChartProps> = ({ chainId, token }) => {
   const [selectedChartType, setSelectedChartType] = useState<ChartType>('Price')
 
   return (
@@ -91,7 +93,11 @@ export const TokenChart: FC<TokenChartProps> = ({ token }) => {
 
       <Separator />
 
-      <div>{selectedChartType === 'Price' && <PriceChart token={token} />}</div>
+      <div>
+        {selectedChartType === 'Price' && (
+          <PriceChart chainId={chainId} address={token.address} />
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/_ui/token-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/_ui/token-page.tsx
@@ -3,8 +3,10 @@
 import { ChevronRightIcon } from '@heroicons/react/20/solid'
 import type {
   PoolChainId,
+  SushiSwapChainId,
   TokenInfo as TokenInfoType,
 } from '@sushiswap/graph-client/data-api'
+import { SushiSwapChainIds } from '@sushiswap/graph-client/data-api'
 import { useIsMounted, useMediaQuery } from '@sushiswap/hooks'
 import { Button, Container, LinkInternal } from '@sushiswap/ui'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -15,13 +17,7 @@ import { type FC, useMemo } from 'react'
 import { PoolsFiltersProvider } from 'src/app/(networks)/_ui/pools-filters-provider'
 import { TableFiltersNetwork } from 'src/app/(networks)/_ui/table-filters-network'
 import { TableFiltersSearchToken } from 'src/app/(networks)/_ui/table-filters-search-token'
-import {
-  EvmToken,
-  SUSHISWAP_SUPPORTED_CHAIN_IDS,
-  type SerializedEvmToken,
-  type SushiSwapChainId,
-  getEvmChainById,
-} from 'sushi/evm'
+import { EvmToken, type SerializedEvmToken, getEvmChainById } from 'sushi/evm'
 import { PoolsTable } from '~evm/[chainId]/_ui/pools-table'
 import { TableFiltersFarmsOnly } from '~evm/[chainId]/_ui/table-filters-farms-only'
 import { TableFiltersPoolType } from '~evm/[chainId]/_ui/table-filters-pool-type'
@@ -34,11 +30,16 @@ const SwapWidget = dynamic(() =>
 )
 
 interface TokenPageProps {
+  chainId: SushiSwapChainId
   token: SerializedEvmToken
   tokenInfo: TokenInfoType
 }
 
-export const TokenPage: FC<TokenPageProps> = ({ token: _token, tokenInfo }) => {
+export const TokenPage: FC<TokenPageProps> = ({
+  chainId,
+  token: _token,
+  tokenInfo,
+}) => {
   const token = useMemo(() => EvmToken.fromJSON(_token), [_token])
 
   const router = useRouter()
@@ -98,7 +99,7 @@ export const TokenPage: FC<TokenPageProps> = ({ token: _token, tokenInfo }) => {
             <div className="flex flex-col gap-10 mt-6">
               <div className="flex gap-6">
                 <div className="flex-auto min-w-0">
-                  <TokenChart token={token} />
+                  <TokenChart chainId={chainId} token={token} />
                 </div>
                 <div className="min-[854px]:w-[420px] max-[854px]:hidden">
                   <AnimatePresence>
@@ -130,7 +131,7 @@ export const TokenPage: FC<TokenPageProps> = ({ token: _token, tokenInfo }) => {
                     <TableFiltersPoolType />
                     <TableFiltersNetwork
                       network={token.chainId}
-                      supportedNetworks={SUSHISWAP_SUPPORTED_CHAIN_IDS}
+                      supportedNetworks={SushiSwapChainIds}
                       unsupportedNetworkHref="/ethereum/explore/tokens"
                       onSelect={(network) =>
                         router.push(

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/token/[address]/page.tsx
@@ -86,6 +86,7 @@ export default async function TokenPage(props: {
 
   return (
     <_TokenPage
+      chainId={chainId}
       token={
         token && typeof token.toJSON === 'function' ? token.toJSON() : token
       }

--- a/apps/web/src/lib/network.ts
+++ b/apps/web/src/lib/network.ts
@@ -1,5 +1,5 @@
+import { isSushiSwapChainId } from '@sushiswap/graph-client/data-api'
 import { type ChainId, getChainById } from 'sushi'
-import { isSushiSwapChainId } from 'sushi/evm'
 
 export const getNetworkName = (network: ChainId) => {
   return getChainById(network).name

--- a/apps/web/src/lib/wagmi/config/viem.ts
+++ b/apps/web/src/lib/wagmi/config/viem.ts
@@ -142,6 +142,12 @@ export const publicTransports = {
   [EvmChainId.ROBINHOOD]: http(
     `https://lb.drpc.live/ogrpc?network=robinhood&dkey=${drpcId}`,
   ),
+  [EvmChainId.UNICHAIN]: http(
+    `https://lb.drpc.live/ogrpc?network=unichain&dkey=${drpcId}`,
+  ),
+  [EvmChainId.WORLDCHAIN]: http(
+    `https://lb.drpc.live/ogrpc?network=worldchain&dkey=${drpcId}`,
+  ),
   /* Testnets */
   [EvmChainId.ARBITRUM_SEPOLIA]: http('https://sepolia-rollup.arbitrum.io/rpc'),
   // [EvmChainId.POLYGON_TESTNET]: http('https://rpc.ankr.com/polygon_mumbai'),

--- a/packages/graph-client/src/subgraphs/data-api/queries/pool/v3-pool.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/pool/v3-pool.ts
@@ -53,9 +53,6 @@ export const V3PoolQuery = graphql(
       liquidity
       sqrtPrice
       tick
-      observationIndex
-      feeGrowthGlobal0X128
-      feeGrowthGlobal1X128
       volumeUSD
       liquidityUSD
       token0Price
@@ -137,9 +134,6 @@ export async function getV3Pool(
 
         sqrtPrice: BigInt(pool.sqrtPrice),
         tick: BigInt(pool.tick),
-        observationIndex: BigInt(pool.observationIndex),
-        feeGrowthGlobal0X128: BigInt(pool.feeGrowthGlobal0X128),
-        feeGrowthGlobal1X128: BigInt(pool.feeGrowthGlobal1X128),
 
         liquidityUSD: pool.liquidityUSD,
         volumeUSD: pool.volumeUSD,
@@ -206,8 +200,12 @@ export async function getV3Pool(
 }
 
 export type RawV3Pool = NonNullable<Awaited<ReturnType<typeof getV3Pool>>>
-export type V3Pool = PoolHasSteerVaults<
+type FullV3Pool = PoolHasSteerVaults<
   PoolWithAprs<PoolWithIncentives<PoolHistory1D<PoolV3<PoolBase>>>>
+>
+export type V3Pool = Omit<
+  FullV3Pool,
+  'observationIndex' | 'feeGrowthGlobal0X128' | 'feeGrowthGlobal1X128'
 >
 
 export function hydrateV3Pool(pool: RawV3Pool | V3Pool) {

--- a/packages/graph-client/src/subgraphs/data-api/queries/pool/v3-pool.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/pool/v3-pool.ts
@@ -200,12 +200,8 @@ export async function getV3Pool(
 }
 
 export type RawV3Pool = NonNullable<Awaited<ReturnType<typeof getV3Pool>>>
-type FullV3Pool = PoolHasSteerVaults<
+export type V3Pool = PoolHasSteerVaults<
   PoolWithAprs<PoolWithIncentives<PoolHistory1D<PoolV3<PoolBase>>>>
->
-export type V3Pool = Omit<
-  FullV3Pool,
-  'observationIndex' | 'feeGrowthGlobal0X128' | 'feeGrowthGlobal1X128'
 >
 
 export function hydrateV3Pool(pool: RawV3Pool | V3Pool) {

--- a/packages/graph-client/src/subgraphs/data-api/queries/v3/pools-by-tokens.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/v3/pools-by-tokens.ts
@@ -4,14 +4,13 @@ import { type RequestOptions, request } from 'src/lib/request.js'
 import {
   type EvmID,
   EvmToken,
-  type PoolBase,
-  type PoolV3,
   SushiSwapProtocol,
   isSushiSwapV3ChainId,
 } from 'sushi/evm'
 import type { Address } from 'viem'
 import { SUSHI_DATA_API_GRAPHQL_URL } from '../../data-api-host.js'
 import { graphql } from '../../graphql.js'
+import type { V3BasePool } from './pools.js'
 
 export const V3PoolsByTokensQuery = graphql(
   `
@@ -49,9 +48,6 @@ export const V3PoolsByTokensQuery = graphql(
         token1Price
         sqrtPrice
         tick
-        observationIndex
-        feeGrowthGlobal0X128
-        feeGrowthGlobal1X128
         volumeUSD
         liquidityUSD
         feesUSD
@@ -66,7 +62,7 @@ export type GetV3BasePoolsByTokens = VariablesOf<typeof V3PoolsByTokensQuery>
 export async function getV3BasePoolsByToken(
   variables: GetV3BasePoolsByTokens,
   options?: RequestOptions,
-): Promise<PoolV3<PoolBase>[]> {
+): Promise<V3BasePool[]> {
   const url = SUSHI_DATA_API_GRAPHQL_URL
   const chainId = variables.chainId
 
@@ -126,15 +122,12 @@ export async function getV3BasePoolsByToken(
 
           sqrtPrice: BigInt(pool.sqrtPrice),
           tick: BigInt(pool.tick),
-          observationIndex: BigInt(pool.observationIndex),
-          feeGrowthGlobal0X128: BigInt(pool.feeGrowthGlobal0X128),
-          feeGrowthGlobal1X128: BigInt(pool.feeGrowthGlobal1X128),
 
           liquidityUSD: pool.liquidityUSD,
           volumeUSD: pool.volumeUSD,
           feesUSD: pool.feesUSD,
           txCount: pool.txCount,
-        }) satisfies PoolV3<PoolBase>,
+        }) satisfies V3BasePool,
     )
   }
 

--- a/packages/graph-client/src/subgraphs/data-api/queries/v3/pools.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/v3/pools.ts
@@ -61,11 +61,7 @@ export const V3PoolsQuery = graphql(
 )
 
 export type GetV3BasePools = VariablesOf<typeof V3PoolsQuery>
-type RemovedV3PoolFields =
-  | 'observationIndex'
-  | 'feeGrowthGlobal0X128'
-  | 'feeGrowthGlobal1X128'
-export type V3BasePool = Omit<PoolV3<PoolBase>, RemovedV3PoolFields>
+export type V3BasePool = PoolV3<PoolBase>
 
 export async function getV3BasePools(
   variables: GetV3BasePools,

--- a/packages/graph-client/src/subgraphs/data-api/queries/v3/pools.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/v3/pools.ts
@@ -51,9 +51,6 @@ export const V3PoolsQuery = graphql(
       token1Price
       sqrtPrice
       tick
-      observationIndex
-      feeGrowthGlobal0X128
-      feeGrowthGlobal1X128
       volumeUSD
       liquidityUSD
       feesUSD
@@ -64,11 +61,16 @@ export const V3PoolsQuery = graphql(
 )
 
 export type GetV3BasePools = VariablesOf<typeof V3PoolsQuery>
+type RemovedV3PoolFields =
+  | 'observationIndex'
+  | 'feeGrowthGlobal0X128'
+  | 'feeGrowthGlobal1X128'
+export type V3BasePool = Omit<PoolV3<PoolBase>, RemovedV3PoolFields>
 
 export async function getV3BasePools(
   variables: GetV3BasePools,
   options?: RequestOptions,
-): Promise<PoolV3<PoolBase>[]> {
+): Promise<V3BasePool[]> {
   const url = SUSHI_DATA_API_GRAPHQL_URL
   const chainId = variables.chainId as EvmChainId
 
@@ -122,20 +124,13 @@ export async function getV3BasePools(
 
           sqrtPrice: BigInt(pool.sqrtPrice),
           tick: BigInt(pool.tick),
-          observationIndex: BigInt(pool.observationIndex),
-          feeGrowthGlobal0X128: BigInt(pool.feeGrowthGlobal0X128),
-          feeGrowthGlobal1X128: BigInt(pool.feeGrowthGlobal1X128),
 
           liquidityUSD: pool.liquidityUSD,
           volumeUSD: pool.volumeUSD,
           feesUSD: pool.feesUSD,
           txCount: pool.txCount,
-        }) satisfies PoolV3<PoolBase>,
+        }) satisfies V3BasePool,
     )
   }
   return []
 }
-
-export type V3BasePool = NonNullable<
-  Awaited<ReturnType<typeof getV3BasePools>>
->[0]

--- a/packages/graph-client/src/subgraphs/data-api/schema.graphql
+++ b/packages/graph-client/src/subgraphs/data-api/schema.graphql
@@ -834,9 +834,6 @@ type V3Pool {
   liquidity: String!
   sqrtPrice: String!
   tick: String!
-  observationIndex: String!
-  feeGrowthGlobal0X128: String!
-  feeGrowthGlobal1X128: String!
   volumeUSD: Float!
   liquidityUSD: Float!
   token0Price: Float!
@@ -878,9 +875,6 @@ type V3BasePool {
   token1Price: Float!
   sqrtPrice: String!
   tick: String!
-  observationIndex: String!
-  feeGrowthGlobal0X128: String!
-  feeGrowthGlobal1X128: String!
   volumeUSD: Float!
   liquidityUSD: Float!
   feesUSD: Float!

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 3.2.2
       version: 3.2.2
     sushi:
-      specifier: 7.3.1
-      version: 7.3.1
+      specifier: 7.3.2
+      version: 7.3.2
     wagmi:
       specifier: 3.3.2
       version: 3.3.2
@@ -134,7 +134,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 8.4.7
@@ -603,7 +603,7 @@ importers:
         version: 2.3.3
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tiny-invariant:
         specifier: 1.3.1
         version: 1.3.1
@@ -791,7 +791,7 @@ importers:
         version: 1.0.0
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       viem:
         specifier: 2.55.0
         version: 2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11)
@@ -853,7 +853,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.4.19(tsx@4.23.0)(yaml@2.9.0)
@@ -899,7 +899,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -953,7 +953,7 @@ importers:
         version: 6.0.3
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -969,7 +969,7 @@ importers:
         version: 6.0.3
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -1234,7 +1234,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sushi:
         specifier: catalog:web3
-        version: 7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.4.19(tsx@4.23.0)(yaml@2.9.0)
@@ -15322,8 +15322,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  sushi@7.3.1:
-    resolution: {integrity: sha512-Ot2O2ntvmAatYRqh6dleueDWY71ayTcEQVVcCZpAHzMUHZbGcNPrniOM8QxEs6L4vJt9RKUJBuuf14s5bzAMhg==}
+  sushi@7.3.2:
+    resolution: {integrity: sha512-DJHxBoAPd9WDWbH7Raw0U+TaHrdt5kIDEiLJeBpEEFKtGmke7E0/jS823E7J4t9zwvskVmQnzYso/4NEg+MYbw==}
     peerDependencies:
       typescript: 5.9.3
       viem: 2.55.0
@@ -36496,7 +36496,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  sushi@7.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
+  sushi@7.3.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
     dependencies:
       '@solana/addresses': 6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       tiny-invariant: 1.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalogs:
     "@wagmi/core": 3.2.2
     "viem": 2.55.0
     "@solana/addresses": 6.0.1
-    "sushi": 7.3.1
+    "sushi": 7.3.2
 
   react:
     "next": 16.2.9


### PR DESCRIPTION
## Summary

- remove `observationIndex` and global fee-growth fields from the data-api schema mirror
- stop requesting and converting the removed fields in V3 pool queries
- update the web3 catalog to `sushi@7.3.2`
- use the reduced shared `PoolV3` shape directly for `V3Pool` and `V3BasePool`, without compatibility `Omit` types
- add public transports for Unichain and World Chain, which are included in the expanded `EvmChainId` in 7.3.2
- narrow V2 positions and data-api-backed routes at their capability boundaries while leaving generic query hooks unchanged

## Related

- depends on sushi-labs/data-api#374
- shared type release: sushi-labs/sushi#510 (`sushi@7.3.2`)

## Verification

- `pnpm --filter @sushiswap/graph-client check`
- `pnpm lint`
- `pnpm format`
- frozen lockfile install with scripts disabled
- `git diff --check`
- GitHub build, types, unit tests, and end-to-end test checks pass
- Vercel preview deployment passes