### PR TITLE
Chore: decouple launchpad fee split query

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.test.ts
@@ -21,10 +21,6 @@ const token: LaunchpadToken = {
   symbol: 'TEST',
   decimals: 18,
   initialSupply: '1000000000000000000000000000',
-  feeSplit: {
-    sushiFeeBps: 50,
-    creatorFeeBps: 50,
-  },
   indexingStatus: 'CONFIRMED',
   pool: {
     address: '0x4444444444444444444444444444444444444444',

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
@@ -30,7 +30,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { isUserRejectedError } from 'src/lib/wagmi/errors'
 import { Checker } from 'src/lib/wagmi/systems/checker'
-import { formatPercent } from 'sushi'
 import type { EvmAddress } from 'sushi/evm'
 import { getEvmChainById } from 'sushi/evm'
 import {
@@ -639,19 +638,10 @@ export function ManageTokenPage({
               </p>
             </div>
             <div className="rounded-2xl border border-white/[0.06] bg-white/[0.03] p-5">
-              <DetailList
-                className="space-y-3"
-                items={[
-                  {
-                    label: 'Sushi recipient',
-                    value: formatPercent(token.feeSplit.sushiFeeBps / 10_000),
-                  },
-                  {
-                    label: 'Creator recipient',
-                    value: formatPercent(token.feeSplit.creatorFeeBps / 10_000),
-                  },
-                ]}
-              />
+              <p className="text-sm text-perps-muted-50">
+                Distribution follows the fee configuration recorded by the
+                launch contract.
+              </p>
               <Checker.Connect
                 namespace="evm"
                 fullWidth

--- a/packages/graph-client/src/subgraphs/data-api/queries/launchpad/token-fragment.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/launchpad/token-fragment.ts
@@ -12,10 +12,6 @@ export const LaunchpadTokenFragment = graphql(`
     symbol
     decimals
     initialSupply
-    feeSplit {
-      sushiFeeBps
-      creatorFeeBps
-    }
     indexingStatus
     pool {
       address


### PR DESCRIPTION
## Summary

- stop selecting feeSplit in the shared launchpad token fragment
- remove fee-recipient percentages from the Manage view
- keep fee distribution behavior unchanged

## Why

Prepares the frontend for the provider-aware launchpad API, where fee split is a Sushi V1-specific field rather than part of the common token interface. This PR can merge before the backend change.

## Testing

- graph-client generation and build passed
- 7 launchpad test files / 41 tests passed
- targeted Biome check passed
- git diff --check passed
- monorepo check reached web and is blocked only by the clean worktree not containing the untracked TradingView library assets