### PR TITLE
feat(web): add launchpad feed filters

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/format.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/format.ts
@@ -134,6 +134,4 @@ export function getSelectedMetric(
         value: format(new Date(token.createdAt), 'MMM d'),
       }
   }
-
-  return { label: 'Launched', value: '—' }
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-feed.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-feed.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_LAUNCHPAD_TOKEN_SORT,
+  getLaunchpadFeed,
+  getLaunchpadFeedSortField,
+  getLaunchpadFeedWindow,
+  isWindowedLaunchpadFeed,
+  parseLaunchpadTokenSortField,
+} from './launchpad-feed'
+
+describe('launchpad feeds', () => {
+  it('opens on the hot feed', () => {
+    expect(DEFAULT_LAUNCHPAD_TOKEN_SORT).toBe('VOLUME_1H')
+    expect(getLaunchpadFeed(DEFAULT_LAUNCHPAD_TOKEN_SORT)).toBe('HOT')
+  })
+
+  it('derives the feed and window from the sort field alone', () => {
+    expect(getLaunchpadFeed('VOLUME_6H')).toBe('HOT')
+    expect(getLaunchpadFeed('CREATED_AT')).toBe('NEW')
+    expect(getLaunchpadFeed('TVL_CHANGE_24H')).toBe('CLIMBING')
+    expect(getLaunchpadFeed('MARKET_CAPITALIZATION')).toBe('TOP')
+
+    expect(getLaunchpadFeedWindow('VOLUME_6H')).toBe('6H')
+    expect(getLaunchpadFeedWindow('TVL_CHANGE_12H')).toBe('12H')
+  })
+
+  it('keeps the pre-feed sort fields resolving', () => {
+    // Shared links and embeds still carry these, so they have to land on a feed
+    // rather than silently falling back to the default.
+    expect(parseLaunchpadTokenSortField('CURRENT_TVL')).toBe('CURRENT_TVL')
+    expect(getLaunchpadFeed('CURRENT_TVL')).toBe('TOP')
+    expect(parseLaunchpadTokenSortField('VOLUME_12H')).toBe('VOLUME_12H')
+    expect(getLaunchpadFeed('VOLUME_12H')).toBe('HOT')
+
+    expect(parseLaunchpadTokenSortField('NONSENSE')).toBe(
+      DEFAULT_LAUNCHPAD_TOKEN_SORT,
+    )
+    expect(parseLaunchpadTokenSortField(null)).toBe(
+      DEFAULT_LAUNCHPAD_TOKEN_SORT,
+    )
+  })
+
+  it('falls back to a real window for the windowless feeds', () => {
+    expect(getLaunchpadFeedWindow('MARKET_CAPITALIZATION')).toBe('1H')
+    expect(getLaunchpadFeedWindow('CREATED_AT')).toBe('1H')
+    expect(getLaunchpadFeedWindow('CURRENT_TVL')).toBe('1H')
+  })
+
+  it('maps a feed and window back to a sort field', () => {
+    expect(getLaunchpadFeedSortField('HOT', '24H')).toBe('VOLUME_24H')
+    expect(getLaunchpadFeedSortField('CLIMBING', '1H')).toBe('TVL_CHANGE_1H')
+    // the window is irrelevant to the feeds that have none
+    expect(getLaunchpadFeedSortField('NEW', '6H')).toBe('CREATED_AT')
+    expect(getLaunchpadFeedSortField('TOP', '6H')).toBe('MARKET_CAPITALIZATION')
+
+    expect(isWindowedLaunchpadFeed('HOT')).toBe(true)
+    expect(isWindowedLaunchpadFeed('TOP')).toBe(false)
+  })
+})

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-feed.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-feed.ts
@@ -1,0 +1,101 @@
+import type { LaunchpadTokenSortField } from '../types'
+
+/**
+ * A feed is a named way to browse launches. It maps onto exactly one
+ * `LaunchpadTokenSortField` — sorting drives the cursor pagination, so the
+ * feed a user picks has to be something the API can order by on its own.
+ */
+export type LaunchpadFeed = 'HOT' | 'NEW' | 'CLIMBING' | 'TOP'
+
+export type LaunchpadFeedWindow = '1H' | '6H' | '12H' | '24H'
+
+export const LAUNCHPAD_FEED_WINDOWS = [
+  '1H',
+  '6H',
+  '12H',
+  '24H',
+] as const satisfies readonly LaunchpadFeedWindow[]
+
+const WINDOWED_FEED_SORT_FIELDS = {
+  HOT: {
+    '1H': 'VOLUME_1H',
+    '6H': 'VOLUME_6H',
+    '12H': 'VOLUME_12H',
+    '24H': 'VOLUME_24H',
+  },
+  CLIMBING: {
+    '1H': 'TVL_CHANGE_1H',
+    '6H': 'TVL_CHANGE_6H',
+    '12H': 'TVL_CHANGE_12H',
+    '24H': 'TVL_CHANGE_24H',
+  },
+} as const satisfies Record<
+  'HOT' | 'CLIMBING',
+  Record<LaunchpadFeedWindow, LaunchpadTokenSortField>
+>
+
+const FIXED_FEED_SORT_FIELDS = {
+  NEW: 'CREATED_AT',
+  TOP: 'MARKET_CAPITALIZATION',
+} as const satisfies Record<'NEW' | 'TOP', LaunchpadTokenSortField>
+
+/**
+ * Every field the API accepts, not just the ones a pill can reach. `CURRENT_TVL`
+ * and the 12H windows predate the feeds and still arrive in shared links and
+ * embeds, so they have to keep resolving.
+ */
+const SORT_FIELDS = new Set<LaunchpadTokenSortField>([
+  'CREATED_AT',
+  'MARKET_CAPITALIZATION',
+  'CURRENT_TVL',
+  'VOLUME_1H',
+  'VOLUME_6H',
+  'VOLUME_12H',
+  'VOLUME_24H',
+  'TVL_CHANGE_1H',
+  'TVL_CHANGE_6H',
+  'TVL_CHANGE_12H',
+  'TVL_CHANGE_24H',
+])
+
+export const DEFAULT_LAUNCHPAD_TOKEN_SORT = 'VOLUME_1H' as const
+
+export function parseLaunchpadTokenSortField(
+  value: string | null,
+): LaunchpadTokenSortField {
+  const requestedSort = value as LaunchpadTokenSortField
+  return SORT_FIELDS.has(requestedSort)
+    ? requestedSort
+    : DEFAULT_LAUNCHPAD_TOKEN_SORT
+}
+
+export function getLaunchpadFeed(
+  sortBy: LaunchpadTokenSortField,
+): LaunchpadFeed {
+  if (sortBy.startsWith('VOLUME_')) return 'HOT'
+  if (sortBy.startsWith('TVL_CHANGE_')) return 'CLIMBING'
+  if (sortBy === 'CREATED_AT') return 'NEW'
+  return 'TOP'
+}
+
+export function isWindowedLaunchpadFeed(
+  feed: LaunchpadFeed,
+): feed is 'HOT' | 'CLIMBING' {
+  return feed === 'HOT' || feed === 'CLIMBING'
+}
+
+export function getLaunchpadFeedWindow(
+  sortBy: LaunchpadTokenSortField,
+): LaunchpadFeedWindow {
+  const suffix = sortBy.split('_').at(-1) as LaunchpadFeedWindow
+  return LAUNCHPAD_FEED_WINDOWS.includes(suffix) ? suffix : '1H'
+}
+
+export function getLaunchpadFeedSortField(
+  feed: LaunchpadFeed,
+  window: LaunchpadFeedWindow,
+): LaunchpadTokenSortField {
+  return isWindowedLaunchpadFeed(feed)
+    ? WINDOWED_FEED_SORT_FIELDS[feed][window]
+    : FIXED_FEED_SORT_FIELDS[feed]
+}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
@@ -271,7 +271,6 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
                 <TokenGrid
                   tokens={tokens}
                   sortBy={sortBy}
-                  ranked
                   isFetchingNextPage={isFetchingNextPage}
                 />
               </InfiniteScroll>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
@@ -20,22 +20,19 @@ import { getEvmChainById } from 'sushi/evm'
 import { isAddress } from 'viem'
 import { PerpsCard } from '~evm/perps/_ui/_common/perps-card'
 import { formatUsd } from '../_lib/format'
+import { parseLaunchpadTokenSortField } from '../_lib/launchpad-feed'
 import {
-  LAUNCHPAD_PROVIDER_FILTERS,
   getLaunchpadProvidersForFilter,
   parseLaunchpadProviderFilter,
 } from '../_lib/launchpad-provider'
 import { useLaunchpadStats } from '../_lib/use-launchpad-stats'
 import { useLaunchpadTokens } from '../_lib/use-launchpad-tokens'
 import type { LaunchpadChainId } from '../constants'
-import { LaunchpadProviderMark } from './launchpad-provider-mark'
 import { MetricStrip, MetricStripItem } from './metric-strip'
+import { ProviderFilterControls } from './provider-filter-controls'
 import { CollectionStateCard } from './state-card'
 import { TokenGrid, TokenGridSkeleton } from './token-grid'
-import {
-  TokenSortControls,
-  parseLaunchpadTokenSortField,
-} from './token-sort-controls'
+import { TokenSortControls } from './token-sort-controls'
 
 export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
   const chainKey = getEvmChainById(chainId).key
@@ -200,20 +197,31 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
       <section id="discover" className="border-t border-white/[0.04] py-8">
         <Container maxWidth="7xl" className="w-full px-4">
           <PerpsCard className="p-3 sm:p-4" fullWidth>
-            <div className="grid gap-3 md:grid-cols-[minmax(240px,1fr)_auto]">
-              <TextField
-                type="text"
-                value={search}
-                onChange={(event) => {
-                  const value = event.target.value
-                  setSearch(value)
-                  updateParams({ search: value || undefined })
-                }}
-                icon={MagnifyingGlassIcon}
-                placeholder="Search name, symbol, or address"
-                aria-label="Search launches"
-                className="!bg-white/[0.04] !text-perps-muted xl:!max-w-[480px]"
-              />
+            <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <TextField
+                  type="text"
+                  value={search}
+                  onChange={(event) => {
+                    const value = event.target.value
+                    setSearch(value)
+                    updateParams({ search: value || undefined })
+                  }}
+                  icon={MagnifyingGlassIcon}
+                  placeholder="Search name, symbol, or address"
+                  aria-label="Search launches"
+                  className="!bg-white/[0.04] !text-perps-muted"
+                  wrapperClassName="min-w-0 sm:w-[300px] xl:w-[400px]"
+                />
+                <ProviderFilterControls
+                  filter={providerFilter}
+                  onFilterChange={(nextFilter) =>
+                    updateParams({
+                      provider: nextFilter === 'all' ? undefined : nextFilter,
+                    })
+                  }
+                />
+              </div>
               <TextField
                 type="text"
                 value={creator}
@@ -236,51 +244,6 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
                   })
                 }
               />
-            </div>
-            <div
-              className="mt-3 flex flex-wrap items-center gap-2"
-              role="group"
-              aria-label="Filter launches by provider"
-            >
-              {LAUNCHPAD_PROVIDER_FILTERS.map((option) => (
-                <Button
-                  key={option.value}
-                  type="button"
-                  size="sm"
-                  variant={
-                    option.value === providerFilter
-                      ? 'perps-default'
-                      : 'perps-secondary'
-                  }
-                  aria-pressed={option.value === providerFilter}
-                  onClick={() =>
-                    updateParams({
-                      provider:
-                        option.value === 'all' ? undefined : option.value,
-                    })
-                  }
-                >
-                  <span className="flex items-center gap-1.5">
-                    <span className="flex items-center" aria-hidden>
-                      {getLaunchpadProvidersForFilter(option.value).map(
-                        (provider, index) => (
-                          <LaunchpadProviderMark
-                            key={provider}
-                            provider={provider}
-                            size="sm"
-                            className={
-                              index > 0
-                                ? '-ml-1 rounded-full ring-2 ring-perps-background'
-                                : undefined
-                            }
-                          />
-                        ),
-                      )}
-                    </span>
-                    {option.label}
-                  </span>
-                </Button>
-              ))}
             </div>
           </PerpsCard>
 
@@ -308,6 +271,7 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
                 <TokenGrid
                   tokens={tokens}
                   sortBy={sortBy}
+                  ranked
                   isFetchingNextPage={isFetchingNextPage}
                 />
               </InfiniteScroll>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/provider-filter-controls.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/provider-filter-controls.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { classNames } from '@sushiswap/ui'
+import {
+  LAUNCHPAD_PROVIDER_FILTERS,
+  type LaunchpadProviderFilter,
+  getLaunchpadProvidersForFilter,
+} from '../_lib/launchpad-provider'
+import { LaunchpadProviderMark } from './launchpad-provider-mark'
+import {
+  SEGMENTED_GROUP,
+  SEGMENTED_ITEM,
+  SEGMENTED_ITEM_IDLE,
+  SEGMENTED_ITEM_SELECTED,
+} from './segmented-control'
+
+export function ProviderFilterControls({
+  filter,
+  onFilterChange,
+}: {
+  filter: LaunchpadProviderFilter
+  onFilterChange: (filter: LaunchpadProviderFilter) => void
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter launches by provider"
+      className={classNames(
+        SEGMENTED_GROUP,
+        'justify-between sm:justify-start',
+      )}
+    >
+      {LAUNCHPAD_PROVIDER_FILTERS.map((option) => {
+        const selected = option.value === filter
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onFilterChange(option.value)}
+            className={classNames(
+              SEGMENTED_ITEM,
+              'w-full sm:w-auto',
+              selected ? SEGMENTED_ITEM_SELECTED : SEGMENTED_ITEM_IDLE,
+            )}
+          >
+            <span className="flex items-center" aria-hidden>
+              {getLaunchpadProvidersForFilter(option.value).map(
+                (provider, index) => (
+                  <LaunchpadProviderMark
+                    key={provider}
+                    provider={provider}
+                    size="sm"
+                    className={classNames(
+                      'transition-opacity',
+                      index > 0 &&
+                        '-ml-1.5 rounded-full ring-2 ring-perps-background',
+                      !selected && 'opacity-60',
+                    )}
+                  />
+                ),
+              )}
+            </span>
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/segmented-control.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/segmented-control.ts
@@ -1,0 +1,21 @@
+/**
+ * The discovery toolbar is three segmented groups sitting side by side — feeds,
+ * time window, provider — so they share one set of classes rather than three
+ * copies that drift. Accent marks *what you're looking at* (the active feed);
+ * the neutral state marks the narrower choices within it, which keeps a single
+ * blue emphasis on the bar.
+ */
+export const SEGMENTED_GROUP =
+  'flex shrink-0 items-center gap-1 rounded-xl border border-white/[0.06] bg-white/[0.03] p-1'
+
+export const SEGMENTED_ITEM =
+  'flex h-8 items-center justify-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-perps-blue/50 disabled:cursor-not-allowed'
+
+export const SEGMENTED_ITEM_ACCENT =
+  'bg-perps-blue/[0.14] text-perps-blue shadow-[inset_0_0_0_1px_rgba(52,155,254,0.28)]'
+
+export const SEGMENTED_ITEM_SELECTED =
+  'bg-white/[0.09] text-perps-muted shadow-sm'
+
+export const SEGMENTED_ITEM_IDLE =
+  'text-perps-muted-50 hover:bg-white/[0.04] hover:text-perps-muted disabled:hover:bg-transparent disabled:hover:text-perps-muted-50'

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ArrowUpRightIcon } from '@heroicons/react/20/solid'
-import { SkeletonBox, classNames } from '@sushiswap/ui'
+import { SkeletonBox } from '@sushiswap/ui'
 import { NetworkIcon } from '@sushiswap/ui/icons/network-icon'
 import Link from 'next/link'
 import { getEvmChainById } from 'sushi/evm'
@@ -60,17 +60,14 @@ export function TokenCardSkeleton() {
 export function TokenCard({
   token,
   sortBy = 'VOLUME_24H',
-  rank,
   manage = false,
 }: {
   token: LaunchpadToken
   sortBy?: LaunchpadTokenSortField
-  rank?: number
   manage?: boolean
 }) {
   const chain = getEvmChainById(token.chainId)
   const chainKey = chain.key
-  const isNewFeed = sortBy === 'CREATED_AT'
   const selectedMetric = getSelectedMetric(
     token,
     sortBy === 'MARKET_CAPITALIZATION' || sortBy === 'CURRENT_TVL'
@@ -119,18 +116,6 @@ export function TokenCard({
               </div>
             </div>
           </div>
-          {rank !== undefined && !isNewFeed ? (
-            <span
-              className={classNames(
-                'flex h-[22px] shrink-0 items-center rounded-md px-2 text-[11px] font-semibold tabular-nums',
-                rank === 0
-                  ? 'bg-perps-blue/[0.14] text-perps-blue'
-                  : 'bg-white/[0.06] text-perps-muted-50',
-              )}
-            >
-              #{rank + 1}
-            </span>
-          ) : null}
         </div>
 
         <div className="mt-4">

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
@@ -1,10 +1,17 @@
+'use client'
+
 import { ArrowUpRightIcon } from '@heroicons/react/20/solid'
-import { SkeletonBox } from '@sushiswap/ui'
+import { SkeletonBox, classNames } from '@sushiswap/ui'
 import { NetworkIcon } from '@sushiswap/ui/icons/network-icon'
 import Link from 'next/link'
 import { getEvmChainById } from 'sushi/evm'
 import { PerpsCard } from '~evm/perps/_ui/_common/perps-card'
-import { formatUsd, getSelectedMetric, shortenAddress } from '../_lib/format'
+import {
+  formatLaunchpadPriceUsd,
+  formatUsd,
+  getSelectedMetric,
+  shortenAddress,
+} from '../_lib/format'
 import { launchpadProviderHasCapability } from '../_lib/launchpad-provider'
 import type { LaunchpadToken, LaunchpadTokenSortField } from '../types'
 import { LaunchpadCreatorLink } from './launchpad-creator-link'
@@ -53,17 +60,22 @@ export function TokenCardSkeleton() {
 export function TokenCard({
   token,
   sortBy = 'VOLUME_24H',
+  rank,
   manage = false,
 }: {
   token: LaunchpadToken
   sortBy?: LaunchpadTokenSortField
+  rank?: number
   manage?: boolean
 }) {
   const chain = getEvmChainById(token.chainId)
   const chainKey = chain.key
-  const volumeMetric = getSelectedMetric(
+  const isNewFeed = sortBy === 'CREATED_AT'
+  const selectedMetric = getSelectedMetric(
     token,
-    sortBy.startsWith('VOLUME_') ? sortBy : 'VOLUME_24H',
+    sortBy === 'MARKET_CAPITALIZATION' || sortBy === 'CURRENT_TVL'
+      ? 'VOLUME_24H'
+      : sortBy,
   )
   const href =
     manage && launchpadProviderHasCapability(token.provider, 'manage')
@@ -107,13 +119,25 @@ export function TokenCard({
               </div>
             </div>
           </div>
+          {rank !== undefined && !isNewFeed ? (
+            <span
+              className={classNames(
+                'flex h-[22px] shrink-0 items-center rounded-md px-2 text-[11px] font-semibold tabular-nums',
+                rank === 0
+                  ? 'bg-perps-blue/[0.14] text-perps-blue'
+                  : 'bg-white/[0.06] text-perps-muted-50',
+              )}
+            >
+              #{rank + 1}
+            </span>
+          ) : null}
         </div>
 
         <div className="mt-4">
           <div className="text-[11px] font-medium uppercase tracking-wide text-perps-muted-50">
             MC
           </div>
-          <div className="mt-1 text-xl font-semibold tracking-tight text-perps-muted">
+          <div className="mt-1 text-xl font-semibold tracking-tight text-perps-muted tabular-nums">
             {formatUsd(token.metrics?.marketCapitalizationUsd)}
           </div>
         </div>
@@ -123,19 +147,16 @@ export function TokenCard({
             <div className="text-xs text-perps-muted-50">Price</div>
             <div className="mt-1 text-sm font-medium text-perps-muted">
               <PriceSensitiveText price={token.metrics?.priceUsd}>
-                {token.metrics?.priceUsd === null ||
-                token.metrics?.priceUsd === undefined
-                  ? '—'
-                  : `$${token.metrics.priceUsd.toPrecision(4)}`}
+                {formatLaunchpadPriceUsd(token.metrics?.priceUsd)}
               </PriceSensitiveText>
             </div>
           </div>
           <div className="text-right">
             <div className="text-xs text-perps-muted-50">
-              {volumeMetric.label}
+              {selectedMetric.label}
             </div>
             <div className="mt-1 text-sm font-medium text-perps-muted">
-              {volumeMetric.value}
+              {selectedMetric.value}
             </div>
           </div>
         </div>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-grid.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-grid.tsx
@@ -32,14 +32,11 @@ export function TokenGrid({
   tokens,
   sortBy,
   manage,
-  ranked = false,
   isFetchingNextPage = false,
 }: {
   tokens: LaunchpadToken[]
   sortBy?: LaunchpadTokenSortField
   manage?: boolean
-  /** Number the cards by their position in the feed. */
-  ranked?: boolean
   isFetchingNextPage?: boolean
 }) {
   if (tokens.length === 0) {
@@ -58,12 +55,11 @@ export function TokenGrid({
 
   return (
     <div className="grid grid-cols-1 gap-3 [&>*]:min-w-0 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
-      {tokens.map((token, index) => (
+      {tokens.map((token) => (
         <TokenCard
           key={token.id}
           token={token}
           sortBy={sortBy}
-          rank={ranked ? index : undefined}
           manage={manage}
         />
       ))}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-grid.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-grid.tsx
@@ -32,11 +32,14 @@ export function TokenGrid({
   tokens,
   sortBy,
   manage,
+  ranked = false,
   isFetchingNextPage = false,
 }: {
   tokens: LaunchpadToken[]
   sortBy?: LaunchpadTokenSortField
   manage?: boolean
+  /** Number the cards by their position in the feed. */
+  ranked?: boolean
   isFetchingNextPage?: boolean
 }) {
   if (tokens.length === 0) {
@@ -55,11 +58,12 @@ export function TokenGrid({
 
   return (
     <div className="grid grid-cols-1 gap-3 [&>*]:min-w-0 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
-      {tokens.map((token) => (
+      {tokens.map((token, index) => (
         <TokenCard
           key={token.id}
           token={token}
           sortBy={sortBy}
+          rank={ranked ? index : undefined}
           manage={manage}
         />
       ))}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-sort-controls.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-sort-controls.tsx
@@ -1,138 +1,125 @@
 'use client'
 
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  classNames,
-} from '@sushiswap/ui'
+  ArrowTrendingUpIcon,
+  FireIcon,
+  SparklesIcon,
+  TrophyIcon,
+} from '@heroicons/react/24/outline'
+import { classNames } from '@sushiswap/ui'
+import { useState } from 'react'
+import {
+  LAUNCHPAD_FEED_WINDOWS,
+  type LaunchpadFeed,
+  getLaunchpadFeed,
+  getLaunchpadFeedSortField,
+  getLaunchpadFeedWindow,
+  isWindowedLaunchpadFeed,
+} from '../_lib/launchpad-feed'
 import type { LaunchpadTokenSortField } from '../types'
+import {
+  SEGMENTED_GROUP,
+  SEGMENTED_ITEM,
+  SEGMENTED_ITEM_ACCENT,
+  SEGMENTED_ITEM_IDLE,
+  SEGMENTED_ITEM_SELECTED,
+} from './segmented-control'
 
-type SortMetric =
-  | 'VOLUME'
-  | 'MARKET_CAPITALIZATION'
-  | 'CURRENT_TVL'
-  | 'CREATED_AT'
-type VolumePeriod = '1H' | '6H' | '12H' | '24H'
-
-const SORT_METRICS: Array<{ value: SortMetric; label: string }> = [
-  { value: 'VOLUME', label: 'Volume' },
-  { value: 'MARKET_CAPITALIZATION', label: 'Marketcap' },
-  { value: 'CURRENT_TVL', label: 'Liquidity' },
-  { value: 'CREATED_AT', label: 'Newest' },
-]
-
-const VOLUME_PERIODS: VolumePeriod[] = ['1H', '6H', '12H', '24H']
-
-const VOLUME_SORT_FIELDS = {
-  '1H': 'VOLUME_1H',
-  '6H': 'VOLUME_6H',
-  '12H': 'VOLUME_12H',
-  '24H': 'VOLUME_24H',
-} as const satisfies Record<VolumePeriod, LaunchpadTokenSortField>
-
-const SORT_FIELDS = new Set<LaunchpadTokenSortField>([
-  ...Object.values(VOLUME_SORT_FIELDS),
-  'MARKET_CAPITALIZATION',
-  'CURRENT_TVL',
-  'CREATED_AT',
-])
-
-export const DEFAULT_LAUNCHPAD_TOKEN_SORT = 'MARKET_CAPITALIZATION' as const
-
-export function parseLaunchpadTokenSortField(
-  value: string | null,
-): LaunchpadTokenSortField {
-  const requestedSort = value as LaunchpadTokenSortField
-  return SORT_FIELDS.has(requestedSort)
-    ? requestedSort
-    : DEFAULT_LAUNCHPAD_TOKEN_SORT
-}
-
-function getSortMetric(sortBy: LaunchpadTokenSortField): SortMetric {
-  if (
-    sortBy === 'MARKET_CAPITALIZATION' ||
-    sortBy === 'CURRENT_TVL' ||
-    sortBy === 'CREATED_AT'
-  ) {
-    return sortBy
-  }
-  return 'VOLUME'
-}
-
-function getVolumePeriod(sortBy: LaunchpadTokenSortField): VolumePeriod {
-  const period = VOLUME_PERIODS.find(
-    (candidate) => VOLUME_SORT_FIELDS[candidate] === sortBy,
-  )
-  return period ?? '24H'
-}
+const FEEDS = [
+  { value: 'HOT', label: 'Hot', icon: FireIcon },
+  { value: 'NEW', label: 'New', icon: SparklesIcon },
+  { value: 'CLIMBING', label: 'Climbing', icon: ArrowTrendingUpIcon },
+  { value: 'TOP', label: 'Top', icon: TrophyIcon },
+] as const satisfies readonly {
+  value: LaunchpadFeed
+  label: string
+  icon: typeof FireIcon
+}[]
 
 export function TokenSortControls({
   sortBy,
   onSortByChange,
-  ariaLabel = 'Sort launches by',
+  ariaLabel = 'Launch feeds',
 }: {
   sortBy: LaunchpadTokenSortField
   onSortByChange: (sortBy: LaunchpadTokenSortField) => void
   ariaLabel?: string
 }) {
-  const sortMetric = getSortMetric(sortBy)
-  const volumePeriod = getVolumePeriod(sortBy)
+  const feed = getLaunchpadFeed(sortBy)
+  const windowed = isWindowedLaunchpadFeed(feed)
+
+  // New and Top carry no window, so the chosen one has to be remembered while
+  // they're active — otherwise a detour through Top silently resets Hot to 1H.
+  const sortWindow = getLaunchpadFeedWindow(sortBy)
+  const [lastWindow, setLastWindow] = useState(sortWindow)
+  if (windowed && lastWindow !== sortWindow) setLastWindow(sortWindow)
+  const activeWindow = windowed ? sortWindow : lastWindow
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row">
-      <Select
-        value={sortMetric}
-        onValueChange={(value) => {
-          const metric = value as SortMetric
-          onSortByChange(
-            metric === 'VOLUME' ? VOLUME_SORT_FIELDS[volumePeriod] : metric,
-          )
-        }}
-      >
-        <SelectTrigger
-          aria-label={ariaLabel}
-          className="w-full !border !border-white/[0.06] !bg-white/[0.04] !text-perps-muted focus:!border-perps-blue md:w-[150px]"
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent className="!bg-black/10 backdrop-blur-2xl">
-          {SORT_METRICS.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
       <div
-        role="radiogroup"
-        aria-label="Volume period"
-        aria-disabled={sortMetric !== 'VOLUME'}
+        role="tablist"
+        aria-label={ariaLabel}
         className={classNames(
-          'flex h-10 shrink-0 items-center rounded-lg border border-white/[0.06] bg-white/[0.04] p-1 transition-opacity justify-between md:justify-start',
-          sortMetric !== 'VOLUME' && 'opacity-40',
+          SEGMENTED_GROUP,
+          'justify-between sm:justify-start',
         )}
       >
-        {VOLUME_PERIODS.map((period) => {
-          const selected = sortMetric === 'VOLUME' && volumePeriod === period
+        {FEEDS.map((option) => {
+          const selected = option.value === feed
           return (
             <button
-              key={period}
+              key={option.value}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onClick={() =>
+                onSortByChange(
+                  getLaunchpadFeedSortField(option.value, activeWindow),
+                )
+              }
+              className={classNames(
+                SEGMENTED_ITEM,
+                'w-full sm:w-auto',
+                selected ? SEGMENTED_ITEM_ACCENT : SEGMENTED_ITEM_IDLE,
+              )}
+            >
+              <option.icon className="h-4 w-4 shrink-0" aria-hidden />
+              {option.label}
+            </button>
+          )
+        })}
+      </div>
+      <div
+        role="radiogroup"
+        aria-label="Time window"
+        aria-disabled={!windowed}
+        className={classNames(
+          SEGMENTED_GROUP,
+          'justify-between transition-opacity sm:justify-start',
+          !windowed && 'opacity-40',
+        )}
+      >
+        {LAUNCHPAD_FEED_WINDOWS.map((option) => {
+          const selected = option === activeWindow
+          return (
+            <button
+              key={option}
               type="button"
               role="radio"
               aria-checked={selected}
-              disabled={sortMetric !== 'VOLUME'}
-              onClick={() => onSortByChange(VOLUME_SORT_FIELDS[period])}
+              disabled={!windowed}
+              onClick={() => {
+                setLastWindow(option)
+                onSortByChange(getLaunchpadFeedSortField(feed, option))
+              }}
               className={classNames(
-                'h-8 min-w-10 w-full rounded-md px-2 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-perps-blue/50 disabled:cursor-not-allowed',
-                selected
-                  ? 'bg-white/[0.09] text-perps-muted shadow-sm'
-                  : 'text-perps-muted-50 hover:text-perps-muted disabled:hover:text-perps-muted-50',
+                SEGMENTED_ITEM,
+                'w-full min-w-10 px-2 text-xs tabular-nums sm:w-auto',
+                selected ? SEGMENTED_ITEM_SELECTED : SEGMENTED_ITEM_IDLE,
               )}
             >
-              {period}
+              {option}
             </button>
           )
         })}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/creator/[address]/_ui/creator-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/creator/[address]/_ui/creator-page.tsx
@@ -11,15 +11,13 @@ import { useMemo, useState } from 'react'
 import { type EvmAddress, EvmChainId, getEvmChainById } from 'sushi/evm'
 import { useEnsName } from 'wagmi'
 import { formatUsd, shortenAddress } from '../../../_lib/format'
+import { DEFAULT_LAUNCHPAD_TOKEN_SORT } from '../../../_lib/launchpad-feed'
 import { useLaunchpadCreator } from '../../../_lib/use-launchpad-creator'
 import { MetricCard } from '../../../_ui/metric-card'
 import { PageHeading } from '../../../_ui/page-heading'
 import { CollectionStateCard } from '../../../_ui/state-card'
 import { TokenGrid } from '../../../_ui/token-grid'
-import {
-  DEFAULT_LAUNCHPAD_TOKEN_SORT,
-  TokenSortControls,
-} from '../../../_ui/token-sort-controls'
+import { TokenSortControls } from '../../../_ui/token-sort-controls'
 import type { LaunchpadChainId } from '../../../constants'
 import type { LaunchpadTokenSortField } from '../../../types'
 
@@ -123,7 +121,7 @@ export function CreatorPage({
                 Confirmed launches created by this address.
               </p>
             </div>
-            <div className="grid gap-3 md:grid-cols-[260px_auto]">
+            <div className="flex flex-col gap-3 xl:flex-row xl:items-center">
               <TextField
                 type="text"
                 value={search}
@@ -132,6 +130,7 @@ export function CreatorPage({
                 placeholder="Search launches"
                 aria-label="Search creator launches"
                 className="!bg-white/[0.04] !text-perps-muted"
+                wrapperClassName="min-w-0 xl:w-[260px]"
               />
               <TokenSortControls
                 sortBy={sortBy}


### PR DESCRIPTION
## Summary
- add feed-aware launchpad sorting and URL state
- add provider filter controls and ranked token cards
- remove unused launchpad age and NEW badge timer code

## Validation
- pnpm --filter web exec vitest run 'src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-feed.test.ts'
- pnpm --filter web check