### PR TITLE
fix(web): attach launchpad trade pagination observer

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/trade-history.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/trade-history.tsx
@@ -160,8 +160,9 @@ export function TradeHistory({ token }: { token: LaunchpadToken }) {
     lastEventAt,
   } = useLaunchpadLiveTrades(input)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const [loadMoreTarget, setLoadMoreTarget] =
-    useState<HTMLDivElement | null>(null)
+  const [loadMoreTarget, setLoadMoreTarget] = useState<HTMLDivElement | null>(
+    null,
+  )
 
   useEffect(() => {
     const root = scrollRef.current

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/trade-history.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/trade-history.tsx
@@ -160,11 +160,12 @@ export function TradeHistory({ token }: { token: LaunchpadToken }) {
     lastEventAt,
   } = useLaunchpadLiveTrades(input)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const loadMoreRef = useRef<HTMLDivElement>(null)
+  const [loadMoreTarget, setLoadMoreTarget] =
+    useState<HTMLDivElement | null>(null)
 
   useEffect(() => {
     const root = scrollRef.current
-    const target = loadMoreRef.current
+    const target = loadMoreTarget
     if (!root || !target || !hasNextPage) return
 
     const observer = new IntersectionObserver(
@@ -178,7 +179,7 @@ export function TradeHistory({ token }: { token: LaunchpadToken }) {
     observer.observe(target)
 
     return () => observer.disconnect()
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, loadMoreTarget])
 
   useEffect(() => {
     setNow(Date.now())
@@ -281,7 +282,7 @@ export function TradeHistory({ token }: { token: LaunchpadToken }) {
                 ))}
                 {(hasNextPage || isFetchingNextPage) && (
                   <div
-                    ref={loadMoreRef}
+                    ref={setLoadMoreTarget}
                     className="flex min-h-8 items-center justify-center text-[11px] text-perps-muted-50"
                   >
                     {isFetchingNextPage ? (


### PR DESCRIPTION
## Summary
- track the conditional recent-trades pagination sentinel when it mounts
- ensure the IntersectionObserver attaches after the initial snapshot renders

## Validation
- pnpm --filter web exec vitest run 'src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_lib/launchpad-stream.test.ts'
- pnpm --filter web check