### PR TITLE
fix(web): stabilize launchpad search and provider filters

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
@@ -22,15 +22,14 @@ import { isAddress } from 'viem'
 import { PerpsCard } from '~evm/perps/_ui/_common/perps-card'
 import { formatUsd } from '../_lib/format'
 import {
-  LAUNCHPAD_PROVIDER_FILTERS,
   getLaunchpadProvidersForFilter,
   parseLaunchpadProviderFilter,
 } from '../_lib/launchpad-provider'
 import { useLaunchpadStats } from '../_lib/use-launchpad-stats'
 import { useLaunchpadTokens } from '../_lib/use-launchpad-tokens'
 import type { LaunchpadChainId } from '../constants'
-import { LaunchpadProviderMark } from './launchpad-provider-mark'
 import { MetricStrip, MetricStripItem } from './metric-strip'
+import { ProviderFilterControls } from './provider-filter-controls'
 import { CollectionStateCard } from './state-card'
 import { TokenGrid, TokenGridSkeleton } from './token-grid'
 import {
@@ -199,20 +198,31 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
       <section id="discover" className="border-t border-white/[0.04] py-8">
         <Container maxWidth="7xl" className="w-full px-4">
           <PerpsCard className="p-3 sm:p-4" fullWidth>
-            <div className="grid gap-3 md:grid-cols-[minmax(240px,1fr)_auto]">
-              <TextField
-                type="text"
-                value={search}
-                onChange={(event) => {
-                  const value = event.target.value
-                  setSearch(value)
-                  updateParams({ search: value || undefined })
-                }}
-                icon={MagnifyingGlassIcon}
-                placeholder="Search name, symbol, or address"
-                aria-label="Search launches"
-                className="!bg-white/[0.04] !text-perps-muted xl:!max-w-[480px]"
-              />
+            <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <TextField
+                  type="text"
+                  value={search}
+                  onChange={(event) => {
+                    const value = event.target.value
+                    setSearch(value)
+                    updateParams({ search: value || undefined })
+                  }}
+                  icon={MagnifyingGlassIcon}
+                  placeholder="Search name, symbol, or address"
+                  aria-label="Search launches"
+                  className="!bg-white/[0.04] !text-perps-muted"
+                  wrapperClassName="min-w-0 sm:w-[300px] xl:w-[400px]"
+                />
+                <ProviderFilterControls
+                  filter={providerFilter}
+                  onFilterChange={(nextFilter) =>
+                    updateParams({
+                      provider: nextFilter === 'all' ? undefined : nextFilter,
+                    })
+                  }
+                />
+              </div>
               <TextField
                 type="text"
                 value={creator}
@@ -235,51 +245,6 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
                   })
                 }
               />
-            </div>
-            <div
-              className="mt-3 flex flex-wrap items-center gap-2"
-              role="group"
-              aria-label="Filter launches by provider"
-            >
-              {LAUNCHPAD_PROVIDER_FILTERS.map((option) => (
-                <Button
-                  key={option.value}
-                  type="button"
-                  size="sm"
-                  variant={
-                    option.value === providerFilter
-                      ? 'perps-default'
-                      : 'perps-secondary'
-                  }
-                  aria-pressed={option.value === providerFilter}
-                  onClick={() =>
-                    updateParams({
-                      provider:
-                        option.value === 'all' ? undefined : option.value,
-                    })
-                  }
-                >
-                  <span className="flex items-center gap-1.5">
-                    <span className="flex items-center" aria-hidden>
-                      {getLaunchpadProvidersForFilter(option.value).map(
-                        (provider, index) => (
-                          <LaunchpadProviderMark
-                            key={provider}
-                            provider={provider}
-                            size="sm"
-                            className={
-                              index > 0
-                                ? '-ml-1 rounded-full ring-2 ring-perps-background'
-                                : undefined
-                            }
-                          />
-                        ),
-                      )}
-                    </span>
-                    {option.label}
-                  </span>
-                </Button>
-              ))}
             </div>
           </PerpsCard>
 

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-home-page.tsx
@@ -6,6 +6,7 @@ import {
   MagnifyingGlassIcon,
   SignalIcon,
 } from '@heroicons/react/24/outline'
+import { useDebounce } from '@sushiswap/hooks'
 import {
   Button,
   Container,
@@ -13,7 +14,7 @@ import {
   SkeletonBox,
   TextField,
 } from '@sushiswap/ui'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import { getEvmChainById } from 'sushi/evm'
@@ -40,7 +41,6 @@ import {
 export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
   const chainKey = getEvmChainById(chainId).key
   const pathname = usePathname()
-  const router = useRouter()
   const searchParams = useSearchParams()
   const urlSearch = searchParams.get('search') ?? ''
   const urlCreator = searchParams.get('creator') ?? ''
@@ -49,6 +49,7 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
   )
   const sortBy = parseLaunchpadTokenSortField(searchParams.get('sortBy'))
   const [search, setSearch] = useState(urlSearch)
+  const debouncedSearch = useDebounce(search, 250)
   const [creator, setCreator] = useState(urlCreator)
   const [showScrollToTop, setShowScrollToTop] = useState(false)
 
@@ -67,17 +68,15 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
 
   const updateParams = useCallback(
     (updates: Record<string, string | undefined>) => {
-      const next = new URLSearchParams(searchParams.toString())
+      const next = new URLSearchParams(window.location.search)
       for (const [key, value] of Object.entries(updates)) {
         if (value) next.set(key, value)
         else next.delete(key)
       }
       const query = next.toString()
-      router.replace(query ? `${pathname}?${query}` : pathname, {
-        scroll: false,
-      })
+      history.replaceState(null, '', query ? `${pathname}?${query}` : pathname)
     },
-    [pathname, router, searchParams],
+    [pathname],
   )
 
   const providers = useMemo(
@@ -88,7 +87,7 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
     () => ({
       chainId,
       providers,
-      search: urlSearch || undefined,
+      search: debouncedSearch || undefined,
       creator:
         urlCreator && isAddress(urlCreator, { strict: false })
           ? urlCreator
@@ -97,7 +96,7 @@ export function LaunchpadHomePage({ chainId }: { chainId: LaunchpadChainId }) {
       sortBy,
       sortDirection: 'DESC' as const,
     }),
-    [chainId, providers, sortBy, urlCreator, urlSearch],
+    [chainId, debouncedSearch, providers, sortBy, urlCreator],
   )
   const infiniteScrollKey = useMemo(
     () =>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/provider-filter-controls.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/provider-filter-controls.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { classNames } from '@sushiswap/ui'
+import {
+  LAUNCHPAD_PROVIDER_FILTERS,
+  type LaunchpadProviderFilter,
+  getLaunchpadProvidersForFilter,
+} from '../_lib/launchpad-provider'
+import { LaunchpadProviderMark } from './launchpad-provider-mark'
+import {
+  SEGMENTED_GROUP,
+  SEGMENTED_ITEM,
+  SEGMENTED_ITEM_IDLE,
+  SEGMENTED_ITEM_SELECTED,
+} from './segmented-control'
+
+export function ProviderFilterControls({
+  filter,
+  onFilterChange,
+}: {
+  filter: LaunchpadProviderFilter
+  onFilterChange: (filter: LaunchpadProviderFilter) => void
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter launches by provider"
+      className={classNames(
+        SEGMENTED_GROUP,
+        'justify-between sm:justify-start',
+      )}
+    >
+      {LAUNCHPAD_PROVIDER_FILTERS.map((option) => {
+        const selected = option.value === filter
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onFilterChange(option.value)}
+            className={classNames(
+              SEGMENTED_ITEM,
+              'w-full sm:w-auto',
+              selected ? SEGMENTED_ITEM_SELECTED : SEGMENTED_ITEM_IDLE,
+            )}
+          >
+            <span className="flex items-center" aria-hidden>
+              {getLaunchpadProvidersForFilter(option.value).map(
+                (provider, index) => (
+                  <LaunchpadProviderMark
+                    key={provider}
+                    provider={provider}
+                    size="sm"
+                    className={classNames(
+                      'transition-opacity',
+                      index > 0 &&
+                        '-ml-1.5 rounded-full ring-2 ring-perps-background',
+                      !selected && 'opacity-60',
+                    )}
+                  />
+                ),
+              )}
+            </span>
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/segmented-control.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/segmented-control.ts
@@ -1,0 +1,11 @@
+export const SEGMENTED_GROUP =
+  'flex shrink-0 items-center gap-1 rounded-xl border border-white/[0.06] bg-white/[0.03] p-1'
+
+export const SEGMENTED_ITEM =
+  'flex h-8 items-center justify-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-perps-blue/50 disabled:cursor-not-allowed'
+
+export const SEGMENTED_ITEM_SELECTED =
+  'bg-white/[0.09] text-perps-muted shadow-sm'
+
+export const SEGMENTED_ITEM_IDLE =
+  'text-perps-muted-50 hover:bg-white/[0.04] hover:text-perps-muted disabled:hover:bg-transparent disabled:hover:text-perps-muted-50'


### PR DESCRIPTION
## Summary
- prevent rapid launchpad search input from being overwritten by stale router navigations
- debounce launchpad token queries while keeping URL-backed search state
- extract the All/Sushi/Pools segmented filter redesign from #2236 and place it inline in the discovery toolbar
- exclude the broader feed, sorting, and token-card changes from #2236

## Validation
- pnpm --filter web check
- pnpm --filter web test:unit (198 passed, 1 skipped)
- Biome check on all touched files