### PR TITLE
feat: support pool address token selection

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token-not-found-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token-not-found-dialog.tsx
@@ -8,6 +8,7 @@ import { useCustomTokens } from '@sushiswap/hooks'
 import {
   Badge,
   Button,
+  Currency,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -21,7 +22,6 @@ import {
   classNames,
 } from '@sushiswap/ui'
 import { NetworkIcon } from '@sushiswap/ui/icons/network-icon'
-import { UnknownTokenIcon } from '@sushiswap/ui/icons/unknown-token-icon'
 import React, { useCallback } from 'react'
 import { useTokenSecurity } from 'src/lib/hooks/react-query'
 import { TokenSecurityImportActions } from 'src/lib/wagmi/components/token-security-import-actions'
@@ -85,7 +85,6 @@ export const SimpleSwapTokenNotFoundDialog = () => {
     isError: isToken0SecurityError,
     isFetching: isToken0SecurityFetching,
     isLoading: isToken0SecurityLoading,
-    refetch: refetchToken0Security,
   } = useTokenSecurity({
     currency: token0NotInList && token0?.type === 'token' ? token0 : undefined,
     enabled: Boolean(token0NotInList && token0?.type === 'token'),
@@ -96,7 +95,6 @@ export const SimpleSwapTokenNotFoundDialog = () => {
     isError: isToken1SecurityError,
     isFetching: isToken1SecurityFetching,
     isLoading: isToken1SecurityLoading,
-    refetch: refetchToken1Security,
   } = useTokenSecurity({
     currency: token1NotInList && token1?.type === 'token' ? token1 : undefined,
     enabled: Boolean(token1NotInList && token1?.type === 'token'),
@@ -135,8 +133,8 @@ export const SimpleSwapTokenNotFoundDialog = () => {
       onOpenChange={(open) => !open && reset()}
     >
       <DialogContent className="!flex max-h-[calc(100dvh-16px)] flex-col overflow-hidden md:max-h-[80vh]">
-        <DialogHeader className="!text-left !space-y-3 shrink-0">
-          <DialogTitle>
+        <DialogHeader className="!text-left shrink-0">
+          <DialogTitle className="flex items-center gap-3">
             <div
               className={classNames(
                 'inline-flex items-center px-2 py-1.5 gap-1 rounded-full',
@@ -157,22 +155,22 @@ export const SimpleSwapTokenNotFoundDialog = () => {
                 <ExclamationCircleIcon width={28} height={28} />
               )}
             </div>
+            {isTokenSecurityLoading ? (
+              <span className="w-52">
+                <SkeletonText fontSize="xl" />
+              </span>
+            ) : (
+              <span className="text-xl font-semibold">
+                {isHoneypot
+                  ? 'Honeypot Token Detected'
+                  : isFoT
+                    ? 'Tax Token Deteceted'
+                    : isRisky
+                      ? 'Token Flagged for Risks'
+                      : `Unverified Token${token0NotInList && token1NotInList ? 's' : ''}`}
+              </span>
+            )}
           </DialogTitle>
-          {isTokenSecurityLoading ? (
-            <span className="w-52">
-              <SkeletonText fontSize="xl" />
-            </span>
-          ) : (
-            <span className="text-xl font-semibold">
-              {isHoneypot
-                ? 'Honeypot Token Detected'
-                : isFoT
-                  ? 'Tax Token Deteceted'
-                  : isRisky
-                    ? 'Token Flagged for Risks'
-                    : `Unverified Token${token0NotInList && token1NotInList ? 's' : ''}`}
-            </span>
-          )}
         </DialogHeader>
         <div className="min-h-0 overflow-y-auto">
           <div className="flex flex-col gap-4">
@@ -218,7 +216,12 @@ export const SimpleSwapTokenNotFoundDialog = () => {
                           }
                         >
                           <div className="w-10 h-10">
-                            <UnknownTokenIcon width={40} height={40} />
+                            <Currency.Icon
+                              disableLink
+                              currency={token0}
+                              width={40}
+                              height={40}
+                            />
                           </div>
                         </Badge>
                         <div className="flex flex-col">
@@ -311,7 +314,12 @@ export const SimpleSwapTokenNotFoundDialog = () => {
                           }
                         >
                           <div className="w-10 h-10">
-                            <UnknownTokenIcon width={40} height={40} />
+                            <Currency.Icon
+                              disableLink
+                              currency={token1}
+                              width={40}
+                              height={40}
+                            />
                           </div>
                         </Badge>
                         <div className="flex flex-col">
@@ -371,7 +379,7 @@ export const SimpleSwapTokenNotFoundDialog = () => {
           {isHoneypot
             ? 'Honeypot tokens restrict selling. Sushi does not support this token type.'
             : tokenSecurityImportState === 'unavailable'
-              ? 'The token security scan is unavailable. Retry the scan or explicitly import without security results.'
+              ? 'The token security scan is unavailable. You can explicitly import without security results.'
               : isFoT
                 ? 'This token charges a tax fee on transfer. Tax tokens are not supported in V3. You might not be able to trade, transfer, or withdraw liquidity of this token.'
                 : isRisky
@@ -394,14 +402,6 @@ export const SimpleSwapTokenNotFoundDialog = () => {
                   token1?.type === 'token' ? token1 : undefined,
                 ])
               }
-              onRetry={() => {
-                if (token0SecurityState === 'unavailable') {
-                  void refetchToken0Security()
-                }
-                if (token1SecurityState === 'unavailable') {
-                  void refetchToken1Security()
-                }
-              }}
               onCancel={reset}
             />
           )}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token0-input.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token0-input.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { isTokenSelectorPair } from 'src/lib/wagmi/components/token-selector/selection'
 import { Web3Input } from 'src/lib/wagmi/components/web3-input'
 import { isWNativeSupported } from 'sushi'
 import { useDerivedStateSimpleSwap } from './derivedstate-simple-swap-provider'
@@ -7,7 +8,7 @@ import { useDerivedStateSimpleSwap } from './derivedstate-simple-swap-provider'
 export const SimpleSwapToken0Input = () => {
   const {
     state: { swapAmountString, chainId, token0 },
-    mutate: { setSwapAmount, setToken0 },
+    mutate: { setSwapAmount, setToken0, setTokens },
     isToken0Loading: isLoading,
   } = useDerivedStateSimpleSwap()
 
@@ -17,7 +18,12 @@ export const SimpleSwapToken0Input = () => {
       type="INPUT"
       className="border border-accent p-3 bg-white dark:bg-slate-800 rounded-xl"
       chainId={chainId}
-      onSelect={setToken0}
+      onSelect={(selection) =>
+        isTokenSelectorPair(selection)
+          ? setTokens(...selection)
+          : setToken0(selection)
+      }
+      allowPairSelection
       value={swapAmountString}
       onChange={setSwapAmount}
       currency={token0}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token1-input.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-token1-input.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { isTokenSelectorPair } from 'src/lib/wagmi/components/token-selector/selection'
 import { Web3Input } from 'src/lib/wagmi/components/web3-input'
 import { isWNativeSupported } from 'sushi'
 import {
@@ -10,7 +11,7 @@ import {
 export const SimpleSwapToken1Input = () => {
   const {
     state: { chainId, token1 },
-    mutate: { setToken1 },
+    mutate: { setToken1, setTokens },
     isToken1Loading: tokenLoading,
   } = useDerivedStateSimpleSwap()
 
@@ -28,7 +29,12 @@ export const SimpleSwapToken1Input = () => {
       className="border border-accent p-3 bg-white dark:bg-slate-800 rounded-xl"
       value={quote?.amountOut?.toSignificant() ?? ''}
       chainId={chainId}
-      onSelect={setToken1}
+      onSelect={(selection) =>
+        isTokenSelectorPair(selection)
+          ? setTokens(...selection)
+          : setToken1(selection)
+      }
+      allowPairSelection
       currency={token1}
       loading={isLoading}
       fetching={isFetching}

--- a/apps/web/src/lib/wagmi/components/token-security-import-actions.tsx
+++ b/apps/web/src/lib/wagmi/components/token-security-import-actions.tsx
@@ -18,7 +18,7 @@ interface TokenSecurityImportActionsProps {
   state: TokenSecurityImportState
   hasSecurityRisk: boolean
   onImport(): void
-  onRetry(): void
+  onRetry?(): void
   onCancel(): void
   telemetry?: ImportTelemetry
 }
@@ -54,7 +54,8 @@ export function TokenSecurityImportActions({
 }: TokenSecurityImportActionsProps) {
   const theme = useTokenSelectorTheme()
   const isPerps = theme === 'perps'
-  const hasScanActions = state === 'scanning' || state === 'unavailable'
+  const hasScanActions =
+    state === 'scanning' || (state === 'unavailable' && Boolean(onRetry))
   const importWithoutScan = withImportTelemetry(
     <Button
       fullWidth
@@ -62,7 +63,7 @@ export function TokenSecurityImportActions({
       onClick={onImport}
       variant={isPerps ? 'perps-short' : 'warning'}
     >
-      Force import without scan
+      Import without scan
     </Button>,
     telemetry,
   )
@@ -74,55 +75,62 @@ export function TokenSecurityImportActions({
         !hasScanActions && 'sm:flex-row',
       )}
     >
-      {state === 'scanning' ? (
-        <>
-          <Button
-            fullWidth
-            size="xl"
-            loading
-            disabled
-            variant={isPerps ? 'perps-default' : 'default'}
-          >
-            Checking token security
-          </Button>
-          {importWithoutScan}
-        </>
-      ) : state === 'unavailable' ? (
-        <>
-          <Button
-            fullWidth
-            size="xl"
-            onClick={onRetry}
-            variant={isPerps ? 'perps-default' : 'default'}
-          >
-            Retry security scan
-          </Button>
-          {importWithoutScan}
-        </>
-      ) : (
-        withImportTelemetry(
-          <Button
-            fullWidth
-            size="xl"
-            onClick={onImport}
-            variant={
-              isPerps
-                ? hasSecurityRisk
-                  ? 'perps-short'
-                  : 'perps-default'
-                : hasSecurityRisk
-                  ? 'destructive'
-                  : 'default'
-            }
-          >
-            {hasSecurityRisk ? 'Import Anyway' : 'Confirm Import'}
-          </Button>,
-          telemetry,
-        )
-      )}
+      <div className="flex flex-col gap-3 sm:order-2 sm:flex-1 sm:flex-row">
+        {state === 'scanning' ? (
+          <>
+            <Button
+              fullWidth
+              size="xl"
+              loading
+              disabled
+              variant={isPerps ? 'perps-default' : 'default'}
+            >
+              Checking token security
+            </Button>
+            {importWithoutScan}
+          </>
+        ) : state === 'unavailable' ? (
+          onRetry ? (
+            <>
+              <Button
+                fullWidth
+                size="xl"
+                onClick={onRetry}
+                variant={isPerps ? 'perps-default' : 'default'}
+              >
+                Retry security scan
+              </Button>
+              {importWithoutScan}
+            </>
+          ) : (
+            importWithoutScan
+          )
+        ) : (
+          withImportTelemetry(
+            <Button
+              fullWidth
+              size="xl"
+              onClick={onImport}
+              variant={
+                isPerps
+                  ? hasSecurityRisk
+                    ? 'perps-short'
+                    : 'perps-default'
+                  : hasSecurityRisk
+                    ? 'destructive'
+                    : 'default'
+              }
+            >
+              {hasSecurityRisk ? 'Import Anyway' : 'Confirm Import'}
+            </Button>,
+            telemetry,
+          )
+        )}
+      </div>
       <Button
         fullWidth
         size="xl"
+        className="sm:order-1"
         onClick={onCancel}
         variant={isPerps ? 'perps-secondary' : 'secondary'}
       >

--- a/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.test.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.test.ts
@@ -1,0 +1,95 @@
+import { readContracts } from '@wagmi/core'
+import { EvmChainId } from 'sushi/evm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Config } from 'wagmi'
+import { getToken } from '../../../actions/get-token'
+import { getPoolByAddress } from './use-pool-address'
+
+vi.mock('@wagmi/core', () => ({ readContracts: vi.fn() }))
+vi.mock('wagmi', () => ({ useConfig: vi.fn() }))
+vi.mock('../../../actions/get-token', () => ({ getToken: vi.fn() }))
+
+const poolAddress = '0x0000000000000000000000000000000000000001'
+const token0Address = '0x0000000000000000000000000000000000000002'
+const token1Address = '0x0000000000000000000000000000000000000003'
+const config = {} as Config
+
+function mockTokenMetadata() {
+  vi.mocked(getToken)
+    .mockResolvedValueOnce({
+      address: token0Address,
+      chainId: EvmChainId.ETHEREUM,
+      decimals: 18,
+      name: 'Token Zero',
+      symbol: 'TK0',
+    })
+    .mockResolvedValueOnce({
+      address: token1Address,
+      chainId: EvmChainId.ETHEREUM,
+      decimals: 6,
+      name: 'Token One',
+      symbol: 'TK1',
+    })
+}
+
+describe('getPoolByAddress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('resolves a V3 pool and its tokens from RPC', async () => {
+    vi.mocked(readContracts).mockResolvedValueOnce([
+      { result: token0Address, status: 'success' },
+      { result: token1Address, status: 'success' },
+      { result: 3000, status: 'success' },
+      { error: new Error('not V2'), status: 'failure' },
+    ] as never)
+    mockTokenMetadata()
+
+    const pool = await getPoolByAddress({
+      address: poolAddress,
+      chainId: EvmChainId.ETHEREUM,
+      config,
+    })
+
+    expect(pool?.version).toBe('v3')
+    expect(pool?.token0.symbol).toBe('TK0')
+    expect(pool?.token1.symbol).toBe('TK1')
+  })
+
+  it('resolves a V2 pair when getReserves is available', async () => {
+    vi.mocked(readContracts).mockResolvedValueOnce([
+      { result: token0Address, status: 'success' },
+      { result: token1Address, status: 'success' },
+      { error: new Error('not V3'), status: 'failure' },
+      { result: [1n, 1n, 1], status: 'success' },
+    ] as never)
+    mockTokenMetadata()
+
+    const pool = await getPoolByAddress({
+      address: poolAddress,
+      chainId: EvmChainId.ETHEREUM,
+      config,
+    })
+
+    expect(pool?.version).toBe('v2')
+  })
+
+  it('ignores contracts that do not implement a V2 or V3 pool interface', async () => {
+    vi.mocked(readContracts).mockResolvedValueOnce([
+      { result: token0Address, status: 'success' },
+      { result: token1Address, status: 'success' },
+      { error: new Error('not V3'), status: 'failure' },
+      { error: new Error('not V2'), status: 'failure' },
+    ] as never)
+
+    await expect(
+      getPoolByAddress({
+        address: poolAddress,
+        chainId: EvmChainId.ETHEREUM,
+        config,
+      }),
+    ).resolves.toBeNull()
+    expect(getToken).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.test.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.test.ts
@@ -1,13 +1,15 @@
+import { getTokenList } from '@sushiswap/graph-client/data-api'
 import { readContracts } from '@wagmi/core'
 import { EvmChainId } from 'sushi/evm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Config } from 'wagmi'
-import { getToken } from '../../../actions/get-token'
 import { getPoolByAddress } from './use-pool-address'
 
+vi.mock('@sushiswap/graph-client/data-api', () => ({
+  getTokenList: vi.fn(),
+}))
 vi.mock('@wagmi/core', () => ({ readContracts: vi.fn() }))
 vi.mock('wagmi', () => ({ useConfig: vi.fn() }))
-vi.mock('../../../actions/get-token', () => ({ getToken: vi.fn() }))
 
 const poolAddress = '0x0000000000000000000000000000000000000001'
 const token0Address = '0x0000000000000000000000000000000000000002'
@@ -15,21 +17,33 @@ const token1Address = '0x0000000000000000000000000000000000000003'
 const config = {} as Config
 
 function mockTokenMetadata() {
-  vi.mocked(getToken)
-    .mockResolvedValueOnce({
-      address: token0Address,
-      chainId: EvmChainId.ETHEREUM,
-      decimals: 18,
-      name: 'Token Zero',
-      symbol: 'TK0',
-    })
-    .mockResolvedValueOnce({
-      address: token1Address,
-      chainId: EvmChainId.ETHEREUM,
-      decimals: 6,
-      name: 'Token One',
-      symbol: 'TK1',
-    })
+  vi.mocked(getTokenList)
+    .mockResolvedValueOnce([
+      {
+        id: `${EvmChainId.ETHEREUM}:${token0Address}`,
+        address: token0Address,
+        chainId: EvmChainId.ETHEREUM,
+        decimals: 18,
+        name: 'Token Zero',
+        symbol: 'TK0',
+        approved: true,
+        approvalStatus: 'APPROVED',
+        stellarMetadata: null,
+      },
+    ])
+    .mockResolvedValueOnce([
+      {
+        id: `${EvmChainId.ETHEREUM}:${token1Address}`,
+        address: token1Address,
+        chainId: EvmChainId.ETHEREUM,
+        decimals: 6,
+        name: 'Token One',
+        symbol: 'TK1',
+        approved: false,
+        approvalStatus: 'PERMISSIONLESS',
+        stellarMetadata: null,
+      },
+    ])
 }
 
 describe('getPoolByAddress', () => {
@@ -37,7 +51,7 @@ describe('getPoolByAddress', () => {
     vi.clearAllMocks()
   })
 
-  it('resolves a V3 pool and its tokens from RPC', async () => {
+  it('resolves a V3 pool and its tokens from the token list', async () => {
     vi.mocked(readContracts).mockResolvedValueOnce([
       { result: token0Address, status: 'success' },
       { result: token1Address, status: 'success' },
@@ -55,6 +69,18 @@ describe('getPoolByAddress', () => {
     expect(pool?.version).toBe('v3')
     expect(pool?.token0.symbol).toBe('TK0')
     expect(pool?.token1.symbol).toBe('TK1')
+    expect(pool?.token0.metadata.approved).toBe(true)
+    expect(pool?.token1.metadata.approved).toBe(false)
+    expect(getTokenList).toHaveBeenNthCalledWith(1, {
+      chainId: EvmChainId.ETHEREUM,
+      first: 1,
+      search: token0Address,
+    })
+    expect(getTokenList).toHaveBeenNthCalledWith(2, {
+      chainId: EvmChainId.ETHEREUM,
+      first: 1,
+      search: token1Address,
+    })
   })
 
   it('resolves a V2 pair when getReserves is available', async () => {
@@ -90,6 +116,6 @@ describe('getPoolByAddress', () => {
         config,
       }),
     ).resolves.toBeNull()
-    expect(getToken).not.toHaveBeenCalled()
+    expect(getTokenList).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.ts
@@ -1,0 +1,102 @@
+import { useQuery } from '@tanstack/react-query'
+import { readContracts } from '@wagmi/core'
+import ms from 'ms'
+import { type EvmAddress, type EvmChainId, EvmToken } from 'sushi/evm'
+import { parseAbi, zeroAddress } from 'viem'
+import type { Config } from 'wagmi'
+import { useConfig } from 'wagmi'
+import { getToken } from '../../../actions/get-token'
+
+const poolAbi = parseAbi([
+  'function token0() view returns (address)',
+  'function token1() view returns (address)',
+  'function fee() view returns (uint24)',
+  'function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)',
+])
+
+export interface TokenSelectorPool {
+  address: EvmAddress
+  token0: EvmToken
+  token1: EvmToken
+  version: 'v2' | 'v3'
+}
+
+interface GetPoolByAddress {
+  address: EvmAddress
+  chainId: EvmChainId
+  config: Config
+}
+
+export async function getPoolByAddress({
+  address,
+  chainId,
+  config,
+}: GetPoolByAddress): Promise<TokenSelectorPool | null> {
+  const [token0Result, token1Result, feeResult, reservesResult] =
+    await readContracts(config, {
+      allowFailure: true,
+      contracts: [
+        { abi: poolAbi, address, chainId, functionName: 'token0' },
+        { abi: poolAbi, address, chainId, functionName: 'token1' },
+        { abi: poolAbi, address, chainId, functionName: 'fee' },
+        { abi: poolAbi, address, chainId, functionName: 'getReserves' },
+      ],
+    })
+
+  if (
+    token0Result.status !== 'success' ||
+    token1Result.status !== 'success' ||
+    token0Result.result === zeroAddress ||
+    token1Result.result === zeroAddress ||
+    token0Result.result === token1Result.result
+  ) {
+    return null
+  }
+
+  const version =
+    reservesResult.status === 'success'
+      ? 'v2'
+      : feeResult.status === 'success'
+        ? 'v3'
+        : null
+
+  if (!version) return null
+
+  const [token0Data, token1Data] = await Promise.all([
+    getToken(config, { address: token0Result.result, chainId }),
+    getToken(config, { address: token1Result.result, chainId }),
+  ])
+
+  return {
+    address,
+    token0: new EvmToken({ ...token0Data, metadata: { approved: false } }),
+    token1: new EvmToken({ ...token1Data, metadata: { approved: false } }),
+    version,
+  }
+}
+
+interface UsePoolAddress {
+  address: EvmAddress | undefined
+  chainId: EvmChainId | undefined
+  enabled?: boolean
+}
+
+export function usePoolAddress({
+  address,
+  chainId,
+  enabled = true,
+}: UsePoolAddress) {
+  const config = useConfig()
+
+  return useQuery({
+    queryKey: ['token-selector-pool', { address, chainId }],
+    queryFn: () => {
+      if (!chainId) throw new Error('Chain id is required')
+      if (!address) throw new Error('Pool address is required')
+      return getPoolByAddress({ address, chainId, config })
+    },
+    enabled: Boolean(enabled && address && chainId),
+    retry: false,
+    staleTime: ms('15m'),
+  })
+}

--- a/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/hooks/use-pool-address.ts
@@ -1,11 +1,15 @@
+import {
+  type TokenListChainId,
+  getTokenList,
+} from '@sushiswap/graph-client/data-api'
 import { useQuery } from '@tanstack/react-query'
 import { readContracts } from '@wagmi/core'
 import ms from 'ms'
-import { type EvmAddress, type EvmChainId, EvmToken } from 'sushi/evm'
+import type { EvmAddress, EvmChainId, EvmToken } from 'sushi/evm'
 import { parseAbi, zeroAddress } from 'viem'
 import type { Config } from 'wagmi'
 import { useConfig } from 'wagmi'
-import { getToken } from '../../../actions/get-token'
+import { createTokenListToken } from './token-list-token'
 
 const poolAbi = parseAbi([
   'function token0() view returns (address)',
@@ -23,8 +27,25 @@ export interface TokenSelectorPool {
 
 interface GetPoolByAddress {
   address: EvmAddress
-  chainId: EvmChainId
+  chainId: EvmChainId & TokenListChainId
   config: Config
+}
+
+async function getPoolToken(
+  chainId: EvmChainId & TokenListChainId,
+  address: EvmAddress,
+): Promise<EvmToken> {
+  const [token] = await getTokenList({
+    chainId,
+    first: 1,
+    search: address,
+  })
+
+  if (!token) {
+    throw new Error(`Token ${address} was not returned by the token list`)
+  }
+
+  return createTokenListToken(chainId, token)
 }
 
 export async function getPoolByAddress({
@@ -62,22 +83,22 @@ export async function getPoolByAddress({
 
   if (!version) return null
 
-  const [token0Data, token1Data] = await Promise.all([
-    getToken(config, { address: token0Result.result, chainId }),
-    getToken(config, { address: token1Result.result, chainId }),
+  const [token0, token1] = await Promise.all([
+    getPoolToken(chainId, token0Result.result),
+    getPoolToken(chainId, token1Result.result),
   ])
 
   return {
     address,
-    token0: new EvmToken({ ...token0Data, metadata: { approved: false } }),
-    token1: new EvmToken({ ...token1Data, metadata: { approved: false } }),
+    token0,
+    token1,
     version,
   }
 }
 
 interface UsePoolAddress {
   address: EvmAddress | undefined
-  chainId: EvmChainId | undefined
+  chainId: (EvmChainId & TokenListChainId) | undefined
   enabled?: boolean
 }
 

--- a/apps/web/src/lib/wagmi/components/token-selector/selection.test.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/selection.test.ts
@@ -1,0 +1,36 @@
+import { EvmChainId, EvmToken } from 'sushi/evm'
+import { describe, expect, it } from 'vitest'
+import { type TokenSelectorSelection, isTokenSelectorPair } from './selection'
+
+type EthereumSelection = TokenSelectorSelection<
+  typeof EvmChainId.ETHEREUM,
+  true
+>
+
+const token = new EvmToken({
+  address: '0x0000000000000000000000000000000000000001',
+  chainId: EvmChainId.ETHEREUM,
+  decimals: 18,
+  name: 'Token',
+  symbol: 'TKN',
+})
+
+describe('token selector selection', () => {
+  it('narrows an atomic pair selection', () => {
+    const selection: EthereumSelection = [token, token]
+
+    expect(isTokenSelectorPair(selection)).toBe(true)
+  })
+
+  it('requires pair-enabled consumers to handle pair selections', () => {
+    const tokenOnlyHandler = (
+      _selection: CurrencyFor<typeof EvmChainId.ETHEREUM>,
+    ) => undefined
+
+    // @ts-expect-error A pair-enabled handler cannot accept only one currency.
+    const pairEnabledHandler: (selection: EthereumSelection) => void =
+      tokenOnlyHandler
+
+    expect(pairEnabledHandler).toBe(tokenOnlyHandler)
+  })
+})

--- a/apps/web/src/lib/wagmi/components/token-selector/selection.ts
+++ b/apps/web/src/lib/wagmi/components/token-selector/selection.ts
@@ -1,0 +1,17 @@
+import type { EvmToken } from 'sushi/evm'
+import type { TokenSelectorChainId } from './config'
+
+export type TokenSelectorPair = readonly [EvmToken, EvmToken]
+
+export type TokenSelectorSelection<
+  TChainId extends TokenSelectorChainId,
+  TAllowPairSelection extends boolean,
+> =
+  | CurrencyFor<TChainId>
+  | (TAllowPairSelection extends true ? TokenSelectorPair : never)
+
+export function isTokenSelectorPair<TChainId extends TokenSelectorChainId>(
+  selection: CurrencyFor<TChainId> | TokenSelectorPair,
+): selection is TokenSelectorPair {
+  return Array.isArray(selection)
+}

--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-pool-row.test.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-pool-row.test.tsx
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+
+import { type PropsWithChildren, act } from 'react'
+import { type Root, createRoot } from 'react-dom/client'
+import { EvmChainId, EvmToken } from 'sushi/evm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@sushiswap/ui', () => ({
+  Currency: {
+    Icon: () => null,
+    IconList: ({ children }: PropsWithChildren) => children,
+  },
+  classNames: (...values: unknown[]) => values.filter(Boolean).join(' '),
+}))
+
+vi.mock('../token-selector-theme', () => ({
+  useTokenSelectorTheme: () => 'default',
+}))
+
+import { TokenSelectorPoolRow } from './token-selector-pool-row'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const token0 = new EvmToken({
+  address: '0x0000000000000000000000000000000000000002',
+  chainId: EvmChainId.ETHEREUM,
+  decimals: 18,
+  name: 'Token Zero',
+  symbol: 'TK0',
+})
+const token1 = new EvmToken({
+  address: '0x0000000000000000000000000000000000000003',
+  chainId: EvmChainId.ETHEREUM,
+  decimals: 6,
+  name: 'Token One',
+  symbol: 'TK1',
+})
+
+describe('TokenSelectorPoolRow', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('selects token0 and token1 together', () => {
+    const onSelect = vi.fn()
+
+    act(() => {
+      root.render(
+        <TokenSelectorPoolRow
+          pool={{
+            address: '0x0000000000000000000000000000000000000001',
+            token0,
+            token1,
+            version: 'v3',
+          }}
+          onSelect={onSelect}
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain('TK0/TK1')
+    expect(container.textContent).toContain('v3')
+
+    container.querySelector('button')?.click()
+    expect(onSelect).toHaveBeenCalledWith(token0, token1)
+  })
+})

--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-pool-row.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-pool-row.tsx
@@ -1,0 +1,62 @@
+import { Currency, classNames } from '@sushiswap/ui'
+import { useCallback } from 'react'
+import type { EvmToken } from 'sushi/evm'
+import type { TokenSelectorPool } from '../hooks/use-pool-address'
+import { useTokenSelectorTheme } from '../token-selector-theme'
+
+interface TokenSelectorPoolRow {
+  onSelect(token0: EvmToken, token1: EvmToken): void
+  pool: TokenSelectorPool
+}
+
+export function TokenSelectorPoolRow({ onSelect, pool }: TokenSelectorPoolRow) {
+  const theme = useTokenSelectorTheme()
+  const isPerps = theme === 'perps'
+  const { token0, token1 } = pool
+
+  const onClick = useCallback(() => {
+    onSelect(token0, token1)
+  }, [onSelect, token0, token1])
+
+  return (
+    <div className="relative h-[64px] py-0.5">
+      <button
+        type="button"
+        aria-label={`Select ${token0.symbol}/${token1.symbol} ${pool.version} pool`}
+        testdata-id={`token-selector-pool-row-${pool.address.toLowerCase()}`}
+        onClick={onClick}
+        className={classNames(
+          isPerps
+            ? 'hover:bg-white/[0.05] focus-visible:bg-white/[0.07]'
+            : 'hover:bg-muted focus-visible:bg-accent',
+          'flex h-full w-full items-center gap-4 rounded-lg px-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        )}
+      >
+        <Currency.IconList iconWidth={40} iconHeight={40}>
+          <Currency.Icon disableLink currency={token0} />
+          <Currency.Icon disableLink currency={token1} />
+        </Currency.IconList>
+        <div className="flex min-w-0 flex-col items-start">
+          <span
+            className={classNames(
+              'truncate font-semibold',
+              isPerps ? 'text-perps-muted' : 'text-primary',
+            )}
+          >
+            {token0.symbol}/{token1.symbol}
+          </span>
+          <span
+            className={classNames(
+              'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none',
+              isPerps
+                ? 'bg-white/[0.08] text-perps-muted-50'
+                : 'bg-blue text-primary',
+            )}
+          >
+            {pool.version}
+          </span>
+        </div>
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-search.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/token-selector-search.tsx
@@ -3,18 +3,29 @@ import { useCustomTokens } from '@sushiswap/hooks'
 import { List, classNames } from '@sushiswap/ui'
 import { useMemo } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
+import { isEvmAddress, isEvmChainId } from 'sushi/evm'
+import { getAddress } from 'viem'
 import { usePrices } from '~evm/_common/ui/price-provider/price-provider/use-prices'
+import { usePoolAddress } from '../hooks/use-pool-address'
 import { useSearchTokens } from '../hooks/use-search-tokens'
+import type { TokenSelectorSelection } from '../selection'
 import { useTokenSelectorTheme } from '../token-selector-theme'
 import {
   TokenSelectorCurrencyList,
   TokenSelectorCurrencyListLoading,
 } from './common/token-selector-currency-list'
+import { TokenSelectorPoolRow } from './token-selector-pool-row'
 
-interface TokenSelectorSearch<TChainId extends TokenListChainId> {
+interface TokenSelectorSearch<
+  TChainId extends TokenListChainId,
+  TAllowPairSelection extends boolean = false,
+> {
   chainId: TChainId
   search: string
-  onSelect(currency: CurrencyFor<TChainId>): void
+  onSelect(
+    selection: TokenSelectorSelection<TChainId, TAllowPairSelection>,
+  ): void
+  allowPairSelection?: TAllowPairSelection
   onShowInfo(currency: CurrencyFor<TChainId> | false): void
   selected: CurrencyFor<TChainId> | undefined
 }
@@ -40,14 +51,31 @@ function Shell({ children }: { children: React.ReactNode }) {
 const emptyMap = new Map()
 const pageSize = 20
 
-export function TokenSelectorSearch<TChainId extends TokenListChainId>({
-  chainId,
-  search,
-  selected,
-  onSelect,
-  onShowInfo,
-}: TokenSelectorSearch<TChainId>) {
-  const { data, isError, isLoading, fetchNextPage, hasMore } = useSearchTokens({
+export function TokenSelectorSearch<
+  TChainId extends TokenListChainId,
+  TAllowPairSelection extends boolean = false,
+>(props: TokenSelectorSearch<TChainId, TAllowPairSelection>): React.JSX.Element
+export function TokenSelectorSearch<TChainId extends TokenListChainId>(
+  props: TokenSelectorSearch<TChainId, boolean>,
+) {
+  const { chainId, search, selected, allowPairSelection, onShowInfo } = props
+  const searchAddress =
+    isEvmChainId(chainId) && isEvmAddress(search.trim())
+      ? getAddress(search.trim())
+      : undefined
+  const poolAddress = allowPairSelection ? searchAddress : undefined
+  const { data: pool, isLoading: isPoolLoading } = usePoolAddress({
+    chainId: isEvmChainId(chainId) ? chainId : undefined,
+    address: poolAddress,
+    enabled: allowPairSelection,
+  })
+  const {
+    data: searchResults,
+    isError,
+    isLoading,
+    fetchNextPage,
+    hasMore,
+  } = useSearchTokens({
     chainId,
     search,
     pagination: {
@@ -55,6 +83,14 @@ export function TokenSelectorSearch<TChainId extends TokenListChainId>({
       pageSize,
     },
   })
+
+  const data = useMemo(() => {
+    if (!searchAddress) return searchResults
+
+    return searchResults?.filter(
+      (token) => token.address.toLowerCase() === searchAddress.toLowerCase(),
+    )
+  }, [searchAddress, searchResults])
 
   const { data: pricesMap } = usePrices({
     chainId,
@@ -86,10 +122,21 @@ export function TokenSelectorSearch<TChainId extends TokenListChainId>({
     return set
   }, [customTokens, data])
 
-  if (isLoading) {
+  if (pool) {
     return (
       <Shell>
-        <TokenSelectorCurrencyListLoading count={20} />
+        <TokenSelectorPoolRow
+          pool={pool}
+          onSelect={(token0, token1) => props.onSelect([token0, token1])}
+        />
+      </Shell>
+    )
+  }
+
+  if (isLoading || (searchAddress && isPoolLoading)) {
+    return (
+      <Shell>
+        <TokenSelectorCurrencyListLoading count={searchAddress ? 1 : 20} />
       </Shell>
     )
   }
@@ -116,7 +163,7 @@ export function TokenSelectorSearch<TChainId extends TokenListChainId>({
     <Shell>
       <InfiniteScroll
         dataLength={data.length}
-        hasMore={hasMore}
+        hasMore={searchAddress ? false : hasMore}
         loader={<TokenSelectorCurrencyListLoading count={pageSize} />}
         next={fetchNextPage}
         // 3/4 of the last page
@@ -128,7 +175,7 @@ export function TokenSelectorSearch<TChainId extends TokenListChainId>({
           <TokenSelectorCurrencyList
             id="trending"
             selected={selected}
-            onSelect={onSelect}
+            onSelect={props.onSelect}
             onShowInfo={onShowInfo}
             // pin={{}}
             currencies={data}
@@ -138,11 +185,9 @@ export function TokenSelectorSearch<TChainId extends TokenListChainId>({
             isBalanceLoading={false}
             importConfig={{
               importableSet,
-              onImport: (_token) => {
-                const token = _token as TokenFor<TChainId>
-
+              onImport: (token) => {
                 mutate('add', [token])
-                onSelect(token)
+                props.onSelect(token)
               },
             }}
           />

--- a/apps/web/src/lib/wagmi/components/token-selector/token-selector-states.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-selector-states.tsx
@@ -14,33 +14,53 @@ import type { TokenSelectorChainId } from './config'
 import { useMyTokens } from './hooks/use-my-tokens'
 import { useSearchTokens } from './hooks/use-search-tokens'
 import { useTrendingTokens } from './hooks/use-trending-tokens'
+import type { TokenSelectorSelection } from './selection'
 import { TokenSelectorChipBar } from './token-lists/token-selector-chip-bar'
 import { TokenSelectorCustomList } from './token-lists/token-selector-custom-list'
 import { TokenSelectorMyTokens } from './token-lists/token-selector-my-tokens'
 import { TokenSelectorSearch } from './token-lists/token-selector-search'
 import { TokenSelectorTrendingTokens } from './token-lists/token-selector-trending-tokens'
 
-interface TokenSelectorStates<TChainId extends TokenSelectorChainId> {
+interface TokenSelectorStates<
+  TChainId extends TokenSelectorChainId,
+  TAllowPairSelection extends boolean = false,
+> {
   selected: CurrencyFor<TChainId> | undefined
   chainId: TChainId
   account?: WalletAddressFor<TChainId>
-  onSelect(currency: CurrencyFor<TChainId>): void
+  onSelect(
+    selection: TokenSelectorSelection<TChainId, TAllowPairSelection>,
+  ): void
+  allowPairSelection?: TAllowPairSelection
   onShowInfo(currency: CurrencyFor<TChainId> | false): void
   currencies?: CurrencyFor<TChainId, { approved?: boolean }>[]
   includeNative?: boolean
   search?: string
 }
 
-export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
-  selected,
-  chainId,
-  account,
-  onSelect,
-  onShowInfo,
-  currencies,
-  includeNative,
-  search,
-}: TokenSelectorStates<TChainId>) {
+export function TokenSelectorStates<
+  TChainId extends TokenSelectorChainId,
+  TAllowPairSelection extends boolean = false,
+>(props: TokenSelectorStates<TChainId, TAllowPairSelection>): React.JSX.Element
+export function TokenSelectorStates<TChainId extends TokenSelectorChainId>(
+  props: TokenSelectorStates<TChainId, boolean>,
+) {
+  const {
+    selected,
+    chainId,
+    account,
+    onSelect,
+    allowPairSelection,
+    onShowInfo,
+    currencies,
+    includeNative,
+    search,
+  } = props
+
+  function onSelectCurrency(currency: CurrencyFor<TChainId>) {
+    onSelect(currency)
+  }
+
   // Ensure that the user's tokens are loaded
   useMyTokens({
     chainId: isTokenListChainId(chainId) ? chainId : undefined,
@@ -82,7 +102,7 @@ export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
         chainId={chainId}
         account={account}
         currencies={currencies}
-        onSelect={onSelect}
+        onSelect={onSelectCurrency}
         selected={selected}
         search={search}
         includeNative={includeNative}
@@ -96,6 +116,7 @@ export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
       <TokenSelectorSearch
         chainId={chainId}
         onSelect={onSelect}
+        allowPairSelection={allowPairSelection}
         onShowInfo={onShowInfo}
         search={search}
         selected={selected}
@@ -108,14 +129,14 @@ export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
       <>
         <TokenSelectorChipBar
           chainId={chainId}
-          onSelect={onSelect}
+          onSelect={onSelectCurrency}
           includeNative={includeNative}
         />
 
         {account ? (
           <TokenSelectorMyTokens
             chainId={chainId}
-            onSelect={onSelect}
+            onSelect={onSelectCurrency}
             onShowInfo={onShowInfo}
             selected={selected}
             includeNative={includeNative}
@@ -124,7 +145,7 @@ export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
 
         <TokenSelectorSearch
           chainId={chainId}
-          onSelect={onSelect}
+          onSelect={onSelectCurrency}
           onShowInfo={onShowInfo}
           selected={selected}
           search={''}
@@ -141,14 +162,14 @@ export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
       <>
         <TokenSelectorChipBar
           chainId={chainId}
-          onSelect={onSelect}
+          onSelect={onSelectCurrency}
           includeNative={includeNative}
         />
 
         {account ? (
           <TokenSelectorMyTokens
             chainId={chainId}
-            onSelect={onSelect}
+            onSelect={onSelectCurrency}
             onShowInfo={onShowInfo}
             selected={selected}
             includeNative={includeNative}
@@ -158,7 +179,9 @@ export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
         <TokenSelectorTrendingTokens
           chainId={trendingChainId}
           onSelect={
-            onSelect as (currency: CurrencyFor<TTrendingChainId>) => void
+            onSelectCurrency as (
+              currency: CurrencyFor<TTrendingChainId>,
+            ) => void
           }
           onShowInfo={
             onShowInfo as (
@@ -176,7 +199,7 @@ export function TokenSelectorStates<TChainId extends TokenSelectorChainId>({
       chainId={chainId}
       account={account}
       currencies={defaultBases}
-      onSelect={onSelect}
+      onSelect={onSelectCurrency}
       selected={selected}
       search={search}
       includeNative={includeNative}

--- a/apps/web/src/lib/wagmi/components/token-selector/token-selector.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-selector.tsx
@@ -31,6 +31,7 @@ import type { TokenSelectorChainId } from './config'
 import { CurrencyInfo } from './currency-info'
 import { DesktopNetworkSelector } from './desktop-network-selector'
 import { MobileNetworkSelector } from './mobile-network-selector'
+import type { TokenSelectorSelection } from './selection'
 import { TokenSelectorStates } from './token-selector-states'
 import {
   type TokenSelectorTheme,
@@ -40,11 +41,15 @@ import {
 interface TokenSelectorProps<
   TChainId extends TokenSelectorChainId,
   TNetwork extends TokenSelectorChainId = TChainId,
+  TAllowPairSelection extends boolean = false,
 > {
   id?: string
   selected: CurrencyFor<TChainId> | undefined
   chainId: TChainId
-  onSelect?(currency: CurrencyFor<TChainId>): void
+  onSelect?(
+    selection: TokenSelectorSelection<TChainId, TAllowPairSelection>,
+  ): void
+  allowPairSelection?: TAllowPairSelection
   children: ReactNode
   currencies?: Record<string, CurrencyFor<TChainId, { approved?: boolean }>>
   includeNative?: boolean
@@ -58,19 +63,21 @@ interface TokenSelectorProps<
 export function TokenSelector<
   TChainId extends TokenSelectorChainId,
   TNetwork extends TokenSelectorChainId = TChainId,
->({
-  includeNative = true,
-  selected,
-  onSelect,
-  chainId,
-  children,
-  currencies: _currencies,
-  hideSearch,
-  networks,
-  selectedNetwork,
-  onNetworkSelect,
-  theme = 'default',
-}: TokenSelectorProps<TChainId, TNetwork>) {
+  TAllowPairSelection extends boolean = false,
+>(props: TokenSelectorProps<TChainId, TNetwork, TAllowPairSelection>) {
+  const {
+    includeNative = true,
+    selected,
+    allowPairSelection,
+    chainId,
+    children,
+    currencies: _currencies,
+    hideSearch,
+    networks,
+    selectedNetwork,
+    onNetworkSelect,
+    theme = 'default',
+  } = props
   const address = useAccount(chainId)
 
   const [query, setQuery] = useState('')
@@ -100,14 +107,12 @@ export function TokenSelector<
   }, [_currencies])
 
   const _onSelect = useCallback(
-    (currency: CurrencyFor<TChainId>) => {
-      if (onSelect) {
-        onSelect(currency)
-      }
+    (selection: TokenSelectorSelection<TChainId, TAllowPairSelection>) => {
+      props.onSelect?.(selection)
 
       setOpen(false)
     },
-    [onSelect],
+    [props.onSelect],
   )
 
   const _onNetworkSelect = useCallback(
@@ -159,8 +164,9 @@ export function TokenSelector<
           <DialogDescription
             className={classNames(theme === 'perps' && '!text-perps-muted-50')}
           >
-            Select a token from our default list or search for a token by symbol
-            or address.
+            {allowPairSelection
+              ? 'Select a token from our default list or search by token symbol, token address, or pool address.'
+              : 'Select a token from our default list or search for a token by symbol or address.'}
           </DialogDescription>
         </DialogHeader>
         {networks && selectedNetwork && onNetworkSelect && !isMd ? (
@@ -173,7 +179,11 @@ export function TokenSelector<
         {!hideSearch ? (
           <div className="flex gap-2">
             <TextField
-              placeholder="Search by token or address"
+              placeholder={
+                allowPairSelection
+                  ? 'Search by token or pool address'
+                  : 'Search by token or address'
+              }
               icon={MagnifyingGlassIcon}
               iconProps={{
                 className: classNames(
@@ -200,6 +210,7 @@ export function TokenSelector<
             chainId={chainId}
             account={address}
             onSelect={_onSelect}
+            allowPairSelection={allowPairSelection}
             currencies={currencies}
             includeNative={includeNative}
             search={query}

--- a/apps/web/src/lib/wagmi/components/web3-input/currency/currency-input.tsx
+++ b/apps/web/src/lib/wagmi/components/web3-input/currency/currency-input.tsx
@@ -19,6 +19,7 @@ import { Amount, type Percent, getChainById } from 'sushi'
 import type { BalanceChainId } from '~evm/_common/ui/balance-provider/types'
 import { useAmountBalance } from '~evm/_common/ui/balance-provider/use-balance'
 import { useCurrencyPrice } from '~evm/_common/ui/price-provider/price-provider/use-currency-price'
+import type { TokenSelectorSelection } from '../../token-selector/selection'
 import { TokenSelector } from '../../token-selector/token-selector'
 import { truncateAmountToDecimals } from './amount-decimals'
 import { BalancePanel } from './balance-panel'
@@ -27,13 +28,17 @@ import { PricePanel } from './price-panel'
 interface CurrencyInputProps<
   TChainId extends BalanceChainId,
   TNetwork extends BalanceChainId = TChainId,
+  TAllowPairSelection extends boolean = false,
 > {
   id?: string
   disabled?: boolean
   value: string
   onChange?(value: string): void
   currency: CurrencyFor<TChainId> | undefined
-  onSelect?(currency: CurrencyFor<TChainId>): void
+  onSelect?(
+    selection: TokenSelectorSelection<TChainId, TAllowPairSelection>,
+  ): void
+  allowPairSelection?: TAllowPairSelection
   chainId: TChainId
   currencyClassName?: string
   className?: string
@@ -62,37 +67,38 @@ interface CurrencyInputProps<
 function CurrencyInput<
   TChainId extends BalanceChainId,
   TNetwork extends BalanceChainId = TChainId,
->({
-  id,
-  disabled,
-  value,
-  onChange,
-  currency,
-  onSelect,
-  chainId,
-  currencyClassName,
-  className,
-  loading,
-  priceImpact,
-  disableMaxButton = false,
-  type,
-  fetching,
-  currencyLoading,
-  currencyError,
-  currencyRetrying,
-  onCurrencyRetry,
-  currencies,
-  allowNative = true,
-  error,
-  disableInsufficientBalanceError = false,
-  hideSearch = false,
-  hidePricing = false,
-  hideIcon = false,
-  label,
-  networks,
-  selectedNetwork,
-  onNetworkChange,
-}: CurrencyInputProps<TChainId, TNetwork>) {
+  TAllowPairSelection extends boolean = false,
+>(props: CurrencyInputProps<TChainId, TNetwork, TAllowPairSelection>) {
+  const {
+    id,
+    disabled,
+    value,
+    onChange,
+    currency,
+    chainId,
+    currencyClassName,
+    className,
+    loading,
+    priceImpact,
+    disableMaxButton = false,
+    type,
+    fetching,
+    currencyLoading,
+    currencyError,
+    currencyRetrying,
+    onCurrencyRetry,
+    currencies,
+    allowNative = true,
+    error,
+    disableInsufficientBalanceError = false,
+    hideSearch = false,
+    hidePricing = false,
+    hideIcon = false,
+    label,
+    networks,
+    selectedNetwork,
+    onNetworkChange,
+  } = props
   const isMounted = useIsMounted()
 
   const [localValue, setLocalValue] = useState<string>('')
@@ -157,14 +163,15 @@ function CurrencyInput<
   }, [currency, chainId])
 
   const selector = useMemo(() => {
-    if (!onSelect) return null
+    if (!props.onSelect) return null
 
     return (
       <TokenSelector
         id={id}
         chainId={chainId}
         selected={currency}
-        onSelect={onSelect}
+        onSelect={props.onSelect}
+        allowPairSelection={props.allowPairSelection}
         currencies={currencies}
         includeNative={allowNative}
         hideSearch={hideSearch}
@@ -242,7 +249,8 @@ function CurrencyInput<
     currencyClassName,
     currencyLoading,
     id,
-    onSelect,
+    props.onSelect,
+    props.allowPairSelection,
     currencies,
     currency,
     chainId,


### PR DESCRIPTION
## Summary
- allow V2 and V3 pool addresses to select token pairs in the swap token selector
- resolve pool token metadata through exact-address Data API lookups so approval status is preserved
- improve the unverified-token dialog with real token icons, a single-line header, and no retry action when scanning is unavailable

## Validation
- pnpm --filter web exec vitest run src/lib/wagmi/components/token-selector/hooks/use-pool-address.test.ts
- pnpm lint
- pnpm format

## Known issue
- pnpm --filter web check is currently blocked by unrelated existing launchpad type errors involving SUSHI_V2 provider mappings and positions fields