### PR TITLE
fix(web): preserve launchpad scroll position

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/layout.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/layout.tsx
@@ -42,7 +42,7 @@ export default async function LaunchpadLayout({
           <div className="absolute left-[5%] top-0 h-72 w-72 rounded-full bg-perps-blue/[0.08] blur-3xl" />
           <div className="absolute right-[8%] top-16 h-80 w-80 rounded-full bg-pink-500/[0.06] blur-3xl" />
         </div>
-        <main className="relative flex flex-1 flex-col animate-slide">
+        <main className="relative flex flex-1 flex-col animate-launchpad-slide">
           {children}
         </main>
       </div>

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -30,10 +30,21 @@ const tailwindConfig = {
             transform: 'translateY(0)',
           },
         },
+        'launchpad-slide': {
+          '0%': {
+            opacity: 0,
+            transform: 'translateY(-56px)',
+          },
+          '100%': {
+            opacity: 1,
+            transform: 'translateY(0)',
+          },
+        },
       },
       animation: {
         marquee: 'marquee 5s linear infinite',
         slide: 'slide .5s',
+        'launchpad-slide': 'launchpad-slide .5s',
       },
     },
   },


### PR DESCRIPTION
## Summary
- preserve the existing launchpad slide animation
- leave the shared `animate-slide` implementation unchanged
- add a Launchpad-only slide starting at `-56px`, matching the header height so Next.js resets scroll correctly

## Validation
- browser regression: navigate from Swap at `scrollY=80`; Launchpad finishes at `scrollY=0` with the slide animation applied
- direct route check: computed `animationName` is `launchpad-slide` and `scrollY=0`
- `pnpm format`
- `pnpm lint`
- `pnpm --filter web check` *(blocked by pre-existing generated route cache corruption and launchpad GraphQL type mismatches, including missing `SUSHI_V2` provider mappings)*