### PR TITLE
fix(web): remove launch management loading flash

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page-skeleton.tsx
@@ -1,0 +1,63 @@
+import { Container, SkeletonBox, SkeletonCircle } from '@sushiswap/ui'
+import { PerpsCard } from '~evm/perps/_ui/_common/perps-card'
+
+export function ManageTokenPageSkeleton() {
+  return (
+    <Container
+      maxWidth="6xl"
+      className="w-full px-4 py-10 sm:py-14"
+      aria-label="Loading launch management"
+      aria-busy="true"
+    >
+      <SkeletonBox className="h-5 w-40 rounded-sm" />
+
+      <div className="mt-7 flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          <SkeletonCircle radius={64} />
+          <div>
+            <SkeletonBox className="h-9 w-64 max-w-[60vw] rounded-lg" />
+            <SkeletonBox className="mt-2 h-4 w-32 rounded-sm" />
+          </div>
+        </div>
+        <SkeletonBox className="h-10 w-40 rounded-xl" />
+      </div>
+
+      <div className="mt-8 grid gap-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
+        <PerpsCard className="p-5 sm:p-7" fullWidth>
+          <SkeletonBox className="h-6 w-32 rounded-md" />
+          <SkeletonBox className="mt-3 h-4 w-full max-w-lg rounded-sm" />
+          <SkeletonBox className="mt-2 h-4 w-4/5 max-w-md rounded-sm" />
+          <SkeletonBox className="mt-6 h-32 w-full rounded-xl" />
+          <div className="mt-6 space-y-5">
+            <SkeletonBox className="h-24 w-full rounded-lg" />
+            <SkeletonBox className="h-10 w-full rounded-lg" />
+            <SkeletonBox className="h-10 w-full rounded-lg" />
+            <SkeletonBox className="h-10 w-full rounded-lg" />
+          </div>
+          <div className="mt-7 flex justify-end">
+            <SkeletonBox className="h-10 w-52 rounded-xl" />
+          </div>
+        </PerpsCard>
+
+        <div className="space-y-5">
+          <PerpsCard className="p-5" fullWidth>
+            <SkeletonBox className="h-6 w-28 rounded-md" />
+            <div className="mt-5 space-y-4">
+              {['creator', 'factory', 'pool', 'fees'].map((item) => (
+                <div key={item} className="flex justify-between gap-4">
+                  <SkeletonBox className="h-4 w-20 rounded-sm" />
+                  <SkeletonBox className="h-4 w-28 rounded-sm" />
+                </div>
+              ))}
+            </div>
+          </PerpsCard>
+          <PerpsCard className="p-5" fullWidth>
+            <SkeletonBox className="h-6 w-36 rounded-md" />
+            <SkeletonBox className="mt-3 h-4 w-full rounded-sm" />
+            <SkeletonBox className="mt-5 h-10 w-full rounded-xl" />
+          </PerpsCard>
+        </div>
+      </div>
+    </Container>
+  )
+}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/loading.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/loading.tsx
@@ -1,5 +1,1 @@
-import { Splash } from '@sushiswap/ui'
-
-export default function Loading() {
-  return <Splash />
-}
+export { ManageTokenPageSkeleton as default } from './_ui/manage-token-page-skeleton'

--- a/apps/web/src/app/_common/cookies/cookie-dialog.test.tsx
+++ b/apps/web/src/app/_common/cookies/cookie-dialog.test.tsx
@@ -1,6 +1,14 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { CookieDialog } from './cookie-dialog'
+
+const { segmentsMock } = vi.hoisted(() => ({
+  segmentsMock: vi.fn((): string[] => []),
+}))
+
+vi.mock('next/navigation', () => ({
+  useSelectedLayoutSegments: segmentsMock,
+}))
 
 describe('CookieDialog', () => {
   it('includes the initial consent banner in server-rendered HTML', () => {
@@ -24,4 +32,19 @@ describe('CookieDialog', () => {
     expect(html).not.toContain('id="cookie-policy-title"')
     expect(html).toContain('Manage cookies')
   })
+
+  it.each([{ segments: ['perps'] }, { segments: ['42161', 'launchpad'] }])(
+    'uses perps styling for segments $segments',
+    ({ segments }) => {
+      segmentsMock.mockReturnValue(segments)
+
+      const html = renderToStaticMarkup(
+        <CookieDialog defaultOpen>
+          <button type="button">Manage cookies</button>
+        </CookieDialog>,
+      )
+
+      expect(html).toContain('bg-perps-background/95')
+    },
+  )
 })

--- a/apps/web/src/app/_common/cookies/cookie-dialog.tsx
+++ b/apps/web/src/app/_common/cookies/cookie-dialog.tsx
@@ -9,9 +9,11 @@ import {
   classNames,
 } from '@sushiswap/ui'
 import dynamic from 'next/dynamic'
+import { useSelectedLayoutSegments } from 'next/navigation'
 import { type ReactElement, useCallback, useEffect, useState } from 'react'
 import { announceCookieChange } from './announce-cookie-change'
 import {
+  type CookieDialogVariant,
   type CookieType,
   type ManageAction,
   alwaysEnabledCookieTypes,
@@ -25,14 +27,23 @@ const ManageCookieDialog = dynamic(() =>
 type BaseAction = 'accept' | 'reject' | 'manage'
 
 function BaseCookieBanner({
+  variant,
   onAction,
-}: { onAction: (action: BaseAction) => void }) {
+}: {
+  variant: CookieDialogVariant
+  onAction: (action: BaseAction) => void
+}) {
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
     <section
       aria-labelledby="cookie-policy-title"
-      className="fixed bottom-0 right-0 z-50 grid w-full gap-4 rounded-t-2xl bg-gray-100 p-6 shadow-lg dark:bg-slate-800 black:bg-secondary md:right-[50px] md:bottom-[50px] md:w-[720px] md:rounded-2xl"
+      className={classNames(
+        'fixed bottom-0 right-0 z-50 grid w-full gap-4 rounded-t-2xl p-6 shadow-lg md:right-[50px] md:bottom-[50px] md:w-[720px] md:rounded-2xl',
+        variant === 'perps'
+          ? 'border border-white/[0.07] bg-perps-background/95 text-perps-muted backdrop-blur-2xl'
+          : 'bg-gray-100 dark:bg-slate-800 black:bg-secondary',
+      )}
     >
       <h2 id="cookie-policy-title" className="sr-only">
         Cookie Policy
@@ -48,7 +59,10 @@ function BaseCookieBanner({
             variant="link"
             size="sm"
             onClick={() => setIsExpanded(!isExpanded)}
-            className={'ml-1 float-right clear-both'}
+            className={classNames(
+              'ml-1 float-right clear-both',
+              variant === 'perps' && '!text-perps-blue',
+            )}
           >
             <span className="pl-0.5">More</span>
           </Button>
@@ -73,11 +87,22 @@ function BaseCookieBanner({
       </p>
       <Separator />
       <div className="flex md:flex-row flex-col w-full gap-3">
-        <Button onClick={() => onAction('accept')}>Accept all cookies</Button>
-        <Button variant="secondary" onClick={() => onAction('manage')}>
+        <Button
+          variant={variant === 'perps' ? 'perps-default' : undefined}
+          onClick={() => onAction('accept')}
+        >
+          Accept all cookies
+        </Button>
+        <Button
+          variant={variant === 'perps' ? 'perps-secondary' : 'secondary'}
+          onClick={() => onAction('manage')}
+        >
           Manage cookie preferences
         </Button>
-        <Button variant="secondary" onClick={() => onAction('reject')}>
+        <Button
+          variant={variant === 'perps' ? 'perps-secondary' : 'secondary'}
+          onClick={() => onAction('reject')}
+        >
           Reject all non-essential cookies
         </Button>
       </div>
@@ -91,6 +116,12 @@ export function CookieDialog({
   defaultOpen,
   children,
 }: { defaultOpen: boolean; children: ReactElement }) {
+  const segments = useSelectedLayoutSegments()
+  const variant: CookieDialogVariant = segments.some(
+    (segment) => segment === 'perps' || segment === 'launchpad',
+  )
+    ? 'perps'
+    : 'default'
   const [open, setOpen] = useState(defaultOpen)
   const [page, setPage] = useState<'base' | 'manage'>('base')
 
@@ -161,7 +192,7 @@ export function CookieDialog({
   return (
     <>
       {open && page === 'base' ? (
-        <BaseCookieBanner onAction={onBaseAction} />
+        <BaseCookieBanner variant={variant} onAction={onBaseAction} />
       ) : null}
 
       <Dialog open={open && page === 'manage'} onOpenChange={setOpen}>
@@ -172,6 +203,7 @@ export function CookieDialog({
         {page === 'manage' ? (
           <ManageCookieDialog
             cookieSet={enabledCookieSet}
+            variant={variant}
             onAction={onManageAction}
           />
         ) : null}

--- a/apps/web/src/app/_common/cookies/cookie-types.ts
+++ b/apps/web/src/app/_common/cookies/cookie-types.ts
@@ -6,6 +6,8 @@ export const cookieTypes = [
   'hotjar',
 ] as const
 
+export type CookieDialogVariant = 'default' | 'perps'
+
 export type CookieType = (typeof cookieTypes)[number]
 
 export const alwaysEnabledCookieTypes = ['essential'] as const

--- a/apps/web/src/app/_common/cookies/manage-cookie-dialog.tsx
+++ b/apps/web/src/app/_common/cookies/manage-cookie-dialog.tsx
@@ -13,17 +13,27 @@ import {
   Switch,
 } from '@sushiswap/ui'
 import { useState } from 'react'
-import type { CookieType, ManageAction } from './cookie-types'
+import type {
+  CookieDialogVariant,
+  CookieType,
+  ManageAction,
+} from './cookie-types'
 
 export function ManageCookieDialog({
   cookieSet,
+  variant,
   onAction,
-}: { cookieSet: Set<CookieType>; onAction: (action: ManageAction) => void }) {
+}: {
+  cookieSet: Set<CookieType>
+  variant: CookieDialogVariant
+  onAction: (action: ManageAction) => void
+}) {
   const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false)
 
   return (
     <DialogContent
       hideClose
+      variant={variant}
       className="!left-[unset] !top-[unset] !bottom-0 md:!right-0 !translate-x-[0%] md:!translate-x-[-50px] md:!translate-y-[-50px] space-y-4"
     >
       <DialogHeader>
@@ -120,9 +130,14 @@ export function ManageCookieDialog({
         </div>
       </div>
       <DialogFooter className="!justify-start flex flex-wrap gap-3">
-        <Button onClick={() => onAction({ type: 'confirm' })}>Confirm</Button>
         <Button
-          variant="secondary"
+          variant={variant === 'perps' ? 'perps-default' : undefined}
+          onClick={() => onAction({ type: 'confirm' })}
+        >
+          Confirm
+        </Button>
+        <Button
+          variant={variant === 'perps' ? 'perps-secondary' : 'secondary'}
           onClick={() => onAction({ type: 'reject' })}
         >
           Reject all non-essential cookies


### PR DESCRIPTION
## Summary
- load the launch token directly in the async server route
- use the segment-level `loading.tsx` Suspense boundary with a destination-shaped management skeleton
- pass the loaded token directly to the management page
- refresh the server route after metadata updates instead of performing an initial client query

## Validation
- `pnpm lint`
- targeted Biome check for the changed files
- `pnpm --filter web check` *(blocked by malformed pre-existing `.next/dev/types/routes.d.ts` and `.next/dev/types/validator.ts` generated files)*