### PR TITLE
perf: server render cookie consent banner

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
@@ -1,0 +1,18 @@
+import { getLaunchpadToken } from '@sushiswap/graph-client/data-api'
+import { unstable_cache } from 'next/cache'
+import type { EvmAddress } from 'sushi/evm'
+import type { LaunchpadChainId } from '../constants'
+
+export function getCachedLaunchpadToken({
+  chainId,
+  address,
+}: {
+  chainId: LaunchpadChainId
+  address: EvmAddress
+}) {
+  return unstable_cache(
+    async () => getLaunchpadToken({ chainId, address }, { retries: 3 }),
+    ['launchpad', 'token', `${chainId}:${address}`],
+    { revalidate: 60 },
+  )()
+}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.ts
@@ -6,7 +6,6 @@ import {
   type LaunchpadTokenConnection,
   getLaunchpadCandles,
   getLaunchpadCreator,
-  getLaunchpadToken,
   getLaunchpadTokens,
 } from '@sushiswap/graph-client/data-api'
 import { unstable_cache } from 'next/cache'
@@ -27,6 +26,7 @@ import { shortenAddress } from 'sushi'
 import { getEvmChainById } from 'sushi/evm'
 import type { EvmAddress } from 'sushi/evm'
 import type { LaunchpadChainId } from '../constants'
+import { getCachedLaunchpadToken } from './get-cached-launchpad-token'
 import { getLaunchpadProvidersForFilter } from './launchpad-provider'
 
 const SUSHI_URL = 'https://www.sushi.com'
@@ -35,13 +35,6 @@ const SUSHI_WEBSITE_ID = `${SUSHI_URL}/#website`
 const POOLS_FUN_URL = 'https://pools.fun'
 const POOLS_FUN_ORGANIZATION_ID = `${POOLS_FUN_URL}/#organization`
 const LAUNCHPAD_REVALIDATE_SECONDS = 60
-
-const getCachedLaunchpadToken = unstable_cache(
-  async (chainId: LaunchpadChainId, address: EvmAddress) =>
-    getLaunchpadToken({ chainId, address }),
-  ['launchpad-token-seo'],
-  { revalidate: LAUNCHPAD_REVALIDATE_SECONDS },
-)
 
 const getCachedLaunchpadTokens = unstable_cache(
   async (chainId: LaunchpadChainId) =>
@@ -99,7 +92,7 @@ export async function getLaunchpadTokenForSeo(
   address: EvmAddress,
 ): Promise<LaunchpadToken | null> {
   try {
-    return await getCachedLaunchpadToken(chainId, address)
+    return await getCachedLaunchpadToken({ chainId, address })
   } catch {
     return null
   }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/use-launchpad-token.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/use-launchpad-token.ts
@@ -38,10 +38,12 @@ function hydrateLaunchpadToken(
 export function useLaunchpadToken(
   chainId: LaunchpadChainId,
   address: EvmAddress,
+  initialData?: LaunchpadToken | null,
 ) {
   return useQuery({
     queryKey: ['launchpad', 'token', { chainId, address }],
     queryFn: () => getLaunchpadToken({ chainId, address }),
+    initialData,
     select: hydrateLaunchpadToken,
     retry: 3,
     retryDelay: (attempt) => Math.min(ms('1s') * 2 ** attempt, ms('5s')),

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
@@ -2,7 +2,6 @@
 
 import {
   ArrowLeftIcon,
-  ArrowPathIcon,
   ArrowTopRightOnSquareIcon,
   BanknotesIcon,
   CheckCircleIcon,
@@ -10,6 +9,7 @@ import {
   UserCircleIcon,
 } from '@heroicons/react/24/outline'
 import { zodResolver } from '@hookform/resolvers/zod'
+import type { LaunchpadToken } from '@sushiswap/graph-client/data-api'
 import { createToast } from '@sushiswap/notifications'
 import {
   Button,
@@ -101,9 +101,11 @@ const METADATA_SIGNER_ERROR = {
 export function ManageTokenPage({
   chainId,
   address,
+  initialToken,
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
+  initialToken: LaunchpadToken | null
 }) {
   const chainKey = getEvmChainById(chainId).key
   const { address: connectedAddress, chainId: connectedChainId } =
@@ -114,9 +116,8 @@ export function ManageTokenPage({
   const {
     data: token,
     isError,
-    isPending,
     refetch,
-  } = useLaunchpadToken(chainId, address)
+  } = useLaunchpadToken(chainId, address, initialToken)
   const canManage = token
     ? launchpadProviderHasCapability(token.provider, 'manage')
     : false
@@ -315,18 +316,6 @@ export function ManageTokenPage({
     } finally {
       setIsDistributing(false)
     }
-  }
-
-  if (isPending) {
-    return (
-      <PageState
-        icon={
-          <ArrowPathIcon className="mx-auto h-8 w-8 animate-spin text-perps-muted-50" />
-        }
-        title="Loading launch"
-        titleClassName="text-xl"
-      />
-    )
   }
 
   if (isError) {

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/loading.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/loading.tsx
@@ -1,0 +1,5 @@
+import { Splash } from '@sushiswap/ui'
+
+export default function Loading() {
+  return <Splash />
+}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import type { EvmAddress } from 'sushi/evm'
 import { isAddress } from 'viem'
+import { getCachedLaunchpadToken } from '../../_lib/get-cached-launchpad-token'
 import { isLaunchpadChainId } from '../../constants'
 import { ManageTokenPage } from './_ui/manage-token-page'
 
@@ -25,5 +26,16 @@ export default async function ManageTokenRoute({
     return notFound()
   }
 
-  return <ManageTokenPage chainId={chainId} address={address as EvmAddress} />
+  const token = await getCachedLaunchpadToken({
+    chainId,
+    address: address as EvmAddress,
+  })
+
+  return (
+    <ManageTokenPage
+      chainId={chainId}
+      address={address as EvmAddress}
+      initialToken={token}
+    />
+  )
 }

--- a/apps/web/src/app/_common/cookies/cookie-dialog.test.tsx
+++ b/apps/web/src/app/_common/cookies/cookie-dialog.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { CookieDialog } from './cookie-dialog'
+
+describe('CookieDialog', () => {
+  it('includes the initial consent banner in server-rendered HTML', () => {
+    const html = renderToStaticMarkup(
+      <CookieDialog defaultOpen>
+        <button type="button">Manage cookies</button>
+      </CookieDialog>,
+    )
+
+    expect(html).toContain('id="cookie-policy-title"')
+    expect(html).toContain('Accept all cookies')
+  })
+
+  it('omits the consent banner when cookies are already confirmed', () => {
+    const html = renderToStaticMarkup(
+      <CookieDialog defaultOpen={false}>
+        <button type="button">Manage cookies</button>
+      </CookieDialog>,
+    )
+
+    expect(html).not.toContain('id="cookie-policy-title"')
+    expect(html).toContain('Manage cookies')
+  })
+})

--- a/apps/web/src/app/_common/cookies/cookie-dialog.tsx
+++ b/apps/web/src/app/_common/cookies/cookie-dialog.tsx
@@ -1,40 +1,42 @@
 'use client'
 
-import { ChevronDownIcon } from '@heroicons/react/24/solid'
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
-import { useIsMounted } from '@sushiswap/hooks'
 import {
   Button,
-  Collapsible,
   Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
   LinkExternal,
   Separator,
-  Switch,
   classNames,
 } from '@sushiswap/ui'
+import dynamic from 'next/dynamic'
 import { type ReactElement, useCallback, useEffect, useState } from 'react'
 import { announceCookieChange } from './announce-cookie-change'
+import {
+  type CookieType,
+  type ManageAction,
+  alwaysEnabledCookieTypes,
+  cookieTypes,
+} from './cookie-types'
+
+const ManageCookieDialog = dynamic(() =>
+  import('./manage-cookie-dialog').then((module) => module.ManageCookieDialog),
+)
 
 type BaseAction = 'accept' | 'reject' | 'manage'
 
-function BaseCookieDialog({
+function BaseCookieBanner({
   onAction,
 }: { onAction: (action: BaseAction) => void }) {
   const [isExpanded, setIsExpanded] = useState(false)
+
   return (
-    <DialogContent
-      hideClose
-      className="md:min-w-[720px] !left-[unset] !top-[unset] !bottom-0 md:!right-0 !translate-x-[0%] md:!translate-x-[-50px] md:!translate-y-[-50px]"
-      onOpenAutoFocus={(e) => e.preventDefault()}
+    <section
+      aria-labelledby="cookie-policy-title"
+      className="fixed bottom-0 right-0 z-50 grid w-full gap-4 rounded-t-2xl bg-gray-100 p-6 shadow-lg dark:bg-slate-800 black:bg-secondary md:right-[50px] md:bottom-[50px] md:w-[720px] md:rounded-2xl"
     >
-      <VisuallyHidden>
-        <DialogTitle>Cookie Policy</DialogTitle>
-      </VisuallyHidden>
+      <h2 id="cookie-policy-title" className="sr-only">
+        Cookie Policy
+      </h2>
       <p
         className={classNames(
           'text-sm',
@@ -79,149 +81,11 @@ function BaseCookieDialog({
           Reject all non-essential cookies
         </Button>
       </div>
-    </DialogContent>
+    </section>
   )
 }
 
-const cookieTypes = [
-  'essential',
-  'functional',
-  'analytical',
-  'google',
-  'hotjar',
-] as const
-
-export type CookieType = (typeof cookieTypes)[number]
-
-type ManageAction =
-  | {
-      type: 'confirm'
-    }
-  | {
-      type: 'set'
-      cookieType: CookieType
-      enabled: boolean
-    }
-  | {
-      type: 'reject'
-    }
-
-function ManageCookieDialog({
-  cookieSet,
-  onAction,
-}: { cookieSet: Set<CookieType>; onAction: (action: ManageAction) => void }) {
-  const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false)
-  return (
-    <>
-      <DialogContent
-        hideClose
-        className="!left-[unset] !top-[unset] !bottom-0 md:!right-0 !translate-x-[0%] md:!translate-x-[-50px] md:!translate-y-[-50px] space-y-4"
-      >
-        <DialogHeader>
-          <DialogTitle className="!mr-0">Manage cookie preferences</DialogTitle>
-        </DialogHeader>
-        <div className="[&>*]:flex [&>*]:justify-between [&>*]:items-center space-y-3">
-          <div>
-            <span>Strictly Neccessary Cookies</span>
-            <Switch checked disabled />
-          </div>
-          <Separator />
-          <div>
-            <span>Functional Cookies</span>
-            <Switch
-              checked={cookieSet.has('functional')}
-              onCheckedChange={(enabled) =>
-                onAction({ type: 'set', cookieType: 'functional', enabled })
-              }
-            />
-          </div>
-          <Separator />
-          <div>
-            <span>Analytical Cookies</span>
-            <Switch
-              checked={cookieSet.has('analytical')}
-              onCheckedChange={(enabled) => {
-                onAction({ type: 'set', cookieType: 'analytical', enabled })
-                onAction({ type: 'set', cookieType: 'google', enabled })
-                onAction({ type: 'set', cookieType: 'hotjar', enabled })
-              }}
-            />
-          </div>
-          <div>
-            <div className="flex flex-col gap-2">
-              <button
-                className="flex gap-1 items-center"
-                type="button"
-                onClick={() => setIsAnalyticsOpen(!isAnalyticsOpen)}
-              >
-                <ChevronDownIcon className="w-3 h-3" />
-                <span>Cookies(2)</span>
-              </button>
-              <Collapsible
-                open={isAnalyticsOpen}
-                className="flex flex-col gap-2 pl-4"
-              >
-                <div className="flex gap-1.5 items-center">
-                  <input
-                    type="checkbox"
-                    checked={cookieSet.has('google')}
-                    onChange={(e) => {
-                      onAction({
-                        type: 'set',
-                        cookieType: 'google',
-                        enabled: e.currentTarget.checked,
-                      })
-                      if (!cookieSet.has('analytical')) {
-                        onAction({
-                          type: 'set',
-                          cookieType: 'analytical',
-                          enabled: true,
-                        })
-                      }
-                    }}
-                  />
-                  Google
-                </div>
-                <div className="flex gap-1.5 items-center">
-                  <input
-                    type="checkbox"
-                    checked={cookieSet.has('hotjar')}
-                    onChange={(e) => {
-                      onAction({
-                        type: 'set',
-                        cookieType: 'hotjar',
-                        enabled: e.currentTarget.checked,
-                      })
-                      if (!cookieSet.has('analytical')) {
-                        onAction({
-                          type: 'set',
-                          cookieType: 'analytical',
-                          enabled: true,
-                        })
-                      }
-                    }}
-                  />
-                  HotJar
-                </div>
-              </Collapsible>
-            </div>
-          </div>
-        </div>
-        <DialogFooter className="!justify-start flex flex-wrap gap-3">
-          <Button onClick={() => onAction({ type: 'confirm' })}>Confirm</Button>
-          <Button
-            variant="secondary"
-            onClick={() => onAction({ type: 'reject' })}
-          >
-            Reject all non-essential cookies
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </>
-  )
-}
-
-const alwaysEnabledCookieTypes = ['essential'] as const
+export type { CookieType } from './cookie-types'
 
 export function CookieDialog({
   defaultOpen,
@@ -229,8 +93,6 @@ export function CookieDialog({
 }: { defaultOpen: boolean; children: ReactElement }) {
   const [open, setOpen] = useState(defaultOpen)
   const [page, setPage] = useState<'base' | 'manage'>('base')
-
-  const isMounted = useIsMounted()
 
   const [enabledCookieSet, setEnabledCookieSet] = useState<Set<CookieType>>(
     new Set(alwaysEnabledCookieTypes),
@@ -297,19 +159,23 @@ export function CookieDialog({
   }, [onConfirm])
 
   return (
-    <Dialog open={open && isMounted} onOpenChange={setOpen}>
-      <DialogTrigger asChild onClick={() => setPage('manage')}>
-        {children}
-      </DialogTrigger>
+    <>
+      {open && page === 'base' ? (
+        <BaseCookieBanner onAction={onBaseAction} />
+      ) : null}
 
-      {page === 'base' ? (
-        <BaseCookieDialog onAction={onBaseAction} />
-      ) : (
-        <ManageCookieDialog
-          cookieSet={enabledCookieSet}
-          onAction={onManageAction}
-        />
-      )}
-    </Dialog>
+      <Dialog open={open && page === 'manage'} onOpenChange={setOpen}>
+        <DialogTrigger asChild onClick={() => setPage('manage')}>
+          {children}
+        </DialogTrigger>
+
+        {page === 'manage' ? (
+          <ManageCookieDialog
+            cookieSet={enabledCookieSet}
+            onAction={onManageAction}
+          />
+        ) : null}
+      </Dialog>
+    </>
   )
 }

--- a/apps/web/src/app/_common/cookies/cookie-types.ts
+++ b/apps/web/src/app/_common/cookies/cookie-types.ts
@@ -1,0 +1,24 @@
+export const cookieTypes = [
+  'essential',
+  'functional',
+  'analytical',
+  'google',
+  'hotjar',
+] as const
+
+export type CookieType = (typeof cookieTypes)[number]
+
+export const alwaysEnabledCookieTypes = ['essential'] as const
+
+export type ManageAction =
+  | {
+      type: 'confirm'
+    }
+  | {
+      type: 'set'
+      cookieType: CookieType
+      enabled: boolean
+    }
+  | {
+      type: 'reject'
+    }

--- a/apps/web/src/app/_common/cookies/manage-cookie-dialog.tsx
+++ b/apps/web/src/app/_common/cookies/manage-cookie-dialog.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { ChevronDownIcon } from '@heroicons/react/24/solid'
+import {
+  Button,
+  Collapsible,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Separator,
+  Switch,
+} from '@sushiswap/ui'
+import { useState } from 'react'
+import type { CookieType, ManageAction } from './cookie-types'
+
+export function ManageCookieDialog({
+  cookieSet,
+  onAction,
+}: { cookieSet: Set<CookieType>; onAction: (action: ManageAction) => void }) {
+  const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false)
+
+  return (
+    <DialogContent
+      hideClose
+      className="!left-[unset] !top-[unset] !bottom-0 md:!right-0 !translate-x-[0%] md:!translate-x-[-50px] md:!translate-y-[-50px] space-y-4"
+    >
+      <DialogHeader>
+        <DialogTitle className="!mr-0">Manage cookie preferences</DialogTitle>
+        <DialogDescription className="sr-only">
+          Choose which non-essential cookies Sushi may store on your device.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="[&>*]:flex [&>*]:justify-between [&>*]:items-center space-y-3">
+        <div>
+          <span>Strictly Neccessary Cookies</span>
+          <Switch checked disabled />
+        </div>
+        <Separator />
+        <div>
+          <span>Functional Cookies</span>
+          <Switch
+            checked={cookieSet.has('functional')}
+            onCheckedChange={(enabled) =>
+              onAction({ type: 'set', cookieType: 'functional', enabled })
+            }
+          />
+        </div>
+        <Separator />
+        <div>
+          <span>Analytical Cookies</span>
+          <Switch
+            checked={cookieSet.has('analytical')}
+            onCheckedChange={(enabled) => {
+              onAction({ type: 'set', cookieType: 'analytical', enabled })
+              onAction({ type: 'set', cookieType: 'google', enabled })
+              onAction({ type: 'set', cookieType: 'hotjar', enabled })
+            }}
+          />
+        </div>
+        <div>
+          <div className="flex flex-col gap-2">
+            <button
+              className="flex gap-1 items-center"
+              type="button"
+              onClick={() => setIsAnalyticsOpen(!isAnalyticsOpen)}
+            >
+              <ChevronDownIcon className="w-3 h-3" />
+              <span>Cookies(2)</span>
+            </button>
+            <Collapsible
+              open={isAnalyticsOpen}
+              className="flex flex-col gap-2 pl-4"
+            >
+              <div className="flex gap-1.5 items-center">
+                <input
+                  type="checkbox"
+                  checked={cookieSet.has('google')}
+                  onChange={(event) => {
+                    onAction({
+                      type: 'set',
+                      cookieType: 'google',
+                      enabled: event.currentTarget.checked,
+                    })
+                    if (!cookieSet.has('analytical')) {
+                      onAction({
+                        type: 'set',
+                        cookieType: 'analytical',
+                        enabled: true,
+                      })
+                    }
+                  }}
+                />
+                Google
+              </div>
+              <div className="flex gap-1.5 items-center">
+                <input
+                  type="checkbox"
+                  checked={cookieSet.has('hotjar')}
+                  onChange={(event) => {
+                    onAction({
+                      type: 'set',
+                      cookieType: 'hotjar',
+                      enabled: event.currentTarget.checked,
+                    })
+                    if (!cookieSet.has('analytical')) {
+                      onAction({
+                        type: 'set',
+                        cookieType: 'analytical',
+                        enabled: true,
+                      })
+                    }
+                  }}
+                />
+                HotJar
+              </div>
+            </Collapsible>
+          </div>
+        </div>
+      </div>
+      <DialogFooter className="!justify-start flex flex-wrap gap-3">
+        <Button onClick={() => onAction({ type: 'confirm' })}>Confirm</Button>
+        <Button
+          variant="secondary"
+          onClick={() => onAction({ type: 'reject' })}
+        >
+          Reject all non-essential cookies
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  )
+}

--- a/apps/web/src/app/utility-buttons.tsx
+++ b/apps/web/src/app/utility-buttons.tsx
@@ -21,14 +21,14 @@ import { SUPPORT_NAVIGATION_LINKS } from './_common/header-elements'
 
 export const UtilityButtons = () => {
   return (
-    <div className="hidden md:flex gap-1 fixed bottom-0 right-2 z-50">
+    <div className="flex gap-1 fixed bottom-0 right-2 z-50">
       <CookieDialogContainer>
         <IconButton
           size="xs"
           variant="ghost"
           icon={BrowserCookieIcon}
           name={'cookies'}
-          className="text-muted-foreground"
+          className="hidden text-muted-foreground md:inline-flex"
         />
       </CookieDialogContainer>
       <Popover>
@@ -38,7 +38,7 @@ export const UtilityButtons = () => {
             variant="ghost"
             icon={QuestionMarkCircleIcon}
             name={'help'}
-            className="text-muted-foreground"
+            className="hidden text-muted-foreground md:inline-flex"
           />
         </PopoverTrigger>
         <PopoverContent className="!p-0">


### PR DESCRIPTION
## Summary
- render the initial cookie consent banner in server HTML instead of waiting for hydration
- remove the initial full-screen blurred dialog overlay and lazy-load preference management
- keep the cookie banner visible on mobile and add an accessible preferences description
- add regression coverage for first-time and returning-user server output

## Validation
- pnpm format
- pnpm lint
- targeted TypeScript check for touched files
- pnpm --filter web exec vitest run src/app/_common/cookies/cookie-dialog.test.tsx
- browser-verified opening, updating, confirming, and closing cookie preferences

## Notes
The full web type-check remains blocked in this worktree by missing proprietary TradingView definitions; it reports 32 errors confined to existing chart files.