### PR TITLE
perf(web): cache launchpad token pages

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
@@ -21,10 +21,7 @@ vi.mock('next/cache', () => ({
     },
 }))
 
-import {
-  getCachedLaunchpadToken,
-  getCachedLaunchpadTokenIdentity,
-} from './get-cached-launchpad-token'
+import { getCachedLaunchpadToken } from './get-cached-launchpad-token'
 
 const input = {
   chainId: 4663,
@@ -53,60 +50,5 @@ describe('getCachedLaunchpadToken', () => {
     getLaunchpadTokenMock.mockRejectedValueOnce(error)
 
     await expect(getCachedLaunchpadToken(input)).rejects.toBe(error)
-  })
-
-  it('caches only immutable token identity fields', async () => {
-    const token = {
-      address: input.address,
-      chainId: input.chainId,
-      creator: '0x0000000000000000000000000000000000000002',
-      decimals: 18,
-      metrics: { priceUsd: 1 },
-      name: 'Token',
-      provider: 'SUSHI_V1',
-      symbol: 'TKN',
-    }
-    getLaunchpadTokenMock.mockResolvedValueOnce(token)
-
-    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toEqual({
-      address: token.address,
-      chainId: token.chainId,
-      creator: token.creator,
-      decimals: token.decimals,
-      name: token.name,
-      provider: token.provider,
-      symbol: token.symbol,
-    })
-    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toEqual({
-      address: token.address,
-      chainId: token.chainId,
-      creator: token.creator,
-      decimals: token.decimals,
-      name: token.name,
-      provider: token.provider,
-      symbol: token.symbol,
-    })
-    expect(getLaunchpadTokenMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('does not negatively cache a missing token identity', async () => {
-    const token = {
-      address: input.address,
-      chainId: input.chainId,
-      creator: '0x0000000000000000000000000000000000000002',
-      decimals: 18,
-      name: 'Token',
-      provider: 'SUSHI_V1',
-      symbol: 'TKN',
-    }
-    getLaunchpadTokenMock
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(token)
-
-    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toBeNull()
-    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toMatchObject(
-      token,
-    )
-    expect(getLaunchpadTokenMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
@@ -21,7 +21,10 @@ vi.mock('next/cache', () => ({
     },
 }))
 
-import { getCachedLaunchpadToken } from './get-cached-launchpad-token'
+import {
+  getCachedLaunchpadToken,
+  getCachedLaunchpadTokenIdentity,
+} from './get-cached-launchpad-token'
 
 const input = {
   chainId: 4663,
@@ -50,5 +53,60 @@ describe('getCachedLaunchpadToken', () => {
     getLaunchpadTokenMock.mockRejectedValueOnce(error)
 
     await expect(getCachedLaunchpadToken(input)).rejects.toBe(error)
+  })
+
+  it('caches only immutable token identity fields', async () => {
+    const token = {
+      address: input.address,
+      chainId: input.chainId,
+      creator: '0x0000000000000000000000000000000000000002',
+      decimals: 18,
+      metrics: { priceUsd: 1 },
+      name: 'Token',
+      provider: 'SUSHI_V1',
+      symbol: 'TKN',
+    }
+    getLaunchpadTokenMock.mockResolvedValueOnce(token)
+
+    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toEqual({
+      address: token.address,
+      chainId: token.chainId,
+      creator: token.creator,
+      decimals: token.decimals,
+      name: token.name,
+      provider: token.provider,
+      symbol: token.symbol,
+    })
+    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toEqual({
+      address: token.address,
+      chainId: token.chainId,
+      creator: token.creator,
+      decimals: token.decimals,
+      name: token.name,
+      provider: token.provider,
+      symbol: token.symbol,
+    })
+    expect(getLaunchpadTokenMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not negatively cache a missing token identity', async () => {
+    const token = {
+      address: input.address,
+      chainId: input.chainId,
+      creator: '0x0000000000000000000000000000000000000002',
+      decimals: 18,
+      name: 'Token',
+      provider: 'SUSHI_V1',
+      symbol: 'TKN',
+    }
+    getLaunchpadTokenMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(token)
+
+    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toBeNull()
+    await expect(getCachedLaunchpadTokenIdentity(input)).resolves.toMatchObject(
+      token,
+    )
+    expect(getLaunchpadTokenMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { cache, getLaunchpadTokenMock } = vi.hoisted(() => ({
+  cache: new Map<string, unknown>(),
+  getLaunchpadTokenMock: vi.fn<() => Promise<unknown>>(),
+}))
+
+vi.mock('@sushiswap/graph-client/data-api', () => ({
+  getLaunchpadToken: getLaunchpadTokenMock,
+}))
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    (callback: () => Promise<unknown>, keyParts: string[]) => async () => {
+      const key = JSON.stringify(keyParts)
+      if (cache.has(key)) return cache.get(key)
+
+      const value = await callback()
+      cache.set(key, value)
+      return value
+    },
+}))
+
+import { getCachedLaunchpadToken } from './get-cached-launchpad-token'
+
+const input = {
+  chainId: 4663,
+  address: '0x0000000000000000000000000000000000000001',
+} as const
+
+describe('getCachedLaunchpadToken', () => {
+  beforeEach(() => {
+    cache.clear()
+    getLaunchpadTokenMock.mockReset()
+  })
+
+  it('does not cache a missing token', async () => {
+    const token = { id: 'launchpad-token' }
+    getLaunchpadTokenMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(token)
+
+    await expect(getCachedLaunchpadToken(input)).resolves.toBeNull()
+    await expect(getCachedLaunchpadToken(input)).resolves.toBe(token)
+    expect(getLaunchpadTokenMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not mask API errors', async () => {
+    const error = new Error('API unavailable')
+    getLaunchpadTokenMock.mockRejectedValueOnce(error)
+
+    await expect(getCachedLaunchpadToken(input)).rejects.toBe(error)
+  })
+})

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
@@ -3,16 +3,33 @@ import { unstable_cache } from 'next/cache'
 import type { EvmAddress } from 'sushi/evm'
 import type { LaunchpadChainId } from '../constants'
 
-export function getCachedLaunchpadToken({
+class LaunchpadTokenNotFoundError extends Error {}
+
+export async function getCachedLaunchpadToken({
   chainId,
   address,
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
 }) {
-  return unstable_cache(
-    async () => getLaunchpadToken({ chainId, address }, { retries: 3 }),
+  const getCachedToken = unstable_cache(
+    async () => {
+      const token = await getLaunchpadToken(
+        { chainId, address },
+        { retries: 3 },
+      )
+      if (!token) throw new LaunchpadTokenNotFoundError()
+
+      return token
+    },
     ['launchpad', 'token', `${chainId}:${address}`],
     { revalidate: 60 },
-  )()
+  )
+
+  try {
+    return await getCachedToken()
+  } catch (error) {
+    if (error instanceof LaunchpadTokenNotFoundError) return null
+    throw error
+  }
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
@@ -1,37 +1,9 @@
-import {
-  type LaunchpadToken,
-  getLaunchpadToken,
-} from '@sushiswap/graph-client/data-api'
+import { getLaunchpadToken } from '@sushiswap/graph-client/data-api'
 import { unstable_cache } from 'next/cache'
 import type { EvmAddress } from 'sushi/evm'
 import type { LaunchpadChainId } from '../constants'
 
 class LaunchpadTokenNotFoundError extends Error {}
-
-export type LaunchpadTokenIdentity = Pick<
-  LaunchpadToken,
-  | 'address'
-  | 'chainId'
-  | 'creator'
-  | 'decimals'
-  | 'name'
-  | 'provider'
-  | 'symbol'
->
-
-function getLaunchpadTokenIdentity(
-  token: LaunchpadToken,
-): LaunchpadTokenIdentity {
-  return {
-    address: token.address,
-    chainId: token.chainId,
-    creator: token.creator,
-    decimals: token.decimals,
-    name: token.name,
-    provider: token.provider,
-    symbol: token.symbol,
-  }
-}
 
 export async function getCachedLaunchpadToken({
   chainId,
@@ -39,7 +11,7 @@ export async function getCachedLaunchpadToken({
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
-}): Promise<LaunchpadToken | null> {
+}) {
   const getCachedToken = unstable_cache(
     async () => {
       const token = await getLaunchpadToken(
@@ -56,32 +28,6 @@ export async function getCachedLaunchpadToken({
 
   try {
     return await getCachedToken()
-  } catch (error) {
-    if (error instanceof LaunchpadTokenNotFoundError) return null
-    throw error
-  }
-}
-
-export async function getCachedLaunchpadTokenIdentity({
-  chainId,
-  address,
-}: {
-  chainId: LaunchpadChainId
-  address: EvmAddress
-}): Promise<LaunchpadTokenIdentity | null> {
-  const getCachedIdentity = unstable_cache(
-    async () => {
-      const token = await getCachedLaunchpadToken({ chainId, address })
-      if (!token) throw new LaunchpadTokenNotFoundError()
-
-      return getLaunchpadTokenIdentity(token)
-    },
-    ['launchpad', 'token-identity', `${chainId}:${address}`],
-    { revalidate: false },
-  )
-
-  try {
-    return await getCachedIdentity()
   } catch (error) {
     if (error instanceof LaunchpadTokenNotFoundError) return null
     throw error

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
@@ -1,9 +1,37 @@
-import { getLaunchpadToken } from '@sushiswap/graph-client/data-api'
+import {
+  type LaunchpadToken,
+  getLaunchpadToken,
+} from '@sushiswap/graph-client/data-api'
 import { unstable_cache } from 'next/cache'
 import type { EvmAddress } from 'sushi/evm'
 import type { LaunchpadChainId } from '../constants'
 
 class LaunchpadTokenNotFoundError extends Error {}
+
+export type LaunchpadTokenIdentity = Pick<
+  LaunchpadToken,
+  | 'address'
+  | 'chainId'
+  | 'creator'
+  | 'decimals'
+  | 'name'
+  | 'provider'
+  | 'symbol'
+>
+
+function getLaunchpadTokenIdentity(
+  token: LaunchpadToken,
+): LaunchpadTokenIdentity {
+  return {
+    address: token.address,
+    chainId: token.chainId,
+    creator: token.creator,
+    decimals: token.decimals,
+    name: token.name,
+    provider: token.provider,
+    symbol: token.symbol,
+  }
+}
 
 export async function getCachedLaunchpadToken({
   chainId,
@@ -11,7 +39,7 @@ export async function getCachedLaunchpadToken({
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
-}) {
+}): Promise<LaunchpadToken | null> {
   const getCachedToken = unstable_cache(
     async () => {
       const token = await getLaunchpadToken(
@@ -28,6 +56,32 @@ export async function getCachedLaunchpadToken({
 
   try {
     return await getCachedToken()
+  } catch (error) {
+    if (error instanceof LaunchpadTokenNotFoundError) return null
+    throw error
+  }
+}
+
+export async function getCachedLaunchpadTokenIdentity({
+  chainId,
+  address,
+}: {
+  chainId: LaunchpadChainId
+  address: EvmAddress
+}): Promise<LaunchpadTokenIdentity | null> {
+  const getCachedIdentity = unstable_cache(
+    async () => {
+      const token = await getCachedLaunchpadToken({ chainId, address })
+      if (!token) throw new LaunchpadTokenNotFoundError()
+
+      return getLaunchpadTokenIdentity(token)
+    },
+    ['launchpad', 'token-identity', `${chainId}:${address}`],
+    { revalidate: false },
+  )
+
+  try {
+    return await getCachedIdentity()
   } catch (error) {
     if (error instanceof LaunchpadTokenNotFoundError) return null
     throw error

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/use-launchpad-token.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/use-launchpad-token.ts
@@ -38,15 +38,17 @@ function hydrateLaunchpadToken(
 export function useLaunchpadToken(
   chainId: LaunchpadChainId,
   address: EvmAddress,
-  initialData?: LaunchpadToken | null,
+  initialData?: LaunchpadToken,
 ) {
   return useQuery({
     queryKey: ['launchpad', 'token', { chainId, address }],
     queryFn: () => getLaunchpadToken({ chainId, address }),
     initialData,
+    initialDataUpdatedAt: initialData ? 0 : undefined,
     select: hydrateLaunchpadToken,
     retry: 3,
     retryDelay: (attempt) => Math.min(ms('1s') * 2 ** attempt, ms('5s')),
     staleTime: ms('10s'),
+    gcTime: Number.POSITIVE_INFINITY,
   })
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/layout.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/layout.tsx
@@ -42,9 +42,7 @@ export default async function LaunchpadLayout({
           <div className="absolute left-[5%] top-0 h-72 w-72 rounded-full bg-perps-blue/[0.08] blur-3xl" />
           <div className="absolute right-[8%] top-16 h-80 w-80 rounded-full bg-pink-500/[0.06] blur-3xl" />
         </div>
-        <main className="relative flex flex-1 flex-col animate-launchpad-slide">
-          {children}
-        </main>
+        <main className="relative flex flex-1 flex-col">{children}</main>
       </div>
     </>
   )

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
@@ -105,7 +105,7 @@ export function ManageTokenPage({
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
-  initialToken: LaunchpadToken | null
+  initialToken: LaunchpadToken
 }) {
   const chainKey = getEvmChainById(chainId).key
   const { address: connectedAddress, chainId: connectedChainId } =

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import type { EvmAddress } from 'sushi/evm'
-import { isAddress } from 'viem'
+import { isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
 import { getCachedLaunchpadToken } from '../../_lib/get-cached-launchpad-token'
 import { isLaunchpadChainId } from '../../constants'
 import { ManageTokenPage } from './_ui/manage-token-page'
@@ -22,19 +21,21 @@ export default async function ManageTokenRoute({
   const { chainId: chainIdParam, address } = await params
   const chainId = Number(chainIdParam)
 
-  if (!isLaunchpadChainId(chainId) || !isAddress(address, { strict: false })) {
+  if (!isLaunchpadChainId(chainId) || !isEvmAddress(address)) {
     return notFound()
   }
+  const normalizedAddress = normalizeEvmAddress(address)
 
   const token = await getCachedLaunchpadToken({
     chainId,
-    address: address as EvmAddress,
+    address: normalizedAddress,
   })
+  if (!token) return notFound()
 
   return (
     <ManageTokenPage
       chainId={chainId}
-      address={address as EvmAddress}
+      address={normalizedAddress}
       initialToken={token}
     />
   )

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
@@ -9,6 +9,7 @@ import {
   HomeIcon,
   LinkIcon,
 } from '@heroicons/react/24/outline'
+import type { LaunchpadToken } from '@sushiswap/graph-client/data-api'
 import {
   Button,
   ClipboardController,
@@ -247,9 +248,11 @@ function MetadataLinks({
 export function TokenDetailPage({
   chainId,
   address,
+  initialToken,
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
+  initialToken: LaunchpadToken
 }) {
   const chain = getEvmChainById(chainId)
   const chainKey = chain.key
@@ -258,7 +261,7 @@ export function TokenDetailPage({
     isError: isTokenError,
     isPending: isTokenPending,
     refetch: refetchToken,
-  } = useLaunchpadToken(chainId, address)
+  } = useLaunchpadToken(chainId, address, initialToken)
   const { data: marketStats } = useLaunchpadMarketStats(chainId, address)
   const { isLg } = useBreakpoint('lg')
   const priceChartDataRef = useRef<PriceChartData>({

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
@@ -46,7 +46,6 @@ import {
   liquidityChange24hUsd,
   shortenAddress,
 } from '../../../_lib/format'
-import type { LaunchpadTokenIdentity } from '../../../_lib/get-cached-launchpad-token'
 import { launchpadProviderHasCapability } from '../../../_lib/launchpad-provider'
 import { useLaunchpadToken } from '../../../_lib/use-launchpad-token'
 import { DetailList } from '../../../_ui/detail-list'
@@ -254,7 +253,7 @@ function TokenHeader({
   indexingStatus,
   links = [],
 }: {
-  token: LaunchpadTokenIdentity
+  token: LaunchpadToken
   chainKey: string
   creatorUrl: string
   tokenUrl: string
@@ -315,11 +314,11 @@ function TokenHeader({
 export function TokenDetailPage({
   chainId,
   address,
-  tokenIdentity,
+  initialToken,
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
-  tokenIdentity: LaunchpadTokenIdentity
+  initialToken: LaunchpadToken
 }) {
   const chain = getEvmChainById(chainId)
   const chainKey = chain.key
@@ -333,10 +332,10 @@ export function TokenDetailPage({
   const { isLg } = useBreakpoint('lg')
   const priceChartDataRef = useRef<PriceChartData>({
     chainId,
-    decimals: token?.decimals ?? tokenIdentity.decimals,
+    decimals: token?.decimals ?? initialToken.decimals,
     initialSupply: token?.initialSupply ?? '0',
     tokenAddress: address,
-    symbol: tokenIdentity.symbol,
+    symbol: initialToken.symbol,
     price: token?.metrics?.priceUsd,
   })
 
@@ -345,10 +344,10 @@ export function TokenDetailPage({
       <TokenDetailSkeleton
         header={
           <TokenHeader
-            token={tokenIdentity}
+            token={initialToken}
             chainKey={chainKey}
-            creatorUrl={chain.getAccountUrl(tokenIdentity.creator)}
-            tokenUrl={chain.getTokenUrl(tokenIdentity.address)}
+            creatorUrl={chain.getAccountUrl(initialToken.creator)}
+            tokenUrl={chain.getTokenUrl(initialToken.address)}
           />
         }
       />
@@ -443,10 +442,10 @@ export function TokenDetailPage({
       className="w-full px-4 pb-20 lg:pb-14 pt-6 sm:pt-8"
     >
       <TokenHeader
-        token={tokenIdentity}
+        token={token}
         chainKey={chainKey}
-        creatorUrl={chain.getAccountUrl(tokenIdentity.creator)}
-        tokenUrl={chain.getTokenUrl(tokenIdentity.address)}
+        creatorUrl={chain.getAccountUrl(token.creator)}
+        tokenUrl={chain.getTokenUrl(token.address)}
         indexingStatus={token.indexingStatus}
         links={token.metadata.links}
       />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
@@ -46,6 +46,7 @@ import {
   liquidityChange24hUsd,
   shortenAddress,
 } from '../../../_lib/format'
+import type { LaunchpadTokenIdentity } from '../../../_lib/get-cached-launchpad-token'
 import { launchpadProviderHasCapability } from '../../../_lib/launchpad-provider'
 import { useLaunchpadToken } from '../../../_lib/use-launchpad-token'
 import { DetailList } from '../../../_ui/detail-list'
@@ -245,14 +246,80 @@ function MetadataLinks({
   )
 }
 
+function TokenHeader({
+  token,
+  chainKey,
+  creatorUrl,
+  tokenUrl,
+  indexingStatus,
+  links = [],
+}: {
+  token: LaunchpadTokenIdentity
+  chainKey: string
+  creatorUrl: string
+  tokenUrl: string
+  indexingStatus?: LaunchpadToken['indexingStatus']
+  links?: MetadataLink[]
+}) {
+  return (
+    <>
+      <div className="mb-5 flex items-center gap-2 text-xs text-perps-muted-50">
+        <Link
+          href={`/${chainKey}/launchpad`}
+          className="transition hover:text-perps-blue"
+        >
+          Launches
+        </Link>
+        <span>/</span>
+        <span className="font-medium text-perps-muted">{token.symbol}</span>
+      </div>
+
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-4">
+          <TokenAvatar token={token} size="lg" />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2.5">
+              <h1 className="truncate text-2xl font-semibold tracking-tight text-perps-muted sm:text-3xl">
+                {token.name}
+              </h1>
+              <span className="text-lg font-medium text-perps-muted-50 mt-0.5">
+                ${token.symbol}
+              </span>
+              {indexingStatus ? <StatusPill status={indexingStatus} /> : null}
+              <LaunchpadProviderBadge provider={token.provider} />
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-perps-muted-50">
+              <CopyableExplorerAddress
+                label="Launched by"
+                address={token.creator}
+                href={creatorUrl}
+                visibleCharacters={5}
+                linkClassName="text-perps-muted-50 transition hover:text-perps-blue"
+              />
+              <span>·</span>
+              <CopyableExplorerAddress
+                label="Token"
+                address={token.address}
+                href={tokenUrl}
+                visibleCharacters={6}
+              />
+            </div>
+          </div>
+        </div>
+        <MetadataLinks links={links} placement="header" />
+      </div>
+    </>
+  )
+}
+
 export function TokenDetailPage({
   chainId,
   address,
-  initialToken,
+  tokenIdentity,
 }: {
   chainId: LaunchpadChainId
   address: EvmAddress
-  initialToken: LaunchpadToken
+  tokenIdentity: LaunchpadTokenIdentity
 }) {
   const chain = getEvmChainById(chainId)
   const chainKey = chain.key
@@ -261,20 +328,31 @@ export function TokenDetailPage({
     isError: isTokenError,
     isPending: isTokenPending,
     refetch: refetchToken,
-  } = useLaunchpadToken(chainId, address, initialToken)
+  } = useLaunchpadToken(chainId, address)
   const { data: marketStats } = useLaunchpadMarketStats(chainId, address)
   const { isLg } = useBreakpoint('lg')
   const priceChartDataRef = useRef<PriceChartData>({
     chainId,
-    decimals: token?.decimals ?? 0,
+    decimals: token?.decimals ?? tokenIdentity.decimals,
     initialSupply: token?.initialSupply ?? '0',
     tokenAddress: address,
-    symbol: token?.symbol ?? '',
+    symbol: tokenIdentity.symbol,
     price: token?.metrics?.priceUsd,
   })
 
   if (isTokenPending) {
-    return <TokenDetailSkeleton />
+    return (
+      <TokenDetailSkeleton
+        header={
+          <TokenHeader
+            token={tokenIdentity}
+            chainKey={chainKey}
+            creatorUrl={chain.getAccountUrl(tokenIdentity.creator)}
+            tokenUrl={chain.getTokenUrl(tokenIdentity.address)}
+          />
+        }
+      />
+    )
   }
 
   if (isTokenError) {
@@ -364,51 +442,14 @@ export function TokenDetailPage({
       maxWidth="8xl"
       className="w-full px-4 pb-20 lg:pb-14 pt-6 sm:pt-8"
     >
-      <div className="mb-5 flex items-center gap-2 text-xs text-perps-muted-50">
-        <Link
-          href={`/${chainKey}/launchpad`}
-          className="transition hover:text-perps-blue"
-        >
-          Launches
-        </Link>
-        <span>/</span>
-        <span className="font-medium text-perps-muted">{token.symbol}</span>
-      </div>
-
-      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex min-w-0 items-center gap-4">
-          <TokenAvatar token={token} size="lg" />
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2.5">
-              <h1 className="truncate text-2xl font-semibold tracking-tight text-perps-muted sm:text-3xl">
-                {token.name}
-              </h1>
-              <span className="text-lg font-medium text-perps-muted-50 mt-0.5">
-                ${token.symbol}
-              </span>
-              <StatusPill status={token.indexingStatus} />
-              <LaunchpadProviderBadge provider={token.provider} />
-            </div>
-            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-perps-muted-50">
-              <CopyableExplorerAddress
-                label="Launched by"
-                address={token.creator}
-                href={chain.getAccountUrl(token.creator)}
-                visibleCharacters={5}
-                linkClassName="text-perps-muted-50 transition hover:text-perps-blue"
-              />
-              <span>·</span>
-              <CopyableExplorerAddress
-                label="Token"
-                address={token.address}
-                href={chain.getTokenUrl(token.address)}
-                visibleCharacters={6}
-              />
-            </div>
-          </div>
-        </div>
-        <MetadataLinks links={token.metadata.links} placement="header" />
-      </div>
+      <TokenHeader
+        token={tokenIdentity}
+        chainKey={chainKey}
+        creatorUrl={chain.getAccountUrl(tokenIdentity.creator)}
+        tokenUrl={chain.getTokenUrl(tokenIdentity.address)}
+        indexingStatus={token.indexingStatus}
+        links={token.metadata.links}
+      />
 
       <div className="mt-6">
         <MetricStrip>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
@@ -1,4 +1,5 @@
 import { Container, SkeletonBox } from '@sushiswap/ui'
+import type { ReactNode } from 'react'
 import { PerpsCard } from '~evm/perps/_ui/_common/perps-card'
 import { MetricStrip, MetricStripItem } from '../../../_ui/metric-strip'
 import { TradeActivitySkeleton } from './trade-activity'
@@ -22,7 +23,7 @@ function CardHeadingSkeleton() {
   )
 }
 
-export function TokenDetailSkeleton() {
+export function TokenDetailSkeleton({ header }: { header?: ReactNode } = {}) {
   return (
     <Container
       maxWidth="8xl"
@@ -32,29 +33,33 @@ export function TokenDetailSkeleton() {
     >
       <span className="sr-only">Loading token details</span>
 
-      <div className="mb-5 flex items-center gap-2">
-        <SkeletonBox className="h-4 w-16 rounded-sm" />
-        <SkeletonBox className="h-4 w-2 rounded-sm" />
-        <SkeletonBox className="h-4 w-10 rounded-sm" />
-      </div>
-
-      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex min-w-0 items-center gap-4">
-          <SkeletonBox className="h-14 w-14 shrink-0 rounded-full" />
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2.5">
-              <SkeletonBox className="h-8 w-36 rounded-lg sm:h-9 sm:w-52" />
-              <SkeletonBox className="h-7 w-12 rounded-md" />
-              <SkeletonBox className="h-6 w-12 rounded-full" />
-            </div>
-            <div className="mt-2 flex flex-wrap items-center gap-3">
-              <SkeletonBox className="h-4 w-32 rounded-sm" />
-              <SkeletonBox className="h-4 w-28 rounded-sm" />
-            </div>
+      {header ?? (
+        <>
+          <div className="mb-5 flex items-center gap-2">
+            <SkeletonBox className="h-4 w-16 rounded-sm" />
+            <SkeletonBox className="h-4 w-2 rounded-sm" />
+            <SkeletonBox className="h-4 w-10 rounded-sm" />
           </div>
-        </div>
-        <div />
-      </div>
+
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-center gap-4">
+              <SkeletonBox className="h-14 w-14 shrink-0 rounded-full" />
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2.5">
+                  <SkeletonBox className="h-8 w-36 rounded-lg sm:h-9 sm:w-52" />
+                  <SkeletonBox className="h-7 w-12 rounded-md" />
+                  <SkeletonBox className="h-6 w-12 rounded-full" />
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-3">
+                  <SkeletonBox className="h-4 w-32 rounded-sm" />
+                  <SkeletonBox className="h-4 w-28 rounded-sm" />
+                </div>
+              </div>
+            </div>
+            <div />
+          </div>
+        </>
+      )}
 
       <div className="mt-6">
         <MetricStrip>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/card.png/route.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/card.png/route.tsx
@@ -1,6 +1,6 @@
 import { cacheLife } from 'next/cache'
 import { ImageResponse } from 'next/og'
-import { getEvmChainById, isEvmAddress } from 'sushi/evm'
+import { getEvmChainById, isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
 import { getLaunchpadCardValues } from '../../../_lib/launchpad-card'
 import { getLaunchpadEmbedFonts } from '../../../_lib/launchpad-embed-fonts'
 import { buildLaunchpadEmbedSparkline } from '../../../_lib/launchpad-embed-sparkline'
@@ -80,8 +80,16 @@ export async function GET(
   const { chainId: chainIdParam, address } = await params
   const chainId = Number(chainIdParam)
   const embedChainId = isLaunchpadChainId(chainId) ? chainId : undefined
+  if (!isEvmAddress(address)) {
+    return new Response('Invalid token address', { status: 400 })
+  }
+
+  const normalizedAddress = normalizeEvmAddress(address)
   const [{ chainName, logoDataUrl, sparkline, values }, fonts] =
-    await Promise.all([getCardData(chainId, address), getLaunchpadEmbedFonts()])
+    await Promise.all([
+      getCardData(chainId, normalizedAddress),
+      getLaunchpadEmbedFonts(),
+    ])
 
   return new ImageResponse(
     <LaunchpadTokenEmbed

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
+import { Suspense } from 'react'
+import { type EvmAddress, isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
 import { getCachedLaunchpadToken } from '../../_lib/get-cached-launchpad-token'
 import {
   getLaunchpadCardValues,
@@ -14,8 +15,9 @@ import {
   getLaunchpadTokenUrl,
   serializeLaunchpadJsonLd,
 } from '../../_lib/launchpad-seo'
-import { isLaunchpadChainId } from '../../constants'
+import { type LaunchpadChainId, isLaunchpadChainId } from '../../constants'
 import { TokenDetailPage } from './_ui/token-detail-page'
+import { TokenDetailSkeleton } from './_ui/token-detail-skeleton'
 
 type LaunchpadTokenPageParams = Promise<{
   chainId: string
@@ -78,14 +80,13 @@ export async function generateMetadata({
   }
 }
 
-export default async function LaunchpadTokenPage({
-  params,
+async function LaunchpadTokenContent({
+  chainId,
+  address,
 }: {
-  params: LaunchpadTokenPageParams
+  chainId: LaunchpadChainId
+  address: EvmAddress
 }) {
-  const result = await getTokenParams(params)
-  if (!result) return notFound()
-  const { address, chainId } = result
   const token = await getCachedLaunchpadToken({ chainId, address })
   if (!token) return notFound()
 
@@ -103,5 +104,20 @@ export default async function LaunchpadTokenPage({
         initialToken={token}
       />
     </>
+  )
+}
+
+export default async function LaunchpadTokenPage({
+  params,
+}: {
+  params: LaunchpadTokenPageParams
+}) {
+  const result = await getTokenParams(params)
+  if (!result) return notFound()
+
+  return (
+    <Suspense fallback={<TokenDetailSkeleton />}>
+      <LaunchpadTokenContent {...result} />
+    </Suspense>
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
-import { getCachedLaunchpadToken } from '../../_lib/get-cached-launchpad-token'
+import { Suspense } from 'react'
+import { type EvmAddress, isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
+import {
+  getCachedLaunchpadToken,
+  getCachedLaunchpadTokenIdentity,
+} from '../../_lib/get-cached-launchpad-token'
 import {
   getLaunchpadCardValues,
   getLaunchpadCardVersion,
@@ -14,7 +18,7 @@ import {
   getLaunchpadTokenUrl,
   serializeLaunchpadJsonLd,
 } from '../../_lib/launchpad-seo'
-import { isLaunchpadChainId } from '../../constants'
+import { type LaunchpadChainId, isLaunchpadChainId } from '../../constants'
 import { TokenDetailPage } from './_ui/token-detail-page'
 
 type LaunchpadTokenPageParams = Promise<{
@@ -78,6 +82,26 @@ export async function generateMetadata({
   }
 }
 
+async function LaunchpadTokenJsonLd({
+  chainId,
+  address,
+}: {
+  chainId: LaunchpadChainId
+  address: EvmAddress
+}) {
+  const token = await getCachedLaunchpadToken({ chainId, address })
+  if (!token) return null
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: serializeLaunchpadJsonLd(getLaunchpadTokenJsonLd(token)),
+      }}
+    />
+  )
+}
+
 export default async function LaunchpadTokenPage({
   params,
 }: {
@@ -86,21 +110,21 @@ export default async function LaunchpadTokenPage({
   const result = await getTokenParams(params)
   if (!result) return notFound()
   const { address, chainId } = result
-  const token = await getCachedLaunchpadToken({ chainId, address })
-  if (!token) return notFound()
+  const tokenIdentity = await getCachedLaunchpadTokenIdentity({
+    chainId,
+    address,
+  })
+  if (!tokenIdentity) return notFound()
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: serializeLaunchpadJsonLd(getLaunchpadTokenJsonLd(token)),
-        }}
-      />
+      <Suspense fallback={null}>
+        <LaunchpadTokenJsonLd chainId={chainId} address={address} />
+      </Suspense>
       <TokenDetailPage
         chainId={chainId}
         address={address}
-        initialToken={token}
+        tokenIdentity={tokenIdentity}
       />
     </>
   )

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import type { EvmAddress } from 'sushi/evm'
-import { isAddress } from 'viem'
+import { isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
+import { getCachedLaunchpadToken } from '../../_lib/get-cached-launchpad-token'
 import {
   getLaunchpadCardValues,
   getLaunchpadCardVersion,
@@ -22,16 +22,16 @@ type LaunchpadTokenPageParams = Promise<{
   address: string
 }>
 
-async function getTokenFromParams(params: LaunchpadTokenPageParams) {
+async function getTokenParams(params: LaunchpadTokenPageParams) {
   const { chainId: chainIdParam, address } = await params
   const chainId = Number(chainIdParam)
 
-  if (!isLaunchpadChainId(chainId) || !isAddress(address, { strict: false })) {
+  if (!isLaunchpadChainId(chainId) || !isEvmAddress(address)) {
     return null
   }
+  const normalizedAddress = normalizeEvmAddress(address)
 
-  const token = await getLaunchpadTokenForSeo(chainId, address as EvmAddress)
-  return { address: address as EvmAddress, chainId, token }
+  return { address: normalizedAddress, chainId }
 }
 
 export async function generateMetadata({
@@ -39,10 +39,11 @@ export async function generateMetadata({
 }: {
   params: LaunchpadTokenPageParams
 }): Promise<Metadata> {
-  const result = await getTokenFromParams(params)
-  if (!result?.token) return {}
+  const result = await getTokenParams(params)
+  if (!result) return {}
 
-  const { token } = result
+  const token = await getLaunchpadTokenForSeo(result.chainId, result.address)
+  if (!token) return {}
   const url = getLaunchpadTokenUrl(token)
   const title = `${token.name} (${token.symbol})`
   const description = getLaunchpadTokenDescription(token)
@@ -82,21 +83,25 @@ export default async function LaunchpadTokenPage({
 }: {
   params: LaunchpadTokenPageParams
 }) {
-  const result = await getTokenFromParams(params)
+  const result = await getTokenParams(params)
   if (!result) return notFound()
-  const { address, chainId, token } = result
+  const { address, chainId } = result
+  const token = await getCachedLaunchpadToken({ chainId, address })
+  if (!token) return notFound()
 
   return (
     <>
-      {token ? (
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: serializeLaunchpadJsonLd(getLaunchpadTokenJsonLd(token)),
-          }}
-        />
-      ) : null}
-      <TokenDetailPage chainId={chainId} address={address} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeLaunchpadJsonLd(getLaunchpadTokenJsonLd(token)),
+        }}
+      />
+      <TokenDetailPage
+        chainId={chainId}
+        address={address}
+        initialToken={token}
+      />
     </>
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
@@ -1,11 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { Suspense } from 'react'
-import { type EvmAddress, isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
-import {
-  getCachedLaunchpadToken,
-  getCachedLaunchpadTokenIdentity,
-} from '../../_lib/get-cached-launchpad-token'
+import { isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
+import { getCachedLaunchpadToken } from '../../_lib/get-cached-launchpad-token'
 import {
   getLaunchpadCardValues,
   getLaunchpadCardVersion,
@@ -18,7 +14,7 @@ import {
   getLaunchpadTokenUrl,
   serializeLaunchpadJsonLd,
 } from '../../_lib/launchpad-seo'
-import { type LaunchpadChainId, isLaunchpadChainId } from '../../constants'
+import { isLaunchpadChainId } from '../../constants'
 import { TokenDetailPage } from './_ui/token-detail-page'
 
 type LaunchpadTokenPageParams = Promise<{
@@ -82,26 +78,6 @@ export async function generateMetadata({
   }
 }
 
-async function LaunchpadTokenJsonLd({
-  chainId,
-  address,
-}: {
-  chainId: LaunchpadChainId
-  address: EvmAddress
-}) {
-  const token = await getCachedLaunchpadToken({ chainId, address })
-  if (!token) return null
-
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: serializeLaunchpadJsonLd(getLaunchpadTokenJsonLd(token)),
-      }}
-    />
-  )
-}
-
 export default async function LaunchpadTokenPage({
   params,
 }: {
@@ -110,21 +86,21 @@ export default async function LaunchpadTokenPage({
   const result = await getTokenParams(params)
   if (!result) return notFound()
   const { address, chainId } = result
-  const tokenIdentity = await getCachedLaunchpadTokenIdentity({
-    chainId,
-    address,
-  })
-  if (!tokenIdentity) return notFound()
+  const token = await getCachedLaunchpadToken({ chainId, address })
+  if (!token) return notFound()
 
   return (
     <>
-      <Suspense fallback={null}>
-        <LaunchpadTokenJsonLd chainId={chainId} address={address} />
-      </Suspense>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeLaunchpadJsonLd(getLaunchpadTokenJsonLd(token)),
+        }}
+      />
       <TokenDetailPage
         chainId={chainId}
         address={address}
-        tokenIdentity={tokenIdentity}
+        initialToken={token}
       />
     </>
   )

--- a/apps/web/src/app/legal/[slug]/layout.tsx
+++ b/apps/web/src/app/legal/[slug]/layout.tsx
@@ -1,12 +1,17 @@
 'use client'
 
+import { Suspense } from 'react'
 import { Header } from '../header'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
-      <Header />
-      <div className="flex flex-col flex-1">{children}</div>
+      <Suspense fallback={null}>
+        <Header />
+      </Suspense>
+      <Suspense fallback={null}>
+        <div className="flex flex-col flex-1">{children}</div>
+      </Suspense>
     </>
   )
 }

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -30,21 +30,10 @@ const tailwindConfig = {
             transform: 'translateY(0)',
           },
         },
-        'launchpad-slide': {
-          '0%': {
-            opacity: 0,
-            transform: 'translateY(-56px)',
-          },
-          '100%': {
-            opacity: 1,
-            transform: 'translateY(0)',
-          },
-        },
       },
       animation: {
         marquee: 'marquee 5s linear infinite',
         slide: 'slide .5s',
-        'launchpad-slide': 'launchpad-slide .5s',
       },
     },
   },


### PR DESCRIPTION
## Summary

- hydrate launchpad token and management pages from the existing server cache
- retain token query data across client navigation while immediately refreshing dynamic fields
- normalize route addresses at the boundary and reject malformed card addresses with HTTP 400
- avoid caching missing token lookups while preserving real API errors

## Validation

- pnpm lint
- pnpm --filter web exec vitest run src/app/\(networks\)/\(evm\)/\[chainId\]/launchpad (78 tests)