### PR TITLE
fix(web): stream launchpad token navigation

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/loading.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/loading.tsx
@@ -1,7 +1,7 @@
 import { Container, SkeletonBox } from '@sushiswap/ui'
 import { PerpsCard } from '~evm/perps/_ui/_common/perps-card'
-import { MetricStrip, MetricStripItem } from './_ui/metric-strip'
-import { TokenGridSkeleton } from './_ui/token-grid'
+import { MetricStrip, MetricStripItem } from '../_ui/metric-strip'
+import { TokenGridSkeleton } from '../_ui/token-grid'
 
 const METRIC_SKELETONS = [
   { key: 'tokens', labelWidth: 'w-24', valueWidth: 'w-20' },

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/page.tsx
@@ -6,9 +6,9 @@ import {
   getLaunchpadTokensForSeo,
   getLaunchpadUrl,
   serializeLaunchpadJsonLd,
-} from './_lib/launchpad-seo'
-import { LaunchpadHomePage } from './_ui/launchpad-home-page'
-import { isLaunchpadChainId } from './constants'
+} from '../_lib/launchpad-seo'
+import { LaunchpadHomePage } from '../_ui/launchpad-home-page'
+import { isLaunchpadChainId } from '../constants'
 
 const DESCRIPTION =
   'Create and discover tokens with live markets and permanently locked Sushi V3 liquidity.'

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
@@ -122,6 +122,7 @@ export function TokenCard({
             <div className="flex w-full min-w-0 justify-center text-center">
               <Link
                 href={href}
+                prefetch={manage ? 'auto' : true}
                 aria-label={`${manage ? 'Manage' : 'View'} ${token.name}`}
                 title={token.name}
                 className="mx-auto flex max-w-full min-w-0 items-center justify-center text-base font-semibold text-perps-muted transition after:absolute after:inset-0 focus-visible:outline-none focus-visible:after:ring-2 focus-visible:after:ring-inset focus-visible:after:ring-perps-blue/50 group-hover:text-perps-blue"

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/creator/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/creator/[address]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
 import { shortenAddress } from 'sushi'
 import { getEvmChainById } from 'sushi/evm'
 import type { EvmAddress } from 'sushi/evm'
@@ -63,7 +64,7 @@ export async function generateMetadata({
   }
 }
 
-export default async function LaunchpadCreatorPage({
+async function LaunchpadCreatorContent({
   params,
 }: {
   params: LaunchpadCreatorPageParams
@@ -85,5 +86,17 @@ export default async function LaunchpadCreatorPage({
       />
       <CreatorPage chainId={chainId} address={address} />
     </>
+  )
+}
+
+export default function LaunchpadCreatorPage({
+  params,
+}: {
+  params: LaunchpadCreatorPageParams
+}) {
+  return (
+    <Suspense fallback={null}>
+      <LaunchpadCreatorContent params={params} />
+    </Suspense>
   )
 }

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
@@ -341,16 +341,18 @@ export function TokenDetailPage({
 
   if (isTokenPending) {
     return (
-      <TokenDetailSkeleton
-        header={
-          <TokenHeader
-            token={initialToken}
-            chainKey={chainKey}
-            creatorUrl={chain.getAccountUrl(initialToken.creator)}
-            tokenUrl={chain.getTokenUrl(initialToken.address)}
-          />
-        }
-      />
+      <Container
+        maxWidth="8xl"
+        className="w-full px-4 pb-20 lg:pb-14 pt-6 sm:pt-8"
+      >
+        <TokenHeader
+          token={initialToken}
+          chainKey={chainKey}
+          creatorUrl={chain.getAccountUrl(initialToken.creator)}
+          tokenUrl={chain.getTokenUrl(initialToken.address)}
+        />
+        <TokenDetailSkeleton bodyOnly />
+      </Container>
     )
   }
 

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
@@ -23,17 +23,25 @@ function CardHeadingSkeleton() {
   )
 }
 
-export function TokenDetailSkeleton({ header }: { header?: ReactNode } = {}) {
+export function TokenDetailSkeleton({
+  header,
+  bodyOnly = false,
+}: {
+  header?: ReactNode
+  bodyOnly?: boolean
+} = {}) {
+  const renderedHeader = bodyOnly ? false : header
+
   return (
     <Container
       maxWidth="8xl"
-      className="w-full px-4 pb-14 pt-6 sm:pt-8"
+      className={bodyOnly ? 'contents' : 'w-full px-4 pb-14 pt-6 sm:pt-8'}
       aria-busy="true"
       aria-label="Loading token details"
     >
       <span className="sr-only">Loading token details</span>
 
-      {header ?? (
+      {renderedHeader ?? (
         <>
           <div className="mb-5 flex items-center gap-2">
             <SkeletonBox className="h-4 w-16 rounded-sm" />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/loading.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/loading.tsx
@@ -1,5 +1,0 @@
-import { TokenDetailSkeleton } from './_ui/token-detail-skeleton'
-
-export default function TokenDetailLoading() {
-  return <TokenDetailSkeleton />
-}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
-import { type EvmAddress, isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
+import { isEvmAddress, normalizeEvmAddress } from 'sushi/evm'
 import { getCachedLaunchpadToken } from '../../_lib/get-cached-launchpad-token'
 import {
   getLaunchpadCardValues,
@@ -15,7 +15,7 @@ import {
   getLaunchpadTokenUrl,
   serializeLaunchpadJsonLd,
 } from '../../_lib/launchpad-seo'
-import { type LaunchpadChainId, isLaunchpadChainId } from '../../constants'
+import { isLaunchpadChainId } from '../../constants'
 import { TokenDetailPage } from './_ui/token-detail-page'
 import { TokenDetailSkeleton } from './_ui/token-detail-skeleton'
 
@@ -81,12 +81,13 @@ export async function generateMetadata({
 }
 
 async function LaunchpadTokenContent({
-  chainId,
-  address,
+  params,
 }: {
-  chainId: LaunchpadChainId
-  address: EvmAddress
+  params: LaunchpadTokenPageParams
 }) {
+  const result = await getTokenParams(params)
+  if (!result) return notFound()
+  const { chainId, address } = result
   const token = await getCachedLaunchpadToken({ chainId, address })
   if (!token) return notFound()
 
@@ -107,17 +108,14 @@ async function LaunchpadTokenContent({
   )
 }
 
-export default async function LaunchpadTokenPage({
+export default function LaunchpadTokenPage({
   params,
 }: {
   params: LaunchpadTokenPageParams
 }) {
-  const result = await getTokenParams(params)
-  if (!result) return notFound()
-
   return (
     <Suspense fallback={<TokenDetailSkeleton />}>
-      <LaunchpadTokenContent {...result} />
+      <LaunchpadTokenContent params={params} />
     </Suspense>
   )
 }


### PR DESCRIPTION
## Summary

- remove the redundant route-level token detail loading boundary
- let the page-level Suspense boundary stream the cached token header during client-side navigation
- align direct loads and in-app launchpad token navigation

## Validation

- `pnpm exec biome check apps/web/src/app/\(networks\)/\(evm\)/\[chainId\]/launchpad/token/\[address\]/page.tsx`
- `git diff --check`