### PR TITLE
fix(web): stabilize launchpad token loading header

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.test.ts
@@ -1,24 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { cache, getLaunchpadTokenMock } = vi.hoisted(() => ({
-  cache: new Map<string, unknown>(),
-  getLaunchpadTokenMock: vi.fn<() => Promise<unknown>>(),
-}))
+const { cache, cacheConfigurations, getLaunchpadTokenMock } = vi.hoisted(
+  () => ({
+    cache: new Map<string, unknown>(),
+    cacheConfigurations: [] as unknown[],
+    getLaunchpadTokenMock: vi.fn<() => Promise<unknown>>(),
+  }),
+)
 
 vi.mock('@sushiswap/graph-client/data-api', () => ({
   getLaunchpadToken: getLaunchpadTokenMock,
 }))
 
 vi.mock('next/cache', () => ({
-  unstable_cache:
-    (callback: () => Promise<unknown>, keyParts: string[]) => async () => {
+  unstable_cache: (
+    callback: () => Promise<unknown>,
+    keyParts: string[],
+    configuration: unknown,
+  ) => {
+    cacheConfigurations.push(configuration)
+
+    return async () => {
       const key = JSON.stringify(keyParts)
       if (cache.has(key)) return cache.get(key)
 
       const value = await callback()
       cache.set(key, value)
       return value
-    },
+    }
+  },
 }))
 
 import { getCachedLaunchpadToken } from './get-cached-launchpad-token'
@@ -31,7 +41,16 @@ const input = {
 describe('getCachedLaunchpadToken', () => {
   beforeEach(() => {
     cache.clear()
+    cacheConfigurations.length = 0
     getLaunchpadTokenMock.mockReset()
+  })
+
+  it('revalidates cached tokens hourly', async () => {
+    getLaunchpadTokenMock.mockResolvedValueOnce({ id: 'launchpad-token' })
+
+    await getCachedLaunchpadToken(input)
+
+    expect(cacheConfigurations).toContainEqual({ revalidate: 60 * 60 })
   })
 
   it('does not cache a missing token', async () => {

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/get-cached-launchpad-token.ts
@@ -3,6 +3,8 @@ import { unstable_cache } from 'next/cache'
 import type { EvmAddress } from 'sushi/evm'
 import type { LaunchpadChainId } from '../constants'
 
+const LAUNCHPAD_TOKEN_REVALIDATE_SECONDS = 60 * 60
+
 class LaunchpadTokenNotFoundError extends Error {}
 
 export async function getCachedLaunchpadToken({
@@ -23,7 +25,7 @@ export async function getCachedLaunchpadToken({
       return token
     },
     ['launchpad', 'token', `${chainId}:${address}`],
-    { revalidate: 60 },
+    { revalidate: LAUNCHPAD_TOKEN_REVALIDATE_SECONDS },
   )
 
   try {

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
@@ -21,6 +21,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
+  SkeletonBox,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -284,7 +285,11 @@ function TokenHeader({
               <span className="text-lg font-medium text-perps-muted-50 mt-0.5">
                 ${token.symbol}
               </span>
-              {indexingStatus ? <StatusPill status={indexingStatus} /> : null}
+              {indexingStatus ? (
+                <StatusPill status={indexingStatus} />
+              ) : (
+                <SkeletonBox className="h-6 w-12 rounded-full" />
+              )}
               <LaunchpadProviderBadge provider={token.provider} />
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-perps-muted-50">

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
@@ -57,6 +57,7 @@ export function TokenDetailSkeleton({
                   <SkeletonBox className="h-8 w-36 rounded-lg sm:h-9 sm:w-52" />
                   <SkeletonBox className="h-7 w-12 rounded-md" />
                   <SkeletonBox className="h-6 w-12 rounded-full" />
+                  <SkeletonBox className="h-7 w-20 rounded-full" />
                 </div>
                 <div className="mt-2 flex flex-wrap items-center gap-3">
                   <SkeletonBox className="h-4 w-32 rounded-sm" />


### PR DESCRIPTION
## Summary
- render both status and provider placeholders in the launchpad token skeleton
- keep a status placeholder visible while fresh indexing state loads
- extend the server token cache revalidation interval to one hour
- cover the cache interval with a unit test

## Validation
- pnpm exec biome check on the four changed files
- pnpm --filter web exec vitest run src/app/\(networks\)/\(evm\)/\[chainId\]/launchpad/_lib/get-cached-launchpad-token.test.ts

## Notes
The full web typecheck currently fails on existing generated-route and unrelated pool/token typing errors; none are in the changed files.