### PR TITLE
fix(web): align launchpad token loading and cards

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/loading.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/loading.tsx
@@ -4,9 +4,9 @@ import { MetricStrip, MetricStripItem } from '../_ui/metric-strip'
 import { TokenGridSkeleton } from '../_ui/token-grid'
 
 const METRIC_SKELETONS = [
-  { key: 'tokens', labelWidth: 'w-24', valueWidth: 'w-20' },
-  { key: 'volume', labelWidth: 'w-20', valueWidth: 'w-24' },
-  { key: 'liquidity', labelWidth: 'w-16', valueWidth: 'w-24' },
+  { key: 'tokens', labelWidth: 'w-[113px]', valueWidth: 'w-12' },
+  { key: 'volume', labelWidth: 'w-[75px]', valueWidth: 'w-16' },
+  { key: 'liquidity', labelWidth: 'w-[57px]', valueWidth: 'w-[82px]' },
 ] as const
 
 export default function LaunchpadLoading() {
@@ -47,7 +47,7 @@ export default function LaunchpadLoading() {
                 key={metric.key}
                 index={index}
                 label={
-                  <div className="flex h-4 items-center">
+                  <div className="flex h-[16.5px] items-center">
                     <SkeletonBox
                       className={`h-3 rounded-sm ${metric.labelWidth}`}
                     />
@@ -63,8 +63,8 @@ export default function LaunchpadLoading() {
             <div className="flex items-center gap-3 border-l border-t border-white/[0.06] px-5 py-4 lg:border-t-0">
               <SkeletonBox className="hidden h-9 w-9 shrink-0 rounded-full sm:block" />
               <div>
-                <SkeletonBox className="h-3 w-20 rounded-sm" />
-                <SkeletonBox className="mt-2 h-5 w-12 rounded-sm" />
+                <SkeletonBox className="h-[16.5px] w-[86px] rounded-sm" />
+                <SkeletonBox className="mt-1 h-5 w-[42px] rounded-sm" />
               </div>
             </div>
           </MetricStrip>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-avatar.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-avatar.tsx
@@ -33,7 +33,7 @@ export function TokenAvatar({
   const pixels = SIZE_IN_PIXELS[size]
 
   return (
-    <span className="relative inline-flex shrink-0">
+    <span className="relative inline-flex shrink-0 align-top">
       <Currency.Icon
         disableLink
         currency={currency}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/token-card.tsx
@@ -26,27 +26,27 @@ export function TokenCardSkeleton() {
             <div className="relative col-start-2 row-start-1">
               <SkeletonCircle radius={96} />
               <SkeletonCircle
-                radius={20}
+                radius={24}
                 className="absolute -bottom-0.5 -right-0.5"
               />
             </div>
           </div>
           <div className="flex w-full min-w-0 flex-col items-center">
-            <SkeletonBox className="h-5 w-3/5 rounded-md" />
-            <SkeletonBox className="mt-1 h-4 w-1/3 rounded-sm" />
-            <SkeletonBox className="mt-1.5 h-3 w-2/5 rounded-sm" />
+            <SkeletonBox className="h-6 w-40 rounded-md" />
+            <SkeletonBox className="h-4 w-[88px] rounded-sm" />
+            <SkeletonBox className="mt-1 h-[15px] w-[127px] rounded-sm" />
           </div>
         </div>
 
         <div className="mt-2 flex flex-col gap-0.5 border-t border-white/[0.06] pt-3">
           {[
             ['market-cap', 'w-16', 'w-14'],
-            ['volume', 'w-12', 'w-12'],
-            ['liquidity', 'w-14', 'w-16'],
+            ['volume', 'w-[42px]', 'w-14'],
+            ['liquidity', 'w-12', 'w-12'],
           ].map(([stat, labelWidth, valueWidth]) => (
             <div
               key={stat}
-              className="flex items-center justify-between py-0.5"
+              className="flex h-[16.5px] items-center justify-between"
             >
               <SkeletonBox className={`h-3 ${labelWidth} rounded-sm`} />
               <SkeletonBox className={`h-3 ${valueWidth} rounded-sm`} />
@@ -56,7 +56,7 @@ export function TokenCardSkeleton() {
 
         <div className="mt-4 grid grid-cols-4 gap-2">
           {['10', '25', '50', '100'].map((amount) => (
-            <SkeletonBox key={amount} className="h-8 rounded-lg" />
+            <SkeletonBox key={amount} className="h-[26px] rounded-lg" />
           ))}
         </div>
       </div>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
@@ -4,7 +4,32 @@ import { PerpsCard } from '~evm/perps/_ui/_common/perps-card'
 import { MetricStrip, MetricStripItem } from '../../../_ui/metric-strip'
 import { TradeActivitySkeleton } from './trade-activity'
 
-const MARKET_STAT_SKELETONS = ['price', 'fdv', 'liquidity', 'volume'] as const
+const MARKET_STAT_SKELETONS = [
+  {
+    key: 'price',
+    labelWidth: 'w-[34px]',
+    valueWidth: 'w-32',
+    detailWidth: 'w-[76px]',
+  },
+  {
+    key: 'fdv',
+    labelWidth: 'w-6',
+    valueWidth: 'w-20',
+    detailWidth: 'w-20',
+  },
+  {
+    key: 'liquidity',
+    labelWidth: 'w-[57px]',
+    valueWidth: 'w-[151px]',
+    detailWidth: 'w-[107px]',
+  },
+  {
+    key: 'volume',
+    labelWidth: 'w-[75px]',
+    valueWidth: 'w-[66px]',
+    detailWidth: 'w-[104px]',
+  },
+] as const
 
 const TRADE_ROW_SKELETONS = ['first', 'second', 'third', 'fourth'] as const
 const LOCKED_POSITION_SKELETONS = [
@@ -74,12 +99,22 @@ export function TokenDetailSkeleton({
         <MetricStrip>
           {MARKET_STAT_SKELETONS.map((stat, index) => (
             <MetricStripItem
-              key={stat}
+              key={stat.key}
               index={index}
               className="min-h-[104px] sm:min-h-[103px]"
-              label={<SkeletonBox className="h-3 w-16 rounded-sm" />}
-              value={<SkeletonBox className="h-6 w-24 rounded-md" />}
-              detail={<SkeletonBox className="h-3 w-20 rounded-sm" />}
+              label={
+                <SkeletonBox
+                  className={`h-[16.5px] rounded-sm ${stat.labelWidth}`}
+                />
+              }
+              value={
+                <SkeletonBox className={`h-7 rounded-md ${stat.valueWidth}`} />
+              }
+              detail={
+                <SkeletonBox
+                  className={`h-[16.5px] rounded-sm ${stat.detailWidth}`}
+                />
+              }
             />
           ))}
         </MetricStrip>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
@@ -70,7 +70,7 @@ export function TokenDetailSkeleton({
         </>
       )}
 
-      <div className="mt-6">
+      <div className="mt-7">
         <MetricStrip>
           {MARKET_STAT_SKELETONS.map((stat, index) => (
             <MetricStripItem

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
@@ -95,7 +95,7 @@ export function TokenDetailSkeleton({
         </>
       )}
 
-      <div className="mt-7">
+      <div className="mt-6">
         <MetricStrip>
           {MARKET_STAT_SKELETONS.map((stat, index) => (
             <MetricStripItem


### PR DESCRIPTION
## Summary

- Match discover token-card skeletons to the rendered card: measured name, symbol, network/age, stat, avatar-badge, and quick-buy dimensions.
- Match the discover metric strip placeholders to the rendered label/value widths.
- Match the token-detail Price, FDV, Liquidity, and 24h volume placeholders to the measured label/value/detail line boxes and widths.
- Align the token-detail skeleton metric strip with the loaded page mt-6 position.
- Align token avatar baselines so discover cards reserve the same vertical space for logo and no-logo tokens.

## Validation

- pnpm format
- pnpm lint
- Browser-measured rendered launchpad discover and token-detail pages.
- pnpm exec turbo run check --filter=web --no-cache is blocked by pre-existing @sushiswap/graph-client type errors for missing observationIndex and fee-growth fields.