### PR TITLE
feat(ui): aurora token logo fallbacks

### DIFF
--- a/apps/web/src/app/(networks)/(non-evm)/aptos/_common/ui/currency/currency-icon.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/aptos/_common/ui/currency/currency-icon.tsx
@@ -1,3 +1,7 @@
+import {
+  getTokenFallbackIconStyle,
+  getTokenFallbackMonogram,
+} from '@sushiswap/ui'
 import React from 'react'
 import type { Token } from '~aptos/_common/lib/types/token'
 
@@ -5,32 +9,6 @@ interface CurrencyIcon {
   currency: Token | undefined
   height?: number
   width?: number
-}
-
-function djb2(str: string) {
-  let hash = 5381
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash << 5) + hash + str.charCodeAt(i) /* hash * 33 + c */
-  }
-  return hash
-}
-
-function hashStringToColor(str: string) {
-  const hash = djb2(str)
-  const r = (hash & 0xff0000) >> 16
-  const g = (hash & 0x00ff00) >> 8
-  const b = hash & 0x0000ff
-
-  return (
-    // biome-ignore lint/style/useTemplate: Minddeft
-    '#' +
-    // biome-ignore lint/style/useTemplate: Minddeft
-    ('0' + r.toString(16)).substr(-2) +
-    // biome-ignore lint/style/useTemplate: Minddeft
-    ('0' + g.toString(16)).substr(-2) +
-    // biome-ignore lint/style/useTemplate: Minddeft
-    ('0' + b.toString(16)).substr(-2)
-  )
 }
 
 export const CurrencyIcon = ({
@@ -50,16 +28,17 @@ export const CurrencyIcon = ({
         />
       ) : (
         <div
-          className="text-xs text-white font-bold rounded-full flex items-center justify-center bg-gradient-to-b from-gray-300 to-gray-200 dark:from-blue-700 dark:to-blue-900"
+          className="rounded-full flex items-center justify-center"
           style={{
             width: `${width}px`,
             height: `${height}px`,
-            background: hashStringToColor(
-              currency ? `${currency.symbol} ${currency.name}` : '??',
+            ...getTokenFallbackIconStyle(
+              { address: currency?.address ?? '??', chainId: 'aptos' },
+              width,
             ),
           }}
         >
-          {currency?.symbol?.substring(0, 2) ?? '??'}
+          {getTokenFallbackMonogram(currency?.symbol)}
         </div>
       )}
     </>

--- a/packages/ui/src/components/currency/currency-avatar.tsx
+++ b/packages/ui/src/components/currency/currency-avatar.tsx
@@ -3,13 +3,18 @@
 import type { ImageProps } from 'next/image'
 import { useState } from 'react'
 
+import { getTokenFallbackIconStyle } from '../../lib/token-fallback-icon'
 import { Avatar, AvatarFallback, AvatarImage } from '../avatar'
 
 type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error'
 
+/** `Avatar` falls back to its own `h-10 w-10` when given no explicit width. */
+const DEFAULT_SIZE_IN_PIXELS = 40
+
 interface CurrencyAvatarProps {
+  address: string
+  chainId: number | string
   fallback: string
-  fallbackColor: string
   height: ImageProps['height']
   src: string
   width: ImageProps['width']
@@ -21,8 +26,9 @@ interface ImageState {
 }
 
 export function CurrencyAvatar({
+  address,
+  chainId,
   fallback,
-  fallbackColor,
   height,
   src,
   width,
@@ -32,6 +38,7 @@ export function CurrencyAvatar({
     status: 'loading',
   })
   const status = imageState.src === src ? imageState.status : 'loading'
+  const fallbackSizeInPixels = Number(width) || DEFAULT_SIZE_IN_PIXELS
 
   return (
     <Avatar key={src} style={{ width, height }}>
@@ -42,8 +49,10 @@ export function CurrencyAvatar({
       />
       {status === 'error' ? (
         <AvatarFallback
-          style={{ backgroundColor: fallbackColor }}
-          className="font-bold text-white"
+          style={getTokenFallbackIconStyle(
+            { address, chainId },
+            fallbackSizeInPixels,
+          )}
         >
           {fallback}
         </AvatarFallback>

--- a/packages/ui/src/components/currency/icon.tsx
+++ b/packages/ui/src/components/currency/icon.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import { ChainId, type Currency, getChainById } from 'sushi'
 
 import type { EvmAddress } from 'sushi/evm'
+import { getTokenFallbackMonogram } from '../../lib/token-fallback-icon'
 import { LinkExternal } from '../link'
 import { CurrencyAvatar } from './currency-avatar'
 
@@ -99,16 +100,6 @@ const LOGO: Record<number, string> = {
   [ChainId.SOLANA]: SolanaLogo,
   [ChainId.ROBINHOOD]: EthereumLogo,
 }
-function hashAddressToColor(address: string): string {
-  let hash = 5381
-
-  for (let index = 0; index < address.length; index++) {
-    hash = (hash << 5) + hash + address.charCodeAt(index)
-  }
-
-  const hue = (hash >>> 0) % 360
-  return `hsl(${hue}, 65%, 45%)`
-}
 
 export interface IconProps extends Omit<ImageProps, 'src' | 'alt'> {
   currency: Currency
@@ -133,8 +124,9 @@ export const Icon: FC<IconProps> = ({
       src={src}
       width={rest.width}
       height={rest.height}
-      fallback={currency.symbol.charAt(0).toUpperCase() || '?'}
-      fallbackColor={hashAddressToColor(address.toLowerCase())}
+      chainId={currency.chainId}
+      address={address}
+      fallback={getTokenFallbackMonogram(currency.symbol)}
     />
   )
 

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './get-onramp-url'
 export * from './gtag'
 export * from './sync-scroll-lock-safe-area'
+export * from './token-fallback-icon'
 export * from './use-breakpoint'

--- a/packages/ui/src/lib/token-fallback-icon.ts
+++ b/packages/ui/src/lib/token-fallback-icon.ts
@@ -1,0 +1,104 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Deterministic generative art for tokens whose logo cannot be resolved — the
+ * "Aurora" fallback: two wide sweeps and a conic veil over a two-hue base.
+ *
+ * Every value (hue pair, sweep positions, angles) is derived from a 32-bit
+ * FNV-1a hash of `${chainId}:${address}`, so the same token renders the same
+ * art on every device with no network calls and no stored data. It is four
+ * stacked CSS gradients on the node that already exists: no filters, no blur,
+ * no animation.
+ */
+
+const FNV_OFFSET_BASIS = 0x811c9dc5
+const FNV_PRIME = 0x01000193
+
+function fnv1a(value: string): number {
+  let hash = FNV_OFFSET_BASIS
+
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, FNV_PRIME) >>> 0
+  }
+
+  return hash >>> 0
+}
+
+/** Mulberry32 — cheap, and identical across engines for a given seed. */
+function createRandom(seed: number): () => number {
+  let state = (seed ^ 0x9e3779b9) >>> 0
+
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let value = state
+    value = Math.imul(value ^ (value >>> 15), value | 1)
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61)
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** On-brand hue pairs: blue, pink, purple, green, amber, red, teal, lime. */
+const HUE_PAIRS = [
+  [212, 258],
+  [330, 292],
+  [266, 208],
+  [152, 188],
+  [38, 12],
+  [352, 20],
+  [186, 158],
+  [86, 46],
+] as const
+
+const MONOGRAM_SIZE_RATIO = 0.38
+
+/**
+ * The token identity the art is derived from. Only the string form matters, so
+ * this accepts an address of any chain type verbatim.
+ */
+export interface TokenFallbackIconSeed {
+  address: string
+  chainId: number | string
+}
+
+function auroraBackground({ address, chainId }: TokenFallbackIconSeed): string {
+  const seed = fnv1a(`${chainId}:${address.toLowerCase()}`)
+  const random = createRandom(seed)
+  const randomInt = (min: number, max: number) =>
+    min + Math.floor(random() * (max - min + 1))
+  const [lead, trail] = HUE_PAIRS[seed % HUE_PAIRS.length]
+
+  // Every `randomInt` call advances one shared sequence, so the art only stays
+  // reproducible while these layers are built in this order.
+  return [
+    `radial-gradient(120% 90% at ${randomInt(0, 100)}% ${randomInt(-20, 40)}%, hsl(${lead} 96% 78% / 0.85), transparent 65%)`,
+    `radial-gradient(110% 80% at ${randomInt(0, 100)}% ${randomInt(60, 120)}%, hsl(${trail} 92% 62% / 0.9), transparent 68%)`,
+    `conic-gradient(from ${randomInt(0, 359)}deg at 50% 50%, hsl(${lead} 80% 46% / 0.55), transparent 40%, hsl(${trail} 80% 52% / 0.5) 75%, transparent)`,
+    `linear-gradient(${randomInt(0, 359)}deg, hsl(${trail} 74% 30%), hsl(${lead} 78% 46%))`,
+  ].join(',')
+}
+
+/**
+ * Style for the fallback surface itself — the aurora art, its inset ring, and
+ * the monogram typography, scaled to the icon's rendered size in pixels.
+ */
+export function getTokenFallbackIconStyle(
+  seed: TokenFallbackIconSeed,
+  sizeInPixels: number,
+): CSSProperties {
+  return {
+    background: auroraBackground(seed),
+    boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.12)',
+    color: 'rgba(255,255,255,0.94)',
+    fontSize: Math.round(sizeInPixels * MONOGRAM_SIZE_RATIO),
+    fontWeight: 700,
+    letterSpacing: '-0.02em',
+    lineHeight: 1,
+    textShadow: '0 1px 8px rgba(0,0,0,0.45)',
+  }
+}
+
+/** The single character painted over the art. */
+export function getTokenFallbackMonogram(symbol: string | undefined): string {
+  return symbol?.charAt(0).toUpperCase() || '?'
+}

--- a/packages/ui/src/lib/token-fallback-icon.ts
+++ b/packages/ui/src/lib/token-fallback-icon.ts
@@ -9,6 +9,16 @@ import type { CSSProperties } from 'react'
  * art on every device with no network calls and no stored data. It is four
  * stacked CSS gradients on the node that already exists: no filters, no blur,
  * no animation.
+ *
+ * Two deliberate departures from the design canvas, both because CSS
+ * `transparent` means `rgba(0, 0, 0, 0)` rather than "this colour at zero
+ * alpha", so fading to it desaturates towards black:
+ *
+ * 1. Every layer fades to a zero-alpha copy of its own colour. Fading to
+ *    `transparent` muddied the midpoints.
+ * 2. The conic veil starts and ends at zero alpha so it closes on itself.
+ *    Starting opaque and ending at `transparent` left a hard step at the start
+ *    angle — a crisp line running from the centre outwards on every icon.
  */
 
 const FNV_OFFSET_BASIS = 0x811c9dc5
@@ -71,9 +81,9 @@ function auroraBackground({ address, chainId }: TokenFallbackIconSeed): string {
   // Every `randomInt` call advances one shared sequence, so the art only stays
   // reproducible while these layers are built in this order.
   return [
-    `radial-gradient(120% 90% at ${randomInt(0, 100)}% ${randomInt(-20, 40)}%, hsl(${lead} 96% 78% / 0.85), transparent 65%)`,
-    `radial-gradient(110% 80% at ${randomInt(0, 100)}% ${randomInt(60, 120)}%, hsl(${trail} 92% 62% / 0.9), transparent 68%)`,
-    `conic-gradient(from ${randomInt(0, 359)}deg at 50% 50%, hsl(${lead} 80% 46% / 0.55), transparent 40%, hsl(${trail} 80% 52% / 0.5) 75%, transparent)`,
+    `radial-gradient(120% 90% at ${randomInt(0, 100)}% ${randomInt(-20, 40)}%, hsl(${lead} 96% 78% / 0.85), hsl(${lead} 96% 78% / 0) 65%)`,
+    `radial-gradient(110% 80% at ${randomInt(0, 100)}% ${randomInt(60, 120)}%, hsl(${trail} 92% 62% / 0.9), hsl(${trail} 92% 62% / 0) 68%)`,
+    `conic-gradient(from ${randomInt(0, 359)}deg at 50% 50%, hsl(${lead} 80% 46% / 0), hsl(${lead} 80% 46% / 0.55) 14%, hsl(${lead} 80% 46% / 0) 40%, hsl(${trail} 80% 52% / 0.5) 75%, hsl(${trail} 80% 52% / 0) 100%)`,
     `linear-gradient(${randomInt(0, 359)}deg, hsl(${trail} 74% 30%), hsl(${lead} 78% 46%))`,
   ].join(',')
 }


### PR DESCRIPTION
Implements the Aurora variant from the [Token Fallback Icons](https://claude.ai/design/p/af9c2a4e-7a2a-45fd-b9b8-22a5bd30d329?file=Token+Fallback+Icons.dc.html) design.

## Before

Tokens whose logo can't be resolved get a flat `hsl(H, 65%, 45%)` fill from a djb2 hash of the address, plus a monogram that inherits whatever font size the surrounding context happens to set — so it doesn't scale with the icon.

## After

Two radial sweeps and a conic veil over a two-hue base. Every value — the hue pair, both sweep positions, the conic start angle, the base angle — is derived from a 32-bit FNV-1a hash of `` `${chainId}:${address}` ``, so a token renders the same art on every device with no network calls and no stored data.

The art lands on the `AvatarFallback` node that already exists, so this adds no DOM and no runtime cost beyond one hash per unresolved icon: no filters, no blur, no animation.

## Scope

`Currency.Icon` is the single fallback path for token icons app-wide (119 call sites), so this covers the launchpad feed as well — `TokenAvatar` delegates to it.

The Aptos currency icon carried a duplicate of the old idea: its own djb2 hash to a hex fill, with two-char initials. It now shares the same helpers, which also drops it to a one-char monogram to match.

## Verification

- **Design fidelity** — ran the design canvas's original `fnv` / `rng` / `ri` / Aurora `build` side by side with the ported module over 3,200 tokens across 8 chains. Every generated `background` string matches character-for-character; 3,200 distinct backgrounds, 0 collisions. Address case-insensitivity confirmed.
- **Visual** — rendered the real module into a static page and screenshotted it headless at 20 / 26 / 30 / 32 / 44 / 56 / 76 / 80 / 96px, plus a 120-icon feed standing in for a launchpad page with nothing resolved. Holds up at list size and in a wall of fallbacks.
- `turbo run check --filter=@sushiswap/ui` clean, `biome check .` and `biome format .` clean repo-wide. `turbo run check --filter=web` shows only the pre-existing `TS2307`s for the private TradingView charting library, which isn't fetched in my environment.

## Deliberately out of scope

- **The launchpad OG/social card** (`launchpad-embed.tsx` → `TokenLogo`) keeps its fixed purple gradient. Satori can render neither conic gradients nor layered backgrounds, so a faithful Aurora isn't possible there. A matching *base layer* is feasible, but needs an `address` prop threaded through the exported embed component and the `card.png` route — happy to do it in a follow-up if we want the two surfaces to agree.
- **Perps `UnknownTokenIcon`** is a deliberate "unknown asset" glyph rather than a per-token identity, so it's a different concept and untouched.

## Note for review

`packages/ui` has no test runner, so nothing locks in the determinism guarantee. The layer order in `auroraBackground` is load-bearing — each `randomInt` call advances one shared sequence, so reordering the layers silently changes every token's art. There's a comment saying so, but a test would be better; adding vitest to `packages/ui` felt like infra scope for this PR.
