### PR TITLE
refactor(launchpad): remove token positions field

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.ts
@@ -2,7 +2,6 @@ import type { LaunchpadProvider } from '@sushiswap/graph-client/data-api'
 
 interface LaunchpadProviderCapabilities {
   creatorProfile: boolean
-  lockedPositions: boolean
   manage: boolean
   metadata: boolean
 }
@@ -18,7 +17,6 @@ export const LAUNCHPAD_PROVIDER_CONFIG = {
     label: 'Sushi',
     capabilities: {
       creatorProfile: true,
-      lockedPositions: true,
       manage: true,
       metadata: true,
     },
@@ -28,7 +26,6 @@ export const LAUNCHPAD_PROVIDER_CONFIG = {
     websiteUrl: 'https://pools.fun',
     capabilities: {
       creatorProfile: false,
-      lockedPositions: false,
       manage: false,
       metadata: false,
     },

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.test.ts
@@ -35,7 +35,6 @@ const token: LaunchpadToken = {
       decimals: 6,
     },
   },
-  positions: [],
   metadata: {
     description: 'A test launchpad token.',
     links: [

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/manage/[address]/_ui/manage-token-page.tsx
@@ -590,7 +590,6 @@ export function ManageTokenPage({
                 ],
                 ['Decimals', `${token.decimals}`],
                 ['Pool tier', `${token.pool.feeTier / 10_000}%`],
-                ['Positions', `${token.positions.length}`],
               ].map(([label, value]) => ({ label, value }))}
             />
           </PerpsCard>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
@@ -50,7 +50,6 @@ import {
   liquidityChange24hUsd,
   shortenAddress,
 } from '../../../_lib/format'
-import { launchpadProviderHasCapability } from '../../../_lib/launchpad-provider'
 import { useLaunchpadToken } from '../../../_lib/use-launchpad-token'
 import { DetailList } from '../../../_ui/detail-list'
 import {
@@ -456,12 +455,6 @@ function TokenDetailPageContent({
         },
       ]
     : null
-  const supportsLockedPositions = token
-    ? launchpadProviderHasCapability(token.provider, 'lockedPositions')
-    : false
-  const showLockedPositions =
-    supportsLockedPositions && (token?.positions.length ?? 0) > 0
-
   return (
     <Container
       maxWidth="8xl"
@@ -609,57 +602,9 @@ function TokenDetailPageContent({
                     ],
                     ['Pool fee', `${token.pool.feeTier / 10_000}%`],
                     ['Starting FDV', formatUsd(Number(token.initialFdvUsd))],
-                    ...(supportsLockedPositions
-                      ? [['Liquidity', 'Single maximum-bound position']]
-                      : []),
                   ].map(([label, value]) => ({ label, value }))}
                 />
               </PerpsCard>
-
-              {showLockedPositions ? (
-                <PerpsCard className="overflow-hidden" fullWidth>
-                  <div className="flex items-center gap-2 border-b border-white/[0.06] p-5">
-                    <h2 className="font-semibold text-perps-muted">
-                      Locked positions
-                    </h2>
-                  </div>
-                  <div className="divide-y divide-white/[0.06]">
-                    {token.positions.map((position) => (
-                      <div key={position.positionIndex} className="p-4 text-sm">
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="font-medium text-perps-muted">
-                            Position #{position.positionId}
-                          </span>
-                        </div>
-                        <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 text-xs">
-                          <div>
-                            <div className="text-perps-muted-50">
-                              Tick range
-                            </div>
-                            <div className="mt-1 text-perps-muted">
-                              {position.tickLower.toLocaleString()} →{' '}
-                              {position.tickUpper.toLocaleString()}
-                            </div>
-                          </div>
-                          <div>
-                            <div className="text-perps-muted-50">
-                              Allocation
-                            </div>
-                            <div className="mt-1 truncate text-perps-muted">
-                              {formatRawAmount(
-                                position.desiredAmount,
-                                token.decimals,
-                                0,
-                              )}{' '}
-                              {token.symbol}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </PerpsCard>
-              ) : null}
             </>
           ) : (
             <TokenSidebarSkeleton />

--- a/packages/graph-client/src/subgraphs/data-api/queries/launchpad/token-fragment.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/launchpad/token-fragment.ts
@@ -26,15 +26,6 @@ export const LaunchpadTokenFragment = graphql(`
         decimals
       }
     }
-    positions {
-      positionIndex
-      positionId
-      tickLower
-      tickUpper
-      desiredAmount
-      usedAmount
-      liquidity
-    }
     metadata {
       description
       links {
@@ -75,7 +66,6 @@ export const LaunchpadTokenFragment = graphql(`
 export type LaunchpadToken = ResultOf<typeof LaunchpadTokenFragment>
 export type LaunchpadIndexingStatus = LaunchpadToken['indexingStatus']
 export type LaunchpadProvider = LaunchpadToken['provider']
-export type LaunchpadPosition = LaunchpadToken['positions'][number]
 export type LaunchpadMetadata = LaunchpadToken['metadata']
 export type LaunchpadMetadataLink = LaunchpadMetadata['links'][number]
 export type LaunchpadMetrics = NonNullable<LaunchpadToken['metrics']>

--- a/packages/graph-client/src/subgraphs/data-api/schema.graphql
+++ b/packages/graph-client/src/subgraphs/data-api/schema.graphql
@@ -333,7 +333,6 @@ interface LaunchpadToken {
   initialFdvUsd: BigInt!
   indexingStatus: LaunchpadIndexingStatus!
   pool: LaunchpadPool!
-  positions: [LaunchpadPosition!]! @deprecated(reason: "V2 and Pools.fun do not expose protocol-owned LP positions; this field will be removed with the V1 cleanup")
   metadata: LaunchpadMetadata!
   metrics: LaunchpadMetrics
   creationTransactionHash: Bytes!
@@ -354,7 +353,6 @@ type SushiV1LaunchpadToken implements LaunchpadToken {
   initialFdvUsd: BigInt!
   indexingStatus: LaunchpadIndexingStatus!
   pool: LaunchpadPool!
-  positions: [LaunchpadPosition!]! @deprecated(reason: "This field will be removed with the V1 cleanup")
   metadata: LaunchpadMetadata!
   metrics: LaunchpadMetrics
   creationTransactionHash: Bytes!
@@ -376,7 +374,6 @@ type PoolsFunV1LaunchpadToken implements LaunchpadToken {
   initialFdvUsd: BigInt!
   indexingStatus: LaunchpadIndexingStatus!
   pool: LaunchpadPool!
-  positions: [LaunchpadPosition!]! @deprecated(reason: "Pools.fun positions are not tracked; this field will be removed with the V1 cleanup")
   metadata: LaunchpadMetadata!
   metrics: LaunchpadMetrics
   creationTransactionHash: Bytes!
@@ -392,16 +389,6 @@ type LaunchpadPool {
 type LaunchpadFeeSplit {
   sushiFeeBps: Int!
   creatorFeeBps: Int!
-}
-
-type LaunchpadPosition {
-  positionIndex: Int!
-  positionId: BigInt!
-  tickLower: Int!
-  tickUpper: Int!
-  desiredAmount: BigInt!
-  usedAmount: BigInt!
-  liquidity: BigInt!
 }
 
 type LaunchpadMetadata {


### PR DESCRIPTION
## Summary

- stop selecting launchpad token positions in the shared GraphQL fragment
- remove locked-position UI and provider capability handling
- remove the deprecated client schema field and orphaned position type
- update launchpad fixtures and management details

## Validation

- `pnpm exec biome check` on all changed TypeScript files
- `pnpm --filter @sushiswap/graph-client build:types`
- `git diff --check`

Full web type-check is currently blocked by existing workspace dependency/generated-output drift, including SUSHI_V2 provider types and unrelated currency errors.