### PR TITLE
refactor: prepare for tailwind-merge (zero rendering change)

### DIFF
--- a/apps/web/src/app/(cms)/academy/explore/components/difficulty-filter-dropdown/difficulty-filter-dropdown-client.tsx
+++ b/apps/web/src/app/(cms)/academy/explore/components/difficulty-filter-dropdown/difficulty-filter-dropdown-client.tsx
@@ -82,7 +82,6 @@ export function DifficultyFilterDropdownClient({
                 key={difficulty.slug}
                 value={difficulty.name}
                 title={difficulty.name}
-                className="px-4 text-base"
               >
                 {difficulty.name}
               </SelectItem>

--- a/apps/web/src/app/(cms)/faq/[category-slug]/[answer-group-slug]/[answer-slug]/loading.tsx
+++ b/apps/web/src/app/(cms)/faq/[category-slug]/[answer-group-slug]/[answer-slug]/loading.tsx
@@ -3,35 +3,35 @@ import { SkeletonText } from '@sushiswap/ui'
 export default function AnswerLoading() {
   return (
     <div className="prose dark:!prose-invert prose-slate space-y-3 w-full">
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
       <div className="h-2" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
       <div className="h-2" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
-      <SkeletonText className="h-[18px]" />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
+      <SkeletonText />
     </div>
   )
 }

--- a/apps/web/src/app/(landing)/components/search.tsx
+++ b/apps/web/src/app/(landing)/components/search.tsx
@@ -98,8 +98,8 @@
 //             <SkeletonCircle radius={36} />
 //           </div>
 //           <div className="flex flex-col gap-1 w-full">
-//             <SkeletonText fontSize="sm" className="w-[120px]" />
-//             <SkeletonText fontSize="xs" className="w-[60px]" />
+//             <SkeletonText fontSize="sm" />
+//             <SkeletonText fontSize="xs" />
 //           </div>
 //         </div>
 //       </div>
@@ -133,7 +133,7 @@
 //                   width={24}
 //                   height={24}
 //                   className="text-neutral-500"
-//                 />
+// />
 //               </div>
 //               <input
 //                 value={query}
@@ -145,7 +145,7 @@
 //                 )}
 //                 autoComplete="new-password"
 //                 autoCorrect="off"
-//               />
+// />
 //             </div>
 //             <p
 //               onClick={() => setSelectNetwork((prev) => !prev)}
@@ -176,7 +176,7 @@
 //                       setSelectNetwork(false)
 //                       setChainId(el)
 //                     }}
-//                   />
+// />
 //                 ))}
 //               </>
 //             ) : query.length > 2 ? (
@@ -197,7 +197,7 @@
 //                         decimals: web3Token.decimals,
 //                       })
 //                     }
-//                   />
+// />
 //                 ) : query.length > 2 && query !== debouncedQuery ? (
 //                   skeleton
 //                 ) : filteredTokens ? (
@@ -215,7 +215,7 @@
 //                               decimals,
 //                             })
 //                           }
-//                         />
+// />
 //                       ),
 //                     )}
 //                   </>
@@ -261,7 +261,7 @@
 //             currency={currency}
 //             width={36}
 //             height={36}
-//           />
+// />
 //         )}
 //       </div>
 //       <div className="flex flex-col">

--- a/apps/web/src/app/(landing)/components/stats.tsx
+++ b/apps/web/src/app/(landing)/components/stats.tsx
@@ -21,7 +21,7 @@ export const Stats: FC = () => {
                   {data?.stats?.price.formatted}
                 </span>
               ) : (
-                <SkeletonText fontSize="3xl" className="w-[120px]" />
+                <SkeletonText fontSize="3xl" />
               )}
               <span className="text-xs font-medium uppercase text-neutral-400 -mt-0.5">
                 Price
@@ -35,7 +35,7 @@ export const Stats: FC = () => {
                   {data?.stats?.liquidity.formatted}
                 </span>
               ) : (
-                <SkeletonText fontSize="3xl" className="w-[120px]" />
+                <SkeletonText fontSize="3xl" />
               )}
               <span className="text-xs font-medium uppercase text-neutral-400 -mt-0.5">
                 Total Liquidity
@@ -49,7 +49,7 @@ export const Stats: FC = () => {
                   {data?.stats?.volume.formatted}
                 </span>
               ) : (
-                <SkeletonText fontSize="3xl" className="w-[120px]" />
+                <SkeletonText fontSize="3xl" />
               )}
               <span className="text-xs font-medium uppercase text-neutral-400 -mt-0.5">
                 Total Volume
@@ -63,7 +63,7 @@ export const Stats: FC = () => {
                   {data?.stats?.pairs.formatted}
                 </span>
               ) : (
-                <SkeletonText fontSize="3xl" className="w-[120px]" />
+                <SkeletonText fontSize="3xl" />
               )}
               <span className="text-xs font-medium uppercase text-neutral-400 -mt-0.5">
                 Total Pairs

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(blade-pool)/pool/blade/[address]/(manage)/_ui/manage-blade-liquidity-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(blade-pool)/pool/blade/[address]/(manage)/_ui/manage-blade-liquidity-card.tsx
@@ -40,13 +40,9 @@ export const ManageBladeLiquidityCard: FC<ManageBladeLiquidityCardProps> = ({
           <TabsList className="!flex">
             <Link
               href={`/${getEvmChainById(pool.chainId).key}/pool/blade/${pool.address}/add`}
-              className="flex flex-1"
+              className="flex-1"
             >
-              <TabsTrigger
-                testdata-id="add-tab"
-                value="add"
-                className="flex flex-1"
-              >
+              <TabsTrigger testdata-id="add-tab" value="add" className="flex-1">
                 Add
               </TabsTrigger>
             </Link>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(positions)/migrate/_ui/position-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(positions)/migrate/_ui/position-card.tsx
@@ -21,21 +21,18 @@ interface PositionCard {
 export const PositionCardSkeleton = () => {
   return (
     <div className="relative bg-white dark:bg-slate-800 hover:shadow-md transition-all rounded-2xl p-7 overflow-hidden w-[320px]">
-      <SkeletonText fontSize="xs" className="w-[40px]" />
-      <SkeletonText fontSize="2xl" className="w-[160px]" />
+      <SkeletonText fontSize="xs" />
+      <SkeletonText fontSize="2xl" />
       <div className="flex flex-col gap-2 items-center py-7">
         <div className="inline-flex">
           <SkeletonCircle radius={56} />
           <SkeletonCircle radius={56} style={{ marginLeft: -48 / 3 }} />
         </div>
       </div>
-      <SkeletonText fontSize="sm" className="w-[100px]" />
-      <SkeletonText fontSize="sm" className="w-[40px]" />
+      <SkeletonText fontSize="sm" />
+      <SkeletonText fontSize="sm" />
       <div className="absolute bottom-7 right-7">
-        <SkeletonText
-          fontSize="2xl"
-          className="w-[80px] !h-[32px] !rounded-full"
-        />
+        <SkeletonText fontSize="2xl" className="!h-[32px] !rounded-full" />
       </div>
     </div>
   )

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/lifi/trade-review-dialog/trade-details.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/lifi/trade-review-dialog/trade-details.tsx
@@ -94,7 +94,7 @@ function TradeSummaryList<
       <List.Control>
         <List.KeyValue title="Estimated arrival">
           {!executionDuration ? (
-            <SkeletonText align="right" fontSize="sm" className="w-1/5" />
+            <SkeletonText align="right" fontSize="sm" />
           ) : (
             `${executionDuration}`
           )}
@@ -204,7 +204,7 @@ function TradeSummaryList<
             >
               <div className="flex flex-col gap-0.5">
                 {!step?.amountOut ? (
-                  <SkeletonText align="right" fontSize="sm" className="w-1/2" />
+                  <SkeletonText align="right" fontSize="sm" />
                 ) : (
                   <span className="text-sm font-medium">{`${step.amountOut.toSignificant(
                     6,
@@ -232,7 +232,7 @@ function TradeSummaryList<
             >
               <div className="flex flex-col gap-0.5">
                 {!step?.amountOutMin ? (
-                  <SkeletonText align="right" fontSize="sm" className="w-1/2" />
+                  <SkeletonText align="right" fontSize="sm" />
                 ) : (
                   <span className="text-sm font-medium">{`${step.amountOutMin.toSignificant(
                     6,
@@ -259,7 +259,7 @@ function TradeSummaryList<
           <>
             <List.KeyValue title="Total fee">
               {!totalFeesUSD || !feesBreakdown || chainId0Fees === undefined ? (
-                <SkeletonText align="right" fontSize="sm" className="w-1/5" />
+                <SkeletonText align="right" fontSize="sm" />
               ) : (
                 <div className="flex flex-col gap-1">
                   <span>
@@ -278,7 +278,7 @@ function TradeSummaryList<
             >
               <div className="flex flex-col gap-0.5">
                 {!step?.amountOut ? (
-                  <SkeletonText align="right" fontSize="sm" className="w-1/2" />
+                  <SkeletonText align="right" fontSize="sm" />
                 ) : (
                   <span className="text-sm font-medium">{`${step.amountOut.toSignificant(
                     6,

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/lifi/trade-review-dialog/trade-header.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/lifi/trade-review-dialog/trade-header.tsx
@@ -26,7 +26,7 @@ export function TradeHeader<
     <DialogHeader className="!text-left">
       <DialogTitle>
         {!step?.amountOut ? (
-          <SkeletonText fontSize="xs" className="w-2/3" />
+          <SkeletonText fontSize="xs" />
         ) : (
           `Receive ${step.amountOut.toSignificant(6)} ${token1?.symbol}`
         )}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/near-intents/trade-review-dialog.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/cross-chain-swap/_ui/near-intents/trade-review-dialog.tsx
@@ -232,7 +232,7 @@ function NearIntentsTradeReviewDialogContent({
               <DialogHeader className="!text-left">
                 <DialogTitle>
                   {!outputAmount ? (
-                    <SkeletonText fontSize="xs" className="w-2/3" />
+                    <SkeletonText fontSize="xs" />
                   ) : (
                     `Receive ${outputAmount.toSignificant(6)} ${token1?.symbol}`
                   )}
@@ -353,7 +353,7 @@ function NearIntentsTradeDetails({
         <List.Control>
           <List.KeyValue title="Estimated arrival">
             {!executionDuration ? (
-              <SkeletonText align="right" fontSize="sm" className="w-1/5" />
+              <SkeletonText align="right" fontSize="sm" />
             ) : (
               executionDuration
             )}
@@ -367,7 +367,7 @@ function NearIntentsTradeDetails({
                 {networkFeeAmountUsd === undefined ||
                 !networkFeeAmount ||
                 !networkFeeSymbol ? (
-                  <SkeletonText align="right" fontSize="sm" className="w-1/5" />
+                  <SkeletonText align="right" fontSize="sm" />
                 ) : (
                   <FeeWithUsd
                     amount={networkFeeAmount}
@@ -381,7 +381,7 @@ function NearIntentsTradeDetails({
                 subtitle="The fee charged by Sushi."
               >
                 {feeUsd === undefined || !feeTokenAmount || !swapAmount ? (
-                  <SkeletonText align="right" fontSize="sm" className="w-1/5" />
+                  <SkeletonText align="right" fontSize="sm" />
                 ) : (
                   <FeeWithUsd
                     amount={feeTokenAmount}
@@ -412,7 +412,7 @@ function NearIntentsTradeDetails({
                 {totalFeeUsd === undefined ||
                 !networkFeeAmount ||
                 !networkFeeSymbol ? (
-                  <SkeletonText align="right" fontSize="sm" className="w-1/5" />
+                  <SkeletonText align="right" fontSize="sm" />
                 ) : (
                   <FeeWithUsd
                     amount={networkFeeAmount}
@@ -578,7 +578,7 @@ function AmountWithUsd({
   return (
     <div className="flex flex-col gap-0.5">
       {!amount ? (
-        <SkeletonText align="right" fontSize="sm" className="w-1/2" />
+        <SkeletonText align="right" fontSize="sm" />
       ) : (
         <span className="text-sm font-medium">{`${amount.toSignificant(6)} ${amount.currency.symbol}`}</span>
       )}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-trade-review-dialog/trade-details.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/(trade)/swap/_ui/simple-swap-trade-review-dialog/trade-details.tsx
@@ -97,7 +97,7 @@ export function TradeDetails<TChainId extends SupportedChainId>({
               subtitle="The maximum amount you are guaranteed to receive."
             >
               {isSwapQueryFetching ? (
-                <SkeletonText align="right" fontSize="sm" className="w-1/2" />
+                <SkeletonText align="right" fontSize="sm" />
               ) : trade?.amountOut ? (
                 `${trade?.amountOut?.toSignificant(6)} ${token1Symbol}`
               ) : (
@@ -109,7 +109,7 @@ export function TradeDetails<TChainId extends SupportedChainId>({
               subtitle="The minimum amount you are guaranteed to receive."
             >
               {isSwapQueryFetching ? (
-                <SkeletonText align="right" fontSize="sm" className="w-1/2" />
+                <SkeletonText align="right" fontSize="sm" />
               ) : trade?.minAmountOut ? (
                 `${trade?.minAmountOut?.toSignificant(6)} ${token1Symbol}`
               ) : (
@@ -124,7 +124,7 @@ export function TradeDetails<TChainId extends SupportedChainId>({
           ) : isSwapQueryFetching ||
             !trade?.gasSpent ||
             trade.gasSpent === '0' ? (
-            <SkeletonText align="right" fontSize="sm" className="w-1/3" />
+            <SkeletonText align="right" fontSize="sm" />
           ) : (
             `${trade.gasSpent} ${nativeSymbol}`
           )}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/loading.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/(discover)/loading.tsx
@@ -61,7 +61,7 @@ export default function LaunchpadLoading() {
               />
             ))}
             <div className="flex items-center gap-3 border-l border-t border-white/[0.06] px-5 py-4 lg:border-t-0">
-              <SkeletonBox className="hidden h-9 w-9 shrink-0 rounded-full sm:block" />
+              <SkeletonBox className="hidden h-9 w-9 shrink-0 sm:block" />
               <div>
                 <SkeletonBox className="h-[16.5px] w-[86px] rounded-sm" />
                 <SkeletonBox className="mt-1 h-5 w-[42px] rounded-sm" />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/create/_ui/create-launch-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/create/_ui/create-launch-skeleton.tsx
@@ -105,7 +105,7 @@ export function CreateLaunchSkeleton() {
               key={step}
               className="flex min-h-11 items-center justify-center gap-2 rounded-xl px-2"
             >
-              <SkeletonBox className="h-5 w-5 shrink-0 rounded-full" />
+              <SkeletonBox className="h-5 w-5 shrink-0" />
               <SkeletonBox className="hidden h-4 w-20 rounded-sm sm:block" />
             </div>
           ))}

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/portfolio/_ui/portfolio-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/portfolio/_ui/portfolio-skeleton.tsx
@@ -56,7 +56,7 @@ export function HoldingsTableSkeleton() {
               >
                 <td className="h-[84px] px-5">
                   <div className="flex items-center gap-3">
-                    <SkeletonBox className="h-11 w-11 shrink-0 rounded-full" />
+                    <SkeletonBox className="h-11 w-11 shrink-0" />
                     <div className="min-w-0 flex-1">
                       <SkeletonBox className="h-4 w-32 rounded-md" />
                       <SkeletonBox className="mt-2 h-3 w-44 rounded-sm" />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-page.tsx
@@ -296,7 +296,7 @@ function TokenHeader({
               {indexingStatus ? (
                 <StatusPill status={indexingStatus} />
               ) : (
-                <SkeletonBox className="h-6 w-12 rounded-full" />
+                <SkeletonBox className="h-6 w-12" />
               )}
               <LaunchpadProviderBadge provider={token.provider} />
             </div>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/token-detail-skeleton.tsx
@@ -87,13 +87,13 @@ export function TokenSidebarSkeleton() {
             <SkeletonBox className="h-9 w-9 rounded-lg" />
           </div>
           <SkeletonBox className="mt-5 h-12 w-full rounded-xl" />
-          <SkeletonBox className="mt-5 h-[136px] w-full rounded-2xl" />
+          <SkeletonBox className="mt-5 h-[136px] w-full" />
           <div className="my-3 grid grid-cols-4 gap-2">
             {['first', 'second', 'third', 'fourth'].map((preset) => (
               <SkeletonBox key={preset} className="h-7 w-full rounded-lg" />
             ))}
           </div>
-          <SkeletonBox className="h-[108px] w-full rounded-2xl" />
+          <SkeletonBox className="h-[108px] w-full" />
           <SkeletonBox className="mt-4 h-12 w-full rounded-xl" />
         </PerpsCard>
       </div>
@@ -180,13 +180,13 @@ export function TokenDetailSkeleton() {
 
       <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex min-w-0 items-center gap-4">
-          <SkeletonBox className="h-14 w-14 shrink-0 rounded-full" />
+          <SkeletonBox className="h-14 w-14 shrink-0" />
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2.5">
               <SkeletonBox className="h-8 w-36 rounded-lg sm:h-9 sm:w-52" />
               <SkeletonBox className="h-7 w-12 rounded-md" />
-              <SkeletonBox className="h-6 w-12 rounded-full" />
-              <SkeletonBox className="h-7 w-20 rounded-full" />
+              <SkeletonBox className="h-6 w-12" />
+              <SkeletonBox className="h-7 w-20" />
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-3">
               <SkeletonBox className="h-4 w-32 rounded-sm" />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/trade-activity.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/token/[address]/_ui/trade-activity.tsx
@@ -135,7 +135,7 @@ export function TradeActivitySkeleton() {
             <SkeletonBox className="ml-auto h-2.5 w-16 rounded-sm" />
           </div>
         </div>
-        <SkeletonBox className="mt-3 h-2 w-full rounded-full" />
+        <SkeletonBox className="mt-3 h-2 w-full" />
         <div className="mt-3 flex items-start justify-between gap-4">
           <div className="space-y-1.5">
             <SkeletonBox className="h-4 w-16 rounded-sm" />

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v2/[address]/(manage)/_common/ui/manage-v2-liquidity-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v2/[address]/(manage)/_common/ui/manage-v2-liquidity-card.tsx
@@ -51,13 +51,9 @@ export const ManageV2LiquidityCard: FC<ManageV2LiquidityCardProps> = ({
           <TabsList className="!flex">
             <Link
               href={`/${getEvmChainById(pool.chainId).key}/pool/v2/${pool.address}/add`}
-              className="flex flex-1"
+              className="flex-1"
             >
-              <TabsTrigger
-                testdata-id="add-tab"
-                value="add"
-                className="flex flex-1"
-              >
+              <TabsTrigger testdata-id="add-tab" value="add" className="flex-1">
                 Add
               </TabsTrigger>
             </Link>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v2/[address]/(manage)/_common/ui/pool-position.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v2/[address]/(manage)/_common/ui/pool-position.tsx
@@ -38,11 +38,7 @@ const PoolPositionConnected = () => {
       <CardHeader>
         <CardTitle>My Position</CardTitle>
         <CardDescription>
-          {isLoading ? (
-            <SkeletonText className="w-[ch-16]" />
-          ) : (
-            <>{formatUSD(value0 + value1)}</>
-          )}
+          {isLoading ? <SkeletonText /> : <>{formatUSD(value0 + value1)}</>}
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/pool-reward-distributions-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(landing)/_ui/pool-reward-distributions-card.tsx
@@ -97,10 +97,10 @@ const MerklPoolRewardDistributionsCard: FC<
       <Tabs className="w-full" defaultValue="active">
         <CardContent>
           <TabsList className="!flex">
-            <TabsTrigger value="active" className="flex flex-1">
+            <TabsTrigger value="active" className="flex-1">
               Active
             </TabsTrigger>
-            <TabsTrigger value="inactive" className="flex flex-1">
+            <TabsTrigger value="inactive" className="flex-1">
               Upcoming & Expired
             </TabsTrigger>
           </TabsList>

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/[position]/_common/ui/v3-position-view.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/pool/v3/[address]/(manage)/[position]/_common/ui/v3-position-view.tsx
@@ -236,21 +236,21 @@ const Component: FC<{
                     <TabsTrigger
                       testdata-id="add-tab"
                       value="add"
-                      className="flex flex-1"
+                      className="flex-1"
                     >
                       Add
                     </TabsTrigger>
                     <TabsTrigger
                       testdata-id="remove-tab"
                       value="remove"
-                      className="flex flex-1"
+                      className="flex-1"
                     >
                       Remove
                     </TabsTrigger>
                     <TabsTrigger
                       testdata-id="fees-tab"
                       value="fees"
-                      className="flex flex-1"
+                      className="flex-1"
                     >
                       Fees
                     </TabsTrigger>
@@ -258,7 +258,7 @@ const Component: FC<{
                       <TabsTrigger
                         testdata-id="rewards-tab"
                         value="rewards"
-                        className="flex flex-1"
+                        className="flex-1"
                       >
                         Rewards
                       </TabsTrigger>
@@ -702,10 +702,10 @@ const Component: FC<{
               <Tabs className="w-full" defaultValue="active">
                 <CardContent>
                   <TabsList className="!flex">
-                    <TabsTrigger value="active" className="flex flex-1">
+                    <TabsTrigger value="active" className="flex-1">
                       Active
                     </TabsTrigger>
-                    <TabsTrigger value="inactive" className="flex flex-1">
+                    <TabsTrigger value="inactive" className="flex-1">
                       Upcoming & Expired
                     </TabsTrigger>
                   </TabsList>

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-tabs.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/asset-tabs.tsx
@@ -87,7 +87,7 @@ export const AssetTabs = () => {
           <TabsTrigger
             key={tab.value}
             value={tab.value}
-            className="flex w-fit !px-1.5 !text-xs capitalize !bg-transparent !border-transparent"
+            className="w-fit !px-1.5 !text-xs capitalize !bg-transparent !border-transparent"
           >
             {<span className="mr-1">{tab.icon}</span>}
             {tab.value}

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/hip-3-assets.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/hip-3-assets.tsx
@@ -127,7 +127,7 @@ export const HIP3Assets = () => {
           <TabsTrigger
             key={tab}
             value={tab}
-            className="flex flex-1 !px-1.5 !max-w-fit !text-xs !bg-transparent !border-transparent"
+            className="flex-1 !px-1.5 !max-w-fit !text-xs !bg-transparent !border-transparent"
           >
             {tab}
             {idx !== TABS.length - 1 ? (

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/spot-assets.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/spot-assets.tsx
@@ -141,7 +141,7 @@ export const SpotAssets = () => {
           <TabsTrigger
             key={tab}
             value={tab}
-            className="flex flex-1 !px-1.5 !max-w-fit !text-xs capitalize !bg-transparent !border-transparent"
+            className="flex-1 !px-1.5 !max-w-fit !text-xs capitalize !bg-transparent !border-transparent"
           >
             {tab}
             {idx !== TABS.length - 1 ? (

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/tradfi-assets.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/asset-selector/tradfi-assets.tsx
@@ -148,7 +148,7 @@ export const TradfiAssets = () => {
           <TabsTrigger
             key={tab}
             value={tab}
-            className="flex flex-1 !px-1.5 !max-w-fit !text-xs capitalize !bg-transparent !border-transparent"
+            className="flex-1 !px-1.5 !max-w-fit !text-xs capitalize !bg-transparent !border-transparent"
           >
             {tab}
             {idx !== TABS.length - 1 ? (

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/order-book-trades-tabbed-view.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/order-book-trades-tabbed-view.tsx
@@ -40,7 +40,7 @@ export const OrderBookTradesTabbedView = () => {
           <TabsList className="!flex !bg-transparent border-0 gap-2 !pt-0 !h-8">
             <TabsTrigger
               value="order-book"
-              className="flex flex-1 !bg-transparent border-0"
+              className="flex-1 !bg-transparent border-0"
               asChild
             >
               <button
@@ -55,7 +55,7 @@ export const OrderBookTradesTabbedView = () => {
             </TabsTrigger>
             <TabsTrigger
               value="trades"
-              className="flex flex-1 !bg-transparent border-0"
+              className="flex-1 !bg-transparent border-0"
               asChild
             >
               <button

--- a/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-tables/_common/mobile-card-skeleton.tsx
+++ b/apps/web/src/app/(networks)/(evm)/perps/_ui/trade-tables/_common/mobile-card-skeleton.tsx
@@ -16,8 +16,8 @@ export const MobileCardSkeleton = () => {
                 key={index}
                 className="flex flex-col gap-1 col-span-1 max-w-[100px]"
               >
-                <SkeletonText className="w-16 h-3" />
-                <SkeletonText className="w-24 h-4" />
+                <SkeletonText />
+                <SkeletonText />
               </div>
             )
           })}

--- a/apps/web/src/app/(networks)/(evm)/stake/_ui/bar-header.tsx
+++ b/apps/web/src/app/(networks)/(evm)/stake/_ui/bar-header.tsx
@@ -38,7 +38,7 @@ export const BarHeader = () => {
             APY (1m)
           </span>
           {isLoading ? (
-            <SkeletonText className="w-12" fontSize="default" />
+            <SkeletonText fontSize="default" />
           ) : (
             <TooltipProvider>
               <Tooltip delayDuration={0}>

--- a/apps/web/src/app/(networks)/(evm)/stake/_ui/manage-bar-card.tsx
+++ b/apps/web/src/app/(networks)/(evm)/stake/_ui/manage-bar-card.tsx
@@ -37,14 +37,14 @@ export const ManageBarCard = () => {
             <TabsTrigger
               testdata-id="stake-tab"
               value="stake"
-              className="flex flex-1"
+              className="flex-1"
             >
               Stake
             </TabsTrigger>
             <TabsTrigger
               testdata-id="unstake-tab"
               value="unstake"
-              className="flex flex-1"
+              className="flex-1"
             >
               Unstake
             </TabsTrigger>

--- a/apps/web/src/app/(networks)/(non-evm)/aptos/_common/components/manage-v2-liquidity-card.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/aptos/_common/components/manage-v2-liquidity-card.tsx
@@ -109,17 +109,13 @@ export const ManageV2LiquidityCard: FC<{ address: string }> = ({ address }) => {
       <Tabs value={tab} onValueChange={setTab} className="w-full">
         <CardContent>
           <TabsList className="!flex">
-            <TabsTrigger
-              testdata-id="add-tab"
-              value="add"
-              className="flex flex-1"
-            >
+            <TabsTrigger testdata-id="add-tab" value="add" className="flex-1">
               Add
             </TabsTrigger>
             <TabsTrigger
               testdata-id="remove-tab"
               value="remove"
-              className="flex flex-1"
+              className="flex-1"
             >
               Remove
             </TabsTrigger>
@@ -127,7 +123,7 @@ export const ManageV2LiquidityCard: FC<{ address: string }> = ({ address }) => {
               <TabsTrigger
                 testdata-id="stake-tab"
                 value="stake"
-                className="flex flex-1"
+                className="flex-1"
               >
                 Stake
               </TabsTrigger>
@@ -136,7 +132,7 @@ export const ManageV2LiquidityCard: FC<{ address: string }> = ({ address }) => {
                 testdata-id="stake-tab"
                 disabled
                 value="stake"
-                className="flex flex-1"
+                className="flex-1"
               >
                 Stake
               </TabsTrigger>
@@ -145,7 +141,7 @@ export const ManageV2LiquidityCard: FC<{ address: string }> = ({ address }) => {
               <TabsTrigger
                 testdata-id="unstake-tab"
                 value="unstake"
-                className="flex flex-1"
+                className="flex-1"
               >
                 Unstake
               </TabsTrigger>
@@ -154,7 +150,7 @@ export const ManageV2LiquidityCard: FC<{ address: string }> = ({ address }) => {
                 testdata-id="unstake-tab"
                 disabled
                 value="unstake"
-                className="flex flex-1"
+                className="flex-1"
               >
                 Unstake
               </TabsTrigger>

--- a/apps/web/src/app/(networks)/(non-evm)/aptos/_common/ui/token-selector/token-selector.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/aptos/_common/ui/token-selector/token-selector.tsx
@@ -153,18 +153,14 @@ export default function TokenSelector({
                 <div className="flex flex-row items-center flex-grow gap-4">
                   <SkeletonCircle radius={40} />
                   <div className="flex flex-col items-start">
-                    <SkeletonText className="w-full w-[100px]" />
-                    <SkeletonText fontSize="sm" className="w-full w-[60px]" />
+                    <SkeletonText className="w-full" />
+                    <SkeletonText fontSize="sm" className="w-full" />
                   </div>
                 </div>
 
                 <div className="flex flex-col w-full">
-                  <SkeletonText className="w-[80px]" />
-                  <SkeletonText
-                    fontSize="sm"
-                    align="right"
-                    className="w-[40px]"
-                  />
+                  <SkeletonText />
+                  <SkeletonText fontSize="sm" align="right" />
                 </div>
               </div>
             </div>

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/pool-details/manage-liquidity-card.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/_common/ui/pool-details/manage-liquidity-card.tsx
@@ -410,10 +410,10 @@ export const ManageLiquidityCard: React.FC<ManageLiquidityCardProps> = ({
       <Tabs value={tab} onValueChange={setTab} className="w-full">
         <CardContent>
           <TabsList className="!flex">
-            <TabsTrigger value="add" className="flex flex-1">
+            <TabsTrigger value="add" className="flex-1">
               Add
             </TabsTrigger>
-            <TabsTrigger value="remove" className="flex flex-1">
+            <TabsTrigger value="remove" className="flex-1">
               Remove
             </TabsTrigger>
           </TabsList>

--- a/apps/web/src/app/(networks)/(non-evm)/stellar/explore/providers.tsx
+++ b/apps/web/src/app/(networks)/(non-evm)/stellar/explore/providers.tsx
@@ -15,10 +15,10 @@ function PoolsTableSkeleton() {
       <div className="p-4 space-y-3">
         {Array.from({ length: 5 }).map((_, i) => (
           <div key={i} className="flex gap-4">
-            <SkeletonText className="w-1/4" />
-            <SkeletonText className="w-1/6" />
-            <SkeletonText className="w-1/6" />
-            <SkeletonText className="w-1/6" />
+            <SkeletonText />
+            <SkeletonText />
+            <SkeletonText />
+            <SkeletonText />
           </div>
         ))}
       </div>

--- a/apps/web/src/app/portal/(authenticated)/dashboard/[teamId]/(dashboard)/_common/ui/team-monthly-usage-card.tsx
+++ b/apps/web/src/app/portal/(authenticated)/dashboard/[teamId]/(dashboard)/_common/ui/team-monthly-usage-card.tsx
@@ -33,7 +33,7 @@ function MonthlyUsageLoading() {
         </span>
       </div>
 
-      <SkeletonBox className="rounded-full h-[16px] w-full" />
+      <SkeletonBox className="h-[16px] w-full" />
     </>
   )
 }

--- a/apps/web/src/app/portal/(authenticated)/dashboard/[teamId]/settings/billing/_common/ui/team-balance/balance-top-up-dialog.tsx
+++ b/apps/web/src/app/portal/(authenticated)/dashboard/[teamId]/settings/billing/_common/ui/team-balance/balance-top-up-dialog.tsx
@@ -164,10 +164,10 @@ export function BalanceTopUpDialog({
           className="w-full space-y-4"
         >
           <TabsList className="!flex">
-            <TabsTrigger value="crypto" className="flex flex-1">
+            <TabsTrigger value="crypto" className="flex-1">
               Crypto
             </TabsTrigger>
-            <TabsTrigger value="voucher" className="flex flex-1">
+            <TabsTrigger value="voucher" className="flex-1">
               Voucher
             </TabsTrigger>
           </TabsList>

--- a/apps/web/src/app/portal/(authenticated)/dashboard/[teamId]/settings/billing/_common/ui/team-balance/crypto/crypto.tsx
+++ b/apps/web/src/app/portal/(authenticated)/dashboard/[teamId]/settings/billing/_common/ui/team-balance/crypto/crypto.tsx
@@ -404,7 +404,7 @@ function WaitTab({ txData }: { txData: TxData }) {
               {!isConfigLoading && chainConfig ? (
                 <>{chainConfig.confirmations}</>
               ) : (
-                <SkeletonText className="w-4" />
+                <SkeletonText />
               )}
             </span>
           </div>

--- a/apps/web/src/lib/steer/components/steer-liquidity-distribution-widget/steer-liquidity-in-range-chip.tsx
+++ b/apps/web/src/lib/steer/components/steer-liquidity-distribution-widget/steer-liquidity-in-range-chip.tsx
@@ -33,8 +33,7 @@ export const SteerLiquidityInRangeChip: FC<SteerLiquidityInRangeChipProps> = ({
     return vault.lowerTick < activeTick && vault.upperTick > activeTick
   }, [vault.lowerTick, vault.upperTick, activeTick])
 
-  if (isActiveTickLoading)
-    return <SkeletonBox className="w-[107px] h-5 rounded-full" />
+  if (isActiveTickLoading) return <SkeletonBox className="w-[107px] h-5" />
 
   return (
     <>

--- a/apps/web/src/lib/steer/components/steer-strategies/steer-base-strategy.tsx
+++ b/apps/web/src/lib/steer/components/steer-strategies/steer-base-strategy.tsx
@@ -85,21 +85,21 @@ export const SteerBaseStrategy: SteerStrategyComponent = ({
                 <TabsTrigger
                   testdata-id="add-tab"
                   value="add"
-                  className="flex flex-1"
+                  className="flex-1"
                 >
                   Add
                 </TabsTrigger>
                 <TabsTrigger
                   testdata-id="remove-tab"
                   value="remove"
-                  className="flex flex-1"
+                  className="flex-1"
                 >
                   Remove
                 </TabsTrigger>
                 <TabsTrigger
                   testdata-id="position-tab"
                   value="position"
-                  className="flex flex-1"
+                  className="flex-1"
                 >
                   Position
                 </TabsTrigger>

--- a/apps/web/src/lib/wagmi/components/token-selector/token-lists/common/token-selector-row.tsx
+++ b/apps/web/src/lib/wagmi/components/token-selector/token-lists/common/token-selector-row.tsx
@@ -234,12 +234,8 @@ function TokenSelectorRowBase<TChainId extends TokenSelectorChainId>({
             <div className="flex items-center gap-4">
               {isBalanceLoading ? (
                 <div className="flex flex-col min-w-[60px]">
-                  <SkeletonText className="w-[60px]" align="right" />
-                  <SkeletonText
-                    fontSize="sm"
-                    className="w-[20px]"
-                    align="right"
-                  />
+                  <SkeletonText align="right" />
+                  <SkeletonText fontSize="sm" align="right" />
                 </div>
               ) : (
                 balance?.gt(ZERO) && (
@@ -322,14 +318,14 @@ export function TokenSelectorRowLoading() {
           <div className="flex flex-row items-center flex-grow gap-4">
             <SkeletonCircle radius={40} />
             <div className="flex flex-col items-start">
-              <SkeletonText className="w-full w-[100px]" />
-              <SkeletonText fontSize="sm" className="w-full w-[60px]" />
+              <SkeletonText className="w-full" />
+              <SkeletonText fontSize="sm" className="w-full" />
             </div>
           </div>
 
           <div className="flex flex-col w-full">
-            <SkeletonText className="w-[80px]" />
-            <SkeletonText fontSize="sm" align="right" className="w-[40px]" />
+            <SkeletonText />
+            <SkeletonText fontSize="sm" align="right" />
           </div>
         </div>
       </div>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,12 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "Sushi UI",
-  "keywords": [
-    "sushi",
-    "ui",
-    "react",
-    "components"
-  ],
+  "keywords": ["sushi", "ui", "react", "components"],
   "repository": {
     "type": "git",
     "url": "https://github.com/sushi-labs/sushiswap.git",
@@ -16,9 +11,7 @@
   },
   "license": "MIT",
   "author": "Matthew Lilley <hello@matthewLilley.com>",
-  "sideEffects": [
-    "**/*.css"
-  ],
+  "sideEffects": ["**/*.css"],
   "exports": {
     "./index.css": "./index.css",
     "./date-picker.css": "./date-picker.css",
@@ -36,20 +29,11 @@
   },
   "typesVersions": {
     "*": {
-      ".": [
-        "src/**/*"
-      ],
-      "./icons/*": [
-        "src/icons/*"
-      ]
+      ".": ["src/**/*"],
+      "./icons/*": ["src/icons/*"]
     }
   },
-  "files": [
-    "dist",
-    "index.css",
-    "date-picker.css",
-    "tailwind.js"
-  ],
+  "files": ["dist", "index.css", "date-picker.css", "tailwind.js"],
   "scripts": {
     "build": "tsc",
     "check": "tsc --pretty --noEmit",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,7 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "description": "Sushi UI",
-  "keywords": ["sushi", "ui", "react", "components"],
+  "keywords": [
+    "sushi",
+    "ui",
+    "react",
+    "components"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/sushi-labs/sushiswap.git",
@@ -11,7 +16,9 @@
   },
   "license": "MIT",
   "author": "Matthew Lilley <hello@matthewLilley.com>",
-  "sideEffects": ["**/*.css"],
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     "./index.css": "./index.css",
     "./date-picker.css": "./date-picker.css",
@@ -29,11 +36,20 @@
   },
   "typesVersions": {
     "*": {
-      ".": ["src/**/*"],
-      "./icons/*": ["src/icons/*"]
+      ".": [
+        "src/**/*"
+      ],
+      "./icons/*": [
+        "src/icons/*"
+      ]
     }
   },
-  "files": ["dist", "index.css", "date-picker.css", "tailwind.js"],
+  "files": [
+    "dist",
+    "index.css",
+    "date-picker.css",
+    "tailwind.js"
+  ],
   "scripts": {
     "build": "tsc",
     "check": "tsc --pretty --noEmit",
@@ -91,6 +107,7 @@
     "react-spring": "9.7.5",
     "react-virtualized-auto-sizer": "1.0.25",
     "react-window": "1.8.11",
+    "tailwind-merge": "2.6.1",
     "tailwindcss-animate": "1.0.7",
     "use-resize-observer": "9.1.0"
   },

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -82,7 +82,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={classNames(
-      'text-lg font-semibold leading-none tracking-tight',
+      'text-lg font-semibold [line-height:1] tracking-tight',
       className,
     )}
     {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -169,7 +169,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={classNames(
-      'text-lg font-semibold leading-none tracking-tight mr-[64px]',
+      'text-lg font-semibold [line-height:1] tracking-tight mr-[64px]',
       className,
     )}
     {...props}

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -128,7 +128,7 @@ const FormLabel = React.forwardRef<
         htmlFor={formItemId}
         {...props}
       />
-      <span className="text-sm text-red-500 text-end leading-none">
+      <span className="text-sm text-red-500 text-end [line-height:1]">
         {error ? error.message : ''}
       </span>
     </div>

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import classNames from 'classnames'
 
 const labelVariants = cva(
-  'text-sm font-medium dark:text-slate-200 leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+  'text-sm font-medium dark:text-slate-200 [line-height:1] peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
 )
 
 const Label = React.forwardRef<

--- a/packages/ui/src/components/navigation.tsx
+++ b/packages/ui/src/components/navigation.tsx
@@ -258,7 +258,7 @@ const NavigationListItem = React.forwardRef<
 
   const content = (
     <>
-      <div className="text-sm font-medium leading-none">{title}</div>
+      <div className="text-sm font-medium [line-height:1]">{title}</div>
       <p className="text-sm leading-snug line-clamp-2 text-muted-foreground">
         {children}
       </p>

--- a/packages/ui/src/components/perps-dialog.tsx
+++ b/packages/ui/src/components/perps-dialog.tsx
@@ -181,7 +181,7 @@ const PerpsDialogTitle = React.forwardRef<
     <DialogPrimitive.Title
       ref={ref}
       className={classNames(
-        'text-lg font-semibold leading-none tracking-tight text-lg lg:text-base ',
+        'text-lg font-semibold [line-height:1] tracking-tight text-lg lg:text-base ',
         className,
       )}
       {...props}

--- a/packages/ui/src/components/typography.tsx
+++ b/packages/ui/src/components/typography.tsx
@@ -11,7 +11,7 @@ const typographyVariants = cva('scroll-m-20', {
       blockquote: 'mt-6 border-l-2 pl-6 italic',
       lead: 'leading-7 [&:not(:first-child)]:mt-6 text-lg text-muted-foreground sm:text-xl',
       large: 'text-lg font-semibold',
-      small: 'text-sm font-medium leading-none',
+      small: 'text-sm font-medium [line-height:1]',
       muted: 'text-muted-foreground',
     },
   },

--- a/packages/ui/src/components/widget.tsx
+++ b/packages/ui/src/components/widget.tsx
@@ -68,7 +68,7 @@ const WidgetTitle = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={classNames(
-      'text-lg font-semibold leading-none tracking-tight mr-[64px]',
+      'text-lg font-semibold [line-height:1] tracking-tight mr-[64px]',
       className,
     )}
     {...props}

--- a/packages/ui/src/lib/cn.ts
+++ b/packages/ui/src/lib/cn.ts
@@ -1,0 +1,35 @@
+import { extendTailwindMerge } from 'tailwind-merge'
+
+/**
+ * `classNames` concatenates; it does not resolve conflicts. When a caller's
+ * class and a component's base class both set the same property, the winner is
+ * decided by the order Tailwind emitted them in the stylesheet, which is not
+ * visible from the call site. `cn` resolves those conflicts so the last
+ * argument wins — so always pass the caller's `className` last:
+ *
+ *     cn(buttonVariants({ variant, size }), className)
+ *
+ * Two groups need teaching, because `index.css` hand-writes classes that look
+ * like utilities but are not, and tailwind-merge can only guess from the name:
+ *
+ * - `border-sushi-gradient` is a ::before gradient border, not a border colour.
+ *   Left to itself tailwind-merge files it under border-color and drops it the
+ *   moment a caller passes any `border-*`.
+ * - The custom `backgroundImage` keys read as background *colours* by name, so
+ *   they would be dropped by a real `bg-<color>` that they should coexist with.
+ *
+ * `bg-sushi-gradient` is deliberately not listed: it sets the `background`
+ * shorthand, so letting a caller's `bg-*` replace it is the correct behaviour.
+ */
+export const cn = extendTailwindMerge<'sushi-gradient-border'>({
+  extend: {
+    classGroups: {
+      'bg-image': [
+        'bg-gradient-radial',
+        'bg-shimmer-gradient',
+        'bg-shimmer-gradient-dark',
+      ],
+      'sushi-gradient-border': ['border-sushi-gradient'],
+    },
+  },
+})

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './cn'
 export * from './get-onramp-url'
 export * from './gtag'
 export * from './sync-scroll-lock-safe-area'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 8.4.7
@@ -600,7 +600,7 @@ importers:
         version: 2.3.3
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tiny-invariant:
         specifier: 1.3.1
         version: 1.3.1
@@ -791,7 +791,7 @@ importers:
         version: 1.0.0
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       viem:
         specifier: 2.55.0
         version: 2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11)
@@ -856,7 +856,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.4.19(tsx@4.23.0)(yaml@2.9.0)
@@ -905,7 +905,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -962,7 +962,7 @@ importers:
         version: 6.0.3
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -978,7 +978,7 @@ importers:
         version: 6.0.3
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -1205,6 +1205,9 @@ importers:
       react-window:
         specifier: 1.8.11
         version: 1.8.11(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwind-merge:
+        specifier: 2.6.1
+        version: 2.6.1
       tailwindcss-animate:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.0)(yaml@2.9.0))
@@ -1244,7 +1247,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sushi:
         specifier: catalog:web3
-        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
+        version: 7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11)
       tailwindcss:
         specifier: catalog:ui
         version: 3.4.19(tsx@4.23.0)(yaml@2.9.0)
@@ -15401,6 +15404,9 @@ packages:
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -36513,7 +36519,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  sushi@7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
+  sushi@7.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(viem@2.55.0(patch_hash=1b986ee9f764c7d8ab02b8b43dbc6b2dc0a8f7b9fa3850ce9c67428faad8ed9a)(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@4.1.11))(zod@4.1.11):
     dependencies:
       '@solana/addresses': 6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       tiny-invariant: 1.3.3
@@ -36555,6 +36561,8 @@ snapshots:
       tslib: 2.8.1
 
   tabbable@6.2.0: {}
+
+  tailwind-merge@2.6.1: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
Stacked on #2280.

Groundwork for adopting `tailwind-merge`. **No rendering changes** — that is the whole point, and it is proven rather than reviewed.

### The problem
Today a caller's `className` and a component's base classes both land in the class attribute, and the winner is decided by **the order Tailwind emitted them in the stylesheet**, not by the caller. Measured:

```
 4:  .!w-20        ← wins via !important
 7:  .w-12
13:  .w-full       ← beats w-12, so `<SkeletonText className="w-12">` does nothing
```

Under `tailwind-merge` the caller would start winning, which changes rendering. Deleting the classes that currently lose keeps the UI identical both now and after the swap.

### Method
Each call site's component is rendered with its own literal props, the resulting class strings are resolved against the compiled stylesheet (ordinal position, `!important`, modifier context), and a class is removed only if it wins no declaration in every string it appears in.

- **Proof A** — deleting the class changes no resolved declaration
- **Proof B** — `twMerge` on the cleaned string changes no resolved declaration

Both run on every touched site; a failure aborts without writing.

**121 classes removed across 118 call sites**, almost all `SkeletonText`/`SkeletonBox`, whose `className` lands on an inner element next to `w-full`/`h-full` and so rarely applied.

Coverage: 444 sites — 184 from real renders, 260 from a static model of base classes. The model collects only *unconditional* string literals (anything behind `&&` or a ternary is dropped, since assuming a class that may be absent could mark a caller's class dead when it wins). It was validated against 40 components that render standalone and reproduced their class strings **exactly, 0 mismatches**.

### `leading-none` → `[line-height:1]`
Tailwind's `text-*` utilities set line-height too, and tailwind-merge treats font-size as conflicting with `leading` — so a caller's `text-xl` silently drops a base `leading-none`. Both classes compile to an identical `line-height: 1` declaration, but arbitrary properties are their own merge group, so the second survives. (`leading-[1]` does **not** work.) Applied to the 8 base strings where `leading-none` shares a string with a font-size utility.

### Deliberately not fixed
`pool-position.tsx` carried `w-[ch-16]`, which compiles to the invalid `width: ch-16` and is discarded by the browser. It is **deleted, not corrected** to `w-[16ch]` — fixing it would change rendering. The element renders full width before and after.

### Still open before the actual `cn()` swap
- The helper must be ordered `cn(base, className)`. Components that currently pass `className` first (e.g. `Badge`) would otherwise let the base win — `z-[11]` → `z-10`.
- 15 cva-modelled components (~27 sites) that neither path models.
- 156 call sites whose `className` is not a literal.
- `extendTailwindMerge` config for the three utility-shaped classes hand-written in `index.css` (`bg-sushi-gradient`, `bg-sushi-gradient-full-opacity`, `border-sushi-gradient`) and the custom `backgroundImage` keys — `border-sushi-gradient` is a `::before` gradient that twMerge would group with border-color and drop.

### Verification
`packages/ui` typechecks and lints clean; `apps/web` identical to clean `master`; biome clean across 2,817 files.