### PR TITLE
feat(launchpad): support Pools V2 and V3

### DIFF
--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getLaunchpadProviderConfig,
+  getLaunchpadProviderIconsForFilter,
   getLaunchpadProvidersForFilter,
   launchpadProviderHasCapability,
   parseLaunchpadProviderFilter,
@@ -13,12 +14,29 @@ describe('launchpad provider policy', () => {
     expect(getLaunchpadProvidersForFilter('all')).toEqual([
       'SUSHI_V1',
       'POOLS_FUN_V1',
+      'POOLS_FUN_V2',
+      'POOLS_FUN_V3',
     ])
   })
 
-  it('maps provider filters to one versioned provider', () => {
-    expect(getLaunchpadProvidersForFilter('sushi')).toEqual(['SUSHI_V1'])
+  it('maps provider filters to provider families', () => {
+    expect(getLaunchpadProvidersForFilter('sushi')).toEqual([
+      'SUSHI_V1',
+    ])
     expect(getLaunchpadProvidersForFilter('pools-fun')).toEqual([
+      'POOLS_FUN_V1',
+      'POOLS_FUN_V2',
+      'POOLS_FUN_V3',
+    ])
+  })
+
+  it('shows one icon for each provider family', () => {
+    expect(getLaunchpadProviderIconsForFilter('all')).toEqual([
+      'SUSHI_V1',
+      'POOLS_FUN_V1',
+    ])
+    expect(getLaunchpadProviderIconsForFilter('sushi')).toEqual(['SUSHI_V1'])
+    expect(getLaunchpadProviderIconsForFilter('pools-fun')).toEqual([
       'POOLS_FUN_V1',
     ])
   })

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.test.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.test.ts
@@ -20,9 +20,7 @@ describe('launchpad provider policy', () => {
   })
 
   it('maps provider filters to provider families', () => {
-    expect(getLaunchpadProvidersForFilter('sushi')).toEqual([
-      'SUSHI_V1',
-    ])
+    expect(getLaunchpadProvidersForFilter('sushi')).toEqual(['SUSHI_V1'])
     expect(getLaunchpadProvidersForFilter('pools-fun')).toEqual([
       'POOLS_FUN_V1',
       'POOLS_FUN_V2',

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-provider.ts
@@ -14,7 +14,7 @@ interface LaunchpadProviderConfig {
 
 export const LAUNCHPAD_PROVIDER_CONFIG = {
   SUSHI_V1: {
-    label: 'Sushi',
+    label: 'Sushi V1',
     capabilities: {
       creatorProfile: true,
       manage: true,
@@ -23,6 +23,24 @@ export const LAUNCHPAD_PROVIDER_CONFIG = {
   },
   POOLS_FUN_V1: {
     label: 'Pools',
+    websiteUrl: 'https://pools.fun',
+    capabilities: {
+      creatorProfile: false,
+      manage: false,
+      metadata: false,
+    },
+  },
+  POOLS_FUN_V2: {
+    label: 'Pools V2',
+    websiteUrl: 'https://pools.fun',
+    capabilities: {
+      creatorProfile: false,
+      manage: false,
+      metadata: false,
+    },
+  },
+  POOLS_FUN_V3: {
+    label: 'Pools V3',
     websiteUrl: 'https://pools.fun',
     capabilities: {
       creatorProfile: false,
@@ -44,6 +62,15 @@ export const LAUNCHPAD_PROVIDER_FILTERS = [
 }[]
 
 const PROVIDERS_BY_FILTER = {
+  all: ['SUSHI_V1', 'POOLS_FUN_V1', 'POOLS_FUN_V2', 'POOLS_FUN_V3'],
+  sushi: ['SUSHI_V1'],
+  'pools-fun': ['POOLS_FUN_V1', 'POOLS_FUN_V2', 'POOLS_FUN_V3'],
+} as const satisfies Record<
+  LaunchpadProviderFilter,
+  readonly LaunchpadProvider[]
+>
+
+const ICON_PROVIDERS_BY_FILTER = {
   all: ['SUSHI_V1', 'POOLS_FUN_V1'],
   sushi: ['SUSHI_V1'],
   'pools-fun': ['POOLS_FUN_V1'],
@@ -62,6 +89,12 @@ export function getLaunchpadProvidersForFilter(
   filter: LaunchpadProviderFilter,
 ): LaunchpadProvider[] {
   return [...PROVIDERS_BY_FILTER[filter]]
+}
+
+export function getLaunchpadProviderIconsForFilter(
+  filter: LaunchpadProviderFilter,
+): LaunchpadProvider[] {
+  return [...ICON_PROVIDERS_BY_FILTER[filter]]
 }
 
 function isLaunchpadProviderFilter(

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.ts
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_lib/launchpad-seo.ts
@@ -226,11 +226,15 @@ function getPoolsFunOrganization(): Organization {
 const PROVIDER_ORGANIZATION_IDS = {
   SUSHI_V1: SUSHI_ORGANIZATION_ID,
   POOLS_FUN_V1: POOLS_FUN_ORGANIZATION_ID,
+  POOLS_FUN_V2: POOLS_FUN_ORGANIZATION_ID,
+  POOLS_FUN_V3: POOLS_FUN_ORGANIZATION_ID,
 } as const satisfies Record<LaunchpadProvider, string>
 
 const PROVIDER_ORGANIZATIONS = {
   SUSHI_V1: getSushiOrganization,
   POOLS_FUN_V1: getPoolsFunOrganization,
+  POOLS_FUN_V2: getPoolsFunOrganization,
+  POOLS_FUN_V3: getPoolsFunOrganization,
 } as const satisfies Record<LaunchpadProvider, () => Organization>
 
 function getLaunchpadProviderOrganizations(

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-provider-mark.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/launchpad-provider-mark.tsx
@@ -46,6 +46,8 @@ function PoolsFunProviderMark({ className, pixels }: ProviderMarkProps) {
 const PROVIDER_MARKS = {
   SUSHI_V1: SushiProviderMark,
   POOLS_FUN_V1: PoolsFunProviderMark,
+  POOLS_FUN_V2: PoolsFunProviderMark,
+  POOLS_FUN_V3: PoolsFunProviderMark,
 } as const satisfies Record<LaunchpadProvider, typeof SushiProviderMark>
 
 export function LaunchpadProviderMark({

--- a/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/provider-filter-controls.tsx
+++ b/apps/web/src/app/(networks)/(evm)/[chainId]/launchpad/_ui/provider-filter-controls.tsx
@@ -4,7 +4,7 @@ import { classNames } from '@sushiswap/ui'
 import {
   LAUNCHPAD_PROVIDER_FILTERS,
   type LaunchpadProviderFilter,
-  getLaunchpadProvidersForFilter,
+  getLaunchpadProviderIconsForFilter,
 } from '../_lib/launchpad-provider'
 import { LaunchpadProviderMark } from './launchpad-provider-mark'
 import {
@@ -46,7 +46,7 @@ export function ProviderFilterControls({
             )}
           >
             <span className="flex items-center" aria-hidden>
-              {getLaunchpadProvidersForFilter(option.value).map(
+              {getLaunchpadProviderIconsForFilter(option.value).map(
                 (provider, index) => (
                   <LaunchpadProviderMark
                     key={provider}

--- a/packages/graph-client/src/subgraphs/data-api/queries/launchpad/token-definition.ts
+++ b/packages/graph-client/src/subgraphs/data-api/queries/launchpad/token-definition.ts
@@ -40,6 +40,12 @@ export const LaunchpadTokenDefinitionQuery = graphql(`
         ... on PoolsFunV1LaunchpadToken {
           originalCreator: creator
         }
+        ... on PoolsFunV2LaunchpadToken {
+          originalCreator: creator
+        }
+        ... on PoolsFunV3LaunchpadToken {
+          originalCreator: creator
+        }
         ... on SushiV2LaunchpadToken {
           originalCreator: launchCreator
         }

--- a/packages/graph-client/src/subgraphs/data-api/schema.graphql
+++ b/packages/graph-client/src/subgraphs/data-api/schema.graphql
@@ -317,6 +317,8 @@ enum LaunchpadIndexingStatus {
 enum LaunchpadProvider {
   SUSHI_V1
   POOLS_FUN_V1
+  POOLS_FUN_V2
+  POOLS_FUN_V3
 }
 
 interface LaunchpadToken {
@@ -361,6 +363,46 @@ type SushiV1LaunchpadToken implements LaunchpadToken {
 }
 
 type PoolsFunV1LaunchpadToken implements LaunchpadToken {
+  id: ID!
+  chainId: LaunchpadChainId!
+  address: EvmAddress!
+  creator: EvmAddress!
+  factoryAddress: EvmAddress!
+  provider: LaunchpadProvider!
+  name: String!
+  symbol: String!
+  decimals: Int!
+  initialSupply: BigInt!
+  initialFdvUsd: BigInt!
+  indexingStatus: LaunchpadIndexingStatus!
+  pool: LaunchpadPool!
+  metadata: LaunchpadMetadata!
+  metrics: LaunchpadMetrics
+  creationTransactionHash: Bytes!
+  createdAt: String!
+}
+
+type PoolsFunV2LaunchpadToken implements LaunchpadToken {
+  id: ID!
+  chainId: LaunchpadChainId!
+  address: EvmAddress!
+  creator: EvmAddress!
+  factoryAddress: EvmAddress!
+  provider: LaunchpadProvider!
+  name: String!
+  symbol: String!
+  decimals: Int!
+  initialSupply: BigInt!
+  initialFdvUsd: BigInt!
+  indexingStatus: LaunchpadIndexingStatus!
+  pool: LaunchpadPool!
+  metadata: LaunchpadMetadata!
+  metrics: LaunchpadMetrics
+  creationTransactionHash: Bytes!
+  createdAt: String!
+}
+
+type PoolsFunV3LaunchpadToken implements LaunchpadToken {
   id: ID!
   chainId: LaunchpadChainId!
   address: EvmAddress!


### PR DESCRIPTION
## Summary

- Add Pools V2 and V3 token types and providers to the data-api schema.
- Group all Pools variants under the single Pools launchpad filter.
- Add provider marks, SEO mappings, and token creator handling.

## Validation

- `pnpm --filter @sushiswap/graph-client check`
- `pnpm --filter web check`
- Launchpad unit tests: 93 passed
- `pnpm lint`