### PR TITLE
ci(e2e): reuse build cache between workflow runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,9 +89,18 @@ jobs:
         run: pnpm playwright install --with-deps chromium
         working-directory: ./apps/web
 
+      - name: Restore Turbo build cache
+        id: turbo-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .turbo/cache
+          key: e2e-turbo-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            e2e-turbo-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Build fork test app
         id: build
-        run: pnpm exec turbo run build --filter web
+        run: pnpm exec turbo run build --filter web --cache-dir=.turbo/cache
         env:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
           ANVIL_BLOCK_NUMBER: ${{ matrix.block-number }}
@@ -101,6 +110,13 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
           # Data API
           NEXT_PUBLIC_SUSHI_DATA_API_HOST: https://production.data-gcp.sushi.com
+
+      - name: Save Turbo build cache
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.turbo-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .turbo/cache
+          key: ${{ steps.turbo-cache.outputs.cache-primary-key }}
 
       - name: Validate fork harness isolation
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}

--- a/apps/web/test/README.md
+++ b/apps/web/test/README.md
@@ -75,6 +75,10 @@ through the UI. Position IDs come from mint receipts, never a table row index.
   in a separate job. This uses the existing GitHub test-account secrets.
 - Fork builds, test execution, and Privy dev-server startup appear as separate
   CI phases. E2E execution is not Turbo-cached; app builds remain cacheable.
+- GitHub Actions restores the Turbo build cache across commits, even when Turbo
+  remote caching is unavailable. Turbo still validates source/dependency/env
+  hashes before reusing outputs. Successful builds are saved before tests run,
+  so a later test failure does not discard the build cache.
 - Each suite writes `test-results/<suite>/artifacts`, `html`, and `results.json`.
   Reports include durations, retry attempts, skipped tests, and named transaction
   steps. Failed tests retain their initial trace and screenshot; the `network`


### PR DESCRIPTION
E2E was rebuilding all 13 Turbo tasks on every fresh runner because remote caching was disabled. Persisting Turbo's local cache cuts the measured build step from 2m50s to 2s on a cache hit, plus 1s for restoration.

Persist `.turbo/cache` with GitHub Actions. Restore prior entries for the same OS, architecture, Node version, and lockfile; Turbo's task hashes still decide which outputs are valid. Save successful builds before running tests so later failures do not discard the cache. E2E execution itself remains uncached.

Validation on the same revision ([CI run](https://github.com/sushi-labs/sushiswap/actions/runs/34142889890)):

| Phase | Cold run | Cached rerun |
| --- | --- | --- |
| Build-cache restore | 0s | 1s |
| Build | 2m50s | 2s |
| Complete job | 7m31s | 5m43s |

Both attempts passed. The cached rerun reported 13/13 build tasks cached and all 18 fork tests passed without retries or flakes. Test execution was slower on the second runner, so the total saving was smaller than the build saving. These are individual CI measurements, not a repeated performance benchmark.

Workflow YAML, cache-step ordering, formatting, and lint passed. This primarily benefits reruns and test-only changes within a PR. App source changes still invalidate the web build; unchanged workspace dependency builds can remain cached.
